### PR TITLE
Add Claude Code GitHub Actions workflows

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,66 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Claude PR Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for the Conduit project — a local-first,
+            model-agnostic personal AI agent harness for macOS. Conduit handles
+            untrusted model output, controls the desktop, and runs sandboxed
+            agents, so security and isolation are first-class concerns.
+
+            Focus your review on:
+
+            1. **Security & Sandbox Integrity**
+               - Prompt injection risks in any code that processes model output
+                 or untrusted content (issues, PR bodies, scraped pages, etc.)
+               - Command injection in shell-out paths (Bash hooks, computer use,
+                 mobile control via ADB / libimobiledevice)
+               - Filesystem isolation: copy-in / copy-out / mount-mode correctness
+               - Network allowlist enforcement and credential handling
+
+            2. **Correctness & Edge Cases**
+               - Error handling around model failover, hook failures, and
+                 sandbox snapshots/rollback
+               - Race conditions in session trees, daemon sessions, and remote
+                 runtime paths
+               - Token-budget and cost-routing logic correctness
+
+            3. **Architecture Fit**
+               - Does the change respect the surface / core / capability-adapter
+                 boundary described in the README?
+               - Does new functionality belong in the core engine or in a plugin?
+
+            4. **Code Quality**
+               - Readability, naming, and consistency with existing patterns
+               - Test coverage — particularly for security-sensitive code paths
+               - Documentation updates (README, PRD) if surface area changed
+
+            Use inline comments for specific issues and a top-level comment for
+            overall observations. Be concise and actionable; skip nits unless
+            they affect correctness or security.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,38 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned, labeled]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude') ||
+      (github.event_name == 'issues' && github.event.action != 'labeled' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -163,6 +163,26 @@ Conduit is shipped in phases. See [docs/PRD.md § 19](./docs/PRD.md) for the ful
 | 7 | Coding Agent Engine | Planned |
 | 8 | Collaboration & Channel Access | Planned |
 
+## Working with Claude on GitHub
+
+This repo is wired up to [Claude Code on GitHub Actions](https://github.com/anthropics/claude-code-action). Two workflows live in [`.github/workflows/`](./.github/workflows/):
+
+- **[`claude.yml`](./.github/workflows/claude.yml)** — On-demand. Tag `@claude` in an issue title/body or in any issue/PR comment, _or_ apply the `claude` label to an issue, and Claude will pick up the work.
+- **[`claude-review.yml`](./.github/workflows/claude-review.yml)** — Automatic. Reviews every PR on open/sync/reopen with a Conduit-specific prompt focused on security, sandbox integrity, and architecture fit.
+
+### One-time setup
+
+The workflows require an `ANTHROPIC_API_KEY` repo secret:
+
+```sh
+gh secret set ANTHROPIC_API_KEY --repo jabreeflor/conduit
+# or via the UI: Settings → Secrets and variables → Actions → New repository secret
+```
+
+You also need the [Claude GitHub App](https://github.com/apps/claude) installed on the repo so Claude can comment and push. If you haven't installed it yet, the easiest way is to run `claude /install-github-app` locally.
+
+To enable the `claude` label trigger, create the label once: `gh label create claude --color 8A63D2 --description "Hand off to Claude Code"`.
+
 ## Links
 
 - 📋 [Product Requirements Document](./docs/PRD.md)


### PR DESCRIPTION
Wires up two workflows from the official anthropics/claude-code-action@v1:

- claude.yml: on-demand. Triggers when @claude is mentioned in an issue title/body, in any issue/PR comment, or when an issue is given the "claude" label.
- claude-review.yml: automatic PR review on open/sync/reopen, with a Conduit-specific prompt focused on prompt-injection risk, sandbox integrity, and architecture fit.

Setup the repo owner still needs to do:
  1. Add ANTHROPIC_API_KEY as a repo secret (gh secret set ANTHROPIC_API_KEY --repo jabreeflor/conduit)
  2. Install the Claude GitHub App on the repo (claude /install-github-app, or via github.com/apps/claude)
  3. (Optional) Create the "claude" label to enable label-based triggers (gh label create claude --color 8A63D2)

README updated with the same instructions.