### PR TITLE
Scaffold Go monorepo foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  verify:
+    name: Lint, type-check, and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Lint
+        run: make lint
+
+      - name: Type-check
+        run: make typecheck
+
+      - name: Unit tests
+        run: make test
+
+  release-build:
+    name: Release build
+    runs-on: ubuntu-latest
+    needs: verify
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build release binaries
+        run: make release
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: conduit-release-binaries
+          path: dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: build clean lint release test typecheck
+
+BINARY := conduit
+DIST_DIR := dist
+
+build:
+	go build -trimpath -o $(DIST_DIR)/$(BINARY) ./cmd/conduit
+
+typecheck:
+	go test -run '^$$' ./...
+
+lint:
+	test -z "$$(gofmt -l .)"
+	go vet ./...
+
+test:
+	go test ./...
+
+release: clean
+	GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags "-s -w" -o $(DIST_DIR)/$(BINARY)-darwin-arm64 ./cmd/conduit
+	GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-s -w" -o $(DIST_DIR)/$(BINARY)-darwin-amd64 ./cmd/conduit
+
+clean:
+	rm -rf $(DIST_DIR)

--- a/README.md
+++ b/README.md
@@ -141,11 +141,32 @@ conduit eval run     # evaluate models against test suites
 
 ```
 conduit/
+├── cmd/
+│   └── conduit/        # CLI entrypoint for the Conduit binary
+├── internal/
+│   ├── contracts/      # Shared core/surface data contracts
+│   ├── core/           # Surface-agnostic engine package
+│   ├── tui/            # Terminal surface package
+│   └── gui/            # macOS GUI package boundary
+├── .github/
+│   └── workflows/      # CI and Claude GitHub automation
 ├── docs/
-│   └── PRD.md          # Full product requirements document
+│   ├── PRD.md          # Full product requirements document
+│   └── adr/            # Architecture decision records
 ├── assets/
 │   └── banner.svg      # Hero banner (this README)
+├── go.mod              # Go module definition
+├── Makefile            # Local build, lint, test, and release tasks
 └── README.md
+```
+
+## Development
+
+```sh
+make lint       # gofmt check + go vet
+make typecheck  # compile all packages without running tests
+make test       # unit tests
+make release    # darwin arm64/amd64 release binaries in dist/
 ```
 
 ## Roadmap

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jabreeflor/conduit/internal/tui"
+)
+
+var version = "dev"
+
+func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "--version", "version":
+			fmt.Printf("conduit %s\n", version)
+			return
+		}
+	}
+
+	if err := tui.Run(os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "conduit: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jabreeflor/conduit
+
+go 1.22

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -1,0 +1,22 @@
+// Package contracts defines the shared data shapes used between the core
+// engine and every user-facing surface.
+package contracts
+
+import "time"
+
+// Surface identifies a frontend attached to the Conduit core.
+type Surface string
+
+const (
+	SurfaceTUI       Surface = "tui"
+	SurfaceGUI       Surface = "gui"
+	SurfaceSpotlight Surface = "spotlight"
+)
+
+// EngineInfo is the minimal boot-time contract exposed by the core engine.
+type EngineInfo struct {
+	Name      string
+	Version   string
+	Surfaces  []Surface
+	StartedAt time.Time
+}

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -1,0 +1,41 @@
+// Package core contains the shared Conduit engine used by all surfaces.
+package core
+
+import (
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// Engine owns the long-lived runtime state for Conduit.
+type Engine struct {
+	name      string
+	version   string
+	startedAt time.Time
+	surfaces  []contracts.Surface
+}
+
+// New creates a core engine instance with the surfaces planned for the
+// monorepo scaffold.
+func New(version string) *Engine {
+	return &Engine{
+		name:      "Conduit",
+		version:   version,
+		startedAt: time.Now().UTC(),
+		surfaces: []contracts.Surface{
+			contracts.SurfaceTUI,
+			contracts.SurfaceGUI,
+			contracts.SurfaceSpotlight,
+		},
+	}
+}
+
+// Info returns a stable summary that frontends can use during startup.
+func (e *Engine) Info() contracts.EngineInfo {
+	return contracts.EngineInfo{
+		Name:      e.name,
+		Version:   e.version,
+		Surfaces:  append([]contracts.Surface(nil), e.surfaces...),
+		StartedAt: e.startedAt,
+	}
+}

--- a/internal/core/engine_test.go
+++ b/internal/core/engine_test.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestEngineInfoIncludesSurfaceContracts(t *testing.T) {
+	engine := New("test")
+
+	info := engine.Info()
+
+	if info.Name != "Conduit" {
+		t.Fatalf("Name = %q, want Conduit", info.Name)
+	}
+	if info.Version != "test" {
+		t.Fatalf("Version = %q, want test", info.Version)
+	}
+	if len(info.Surfaces) != 3 {
+		t.Fatalf("len(Surfaces) = %d, want 3", len(info.Surfaces))
+	}
+	if info.Surfaces[0] != contracts.SurfaceTUI {
+		t.Fatalf("first surface = %q, want %q", info.Surfaces[0], contracts.SurfaceTUI)
+	}
+	if info.StartedAt.IsZero() {
+		t.Fatal("StartedAt is zero")
+	}
+}
+
+func TestEngineInfoReturnsSurfaceCopy(t *testing.T) {
+	engine := New("test")
+
+	info := engine.Info()
+	info.Surfaces[0] = contracts.SurfaceGUI
+
+	next := engine.Info()
+	if next.Surfaces[0] != contracts.SurfaceTUI {
+		t.Fatalf("surface slice was mutated through Info")
+	}
+}

--- a/internal/gui/doc.go
+++ b/internal/gui/doc.go
@@ -1,0 +1,5 @@
+// Package gui reserves the macOS GUI surface boundary.
+//
+// The GUI stack is finalized in Phase 5. Keeping the package boundary in the
+// scaffold makes imports and ownership explicit while the shared core evolves.
+package gui

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,0 +1,25 @@
+// Package tui contains the terminal surface for Conduit.
+package tui
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/jabreeflor/conduit/internal/core"
+)
+
+// Run starts the terminal surface. The real Bubble Tea application will land
+// after the TUI stack decision; this boot path proves the core/surface contract.
+func Run(out io.Writer) error {
+	engine := core.New("dev")
+	info := engine.Info()
+
+	surfaces := make([]string, 0, len(info.Surfaces))
+	for _, surface := range info.Surfaces {
+		surfaces = append(surfaces, string(surface))
+	}
+
+	_, err := fmt.Fprintf(out, "%s core online (%s)\n", info.Name, strings.Join(surfaces, ", "))
+	return err
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -1,0 +1,23 @@
+package tui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunBootsAgainstCore(t *testing.T) {
+	var out bytes.Buffer
+
+	if err := Run(&out); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "Conduit core online") {
+		t.Fatalf("output %q does not include boot message", got)
+	}
+	if !strings.Contains(got, "tui") || !strings.Contains(got, "gui") {
+		t.Fatalf("output %q does not include expected surfaces", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds the Go module, `conduit` CLI entrypoint, and package boundaries for contracts, core, TUI, and GUI.
- Wires local `make` targets and GitHub CI for lint, type-check, unit tests, and release binaries.
- Updates the README with the new project layout and development commands.

Closes #3

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test`
- [x] `make release`
- [x] `./dist/conduit-darwin-arm64 --version && ./dist/conduit-darwin-arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)