### PR TITLE
docs(tui): multi-fidelity TUI mockups + locked design decisions (closes #5)

### DIFF
--- a/docs/mockups/tui-mockups.html
+++ b/docs/mockups/tui-mockups.html
@@ -1,0 +1,934 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Conduit TUI Mockups — Multi-Fidelity Review (Issue #5)</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+  :root {
+    --bg: #0b0d10;
+    --panel: #11151a;
+    --panel-2: #161b22;
+    --border: #2a313a;
+    --text: #d6dde6;
+    --muted: #8a94a3;
+    --dim: #5b6573;
+    --accent: #7cc4ff;     /* tool running */
+    --good: #6dd58c;        /* tool done */
+    --bad: #ff7a7a;         /* tool failed */
+    --warn: #f5c87a;
+    --user: #ffffff;
+    --agent: #b4bccb;
+    --magenta: #c084fc;
+    --cyan: #5ee2cf;
+    --selection: #1b3a52;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0;
+    background: #07090c;
+    color: var(--text);
+    font-family: ui-sans-serif, -apple-system, "SF Pro Text", Inter, system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  header.page {
+    padding: 28px 32px 18px;
+    border-bottom: 1px solid #1a1f27;
+    background: linear-gradient(180deg, #0a0d11 0%, #07090c 100%);
+  }
+  header.page h1 {
+    margin: 0 0 4px 0;
+    font-size: 20px;
+    letter-spacing: -0.01em;
+    font-weight: 600;
+  }
+  header.page p {
+    margin: 0;
+    color: var(--muted);
+    font-size: 13px;
+    max-width: 820px;
+    line-height: 1.55;
+  }
+  header.page .meta {
+    margin-top: 12px;
+    color: var(--dim);
+    font-size: 11.5px;
+    font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+  }
+
+  .tabs {
+    display: flex;
+    gap: 6px;
+    padding: 14px 32px 0;
+    border-bottom: 1px solid #1a1f27;
+    background: #07090c;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    backdrop-filter: blur(8px);
+  }
+  .tab {
+    appearance: none;
+    background: transparent;
+    color: var(--muted);
+    border: 1px solid transparent;
+    border-bottom: none;
+    border-radius: 8px 8px 0 0;
+    padding: 10px 16px;
+    font: 500 13px ui-sans-serif, system-ui;
+    cursor: pointer;
+    transition: color 120ms ease, background 120ms ease, border-color 120ms ease;
+  }
+  .tab:hover { color: var(--text); }
+  .tab[aria-selected="true"] {
+    color: var(--text);
+    background: #11151a;
+    border-color: #1f2630;
+    border-bottom: 1px solid #11151a;
+    margin-bottom: -1px;
+  }
+  .tab .badge {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 1px 7px;
+    font-size: 10.5px;
+    border-radius: 999px;
+    background: #1a2230;
+    color: var(--muted);
+  }
+
+  .pane { display: none; padding: 28px 32px 80px; }
+  .pane[data-active="true"] { display: block; }
+
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+  @media (min-width: 1500px) {
+    .grid.two { grid-template-columns: 1fr 1fr; }
+  }
+
+  .mockup {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 1px 0 rgba(255,255,255,0.02), 0 12px 32px rgba(0,0,0,0.35);
+  }
+  .mockup-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--border);
+    background: linear-gradient(180deg, #161b22 0%, #11151a 100%);
+  }
+  .mockup-head .title {
+    font: 600 13px ui-sans-serif, system-ui;
+    color: var(--text);
+    letter-spacing: -0.005em;
+  }
+  .mockup-head .sub {
+    font: 12px ui-sans-serif, system-ui;
+    color: var(--muted);
+  }
+  .dots { display: inline-flex; gap: 6px; margin-right: 10px; vertical-align: middle; }
+  .dots i { width: 10px; height: 10px; border-radius: 50%; display: inline-block; background: #2a313a; }
+  .dots i:nth-child(1) { background: #ff5f57; }
+  .dots i:nth-child(2) { background: #febc2e; }
+  .dots i:nth-child(3) { background: #28c840; }
+
+  /* TUI canvas: a monospace screen */
+  .term {
+    font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+    font-size: 12.5px;
+    line-height: 1.45;
+    padding: 14px 16px 16px;
+    white-space: pre;
+    overflow-x: auto;
+  }
+  .term .row { display: block; }
+
+  /* ============== FIDELITY: WIREFRAME ============== */
+  .wf .term {
+    background: #ffffff;
+    color: #1a1a1a;
+  }
+  .wf .term .dim { color: #9aa0a6; }
+  .wf .term .rule { color: #1a1a1a; }
+  .wf .term .accent { color: #1a1a1a; text-decoration: underline dotted; }
+  .wf .term .box { color: #1a1a1a; }
+  .wf .term .label { background: #f1f1f1; padding: 0 4px; border-radius: 2px; }
+  .wf .term .ph { color: #c0c0c0; }   /* placeholder lorem */
+  .wf .mockup { background: #fafafa; border-color: #d0d0d0; }
+  .wf .mockup-head { background: #ededed; border-color: #d0d0d0; }
+  .wf .mockup-head .title { color: #1a1a1a; }
+  .wf .mockup-head .sub { color: #5a5a5a; }
+
+  /* ============== FIDELITY: GRAYSCALE ============== */
+  .gs .term {
+    background: #14171b;
+    color: #cfd2d6;
+  }
+  .gs .term .dim { color: #6c727b; }
+  .gs .term .muted { color: #8a8f97; }
+  .gs .term .strong { color: #ffffff; font-weight: 600; }
+  .gs .term .rule { color: #3a3f47; }
+  .gs .term .accent { color: #ffffff; }
+  .gs .term .ok { color: #c8ccd1; }
+  .gs .term .bad { color: #f4f4f4; text-decoration: underline; }
+  .gs .term .bg-sel { background: #2a2f37; color: #ffffff; }
+  .gs .term .pill { background: #262b32; color: #d6d9de; padding: 0 6px; border-radius: 3px; }
+
+  /* ============== FIDELITY: COLOR ============== */
+  .clr .term {
+    background: var(--bg);
+    color: var(--text);
+  }
+  .clr .term .rule { color: var(--border); }
+  .clr .term .dim { color: var(--dim); }
+  .clr .term .muted { color: var(--muted); }
+  .clr .term .agent { color: var(--agent); }
+  .clr .term .user { color: var(--user); font-weight: 600; }
+  .clr .term .ok { color: var(--good); }
+  .clr .term .run { color: var(--accent); }
+  .clr .term .bad { color: var(--bad); }
+  .clr .term .warn { color: var(--warn); }
+  .clr .term .magenta { color: var(--magenta); }
+  .clr .term .cyan { color: var(--cyan); }
+  .clr .term .pill {
+    background: #1a2230;
+    color: var(--accent);
+    padding: 0 6px;
+    border-radius: 3px;
+  }
+  .clr .term .pill-good { background: #14271b; color: var(--good); padding: 0 6px; border-radius: 3px; }
+  .clr .term .pill-warn { background: #2b2110; color: var(--warn); padding: 0 6px; border-radius: 3px; }
+  .clr .term .pill-bad { background: #2a1416; color: var(--bad); padding: 0 6px; border-radius: 3px; }
+  .clr .term .sel { background: var(--selection); color: var(--user); }
+  .clr .term .add { color: var(--good); background: rgba(109, 213, 140, 0.08); }
+  .clr .term .del { color: var(--bad); background: rgba(255, 122, 122, 0.08); }
+  .clr .term .hl { background: #1a2230; color: var(--text); }
+
+  /* Common syntax helpers used everywhere */
+  .term .b { font-weight: 700; }
+  .term .u { text-decoration: underline; }
+  .term .nowrap { white-space: pre; }
+
+  /* Footer notes between mockups */
+  .note {
+    margin: 6px 2px 0;
+    color: var(--muted);
+    font-size: 12.5px;
+    line-height: 1.55;
+  }
+  .note b { color: var(--text); }
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px 22px;
+    padding: 14px 16px;
+    border-top: 1px solid var(--border);
+    background: #0e1217;
+    color: var(--muted);
+    font-size: 12px;
+  }
+  .legend span { white-space: nowrap; }
+  .legend code {
+    color: var(--text);
+    background: #161b22;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 11.5px;
+  }
+
+  .section-title {
+    margin: 8px 2px 12px;
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+  }
+  .section-title h2 {
+    font: 600 14px ui-sans-serif, system-ui;
+    letter-spacing: -0.005em;
+    margin: 0;
+    color: var(--text);
+  }
+  .section-title .num {
+    color: var(--dim);
+    font: 600 12px ui-monospace, monospace;
+    width: 28px;
+  }
+  .section-title .desc {
+    color: var(--muted);
+    font-size: 12.5px;
+  }
+
+  /* Scroll hints */
+  .pane > .intro {
+    margin: 0 0 22px;
+    padding: 14px 16px;
+    border: 1px dashed var(--border);
+    border-radius: 10px;
+    color: var(--muted);
+    font-size: 12.5px;
+    line-height: 1.55;
+    background: #0c1014;
+  }
+  .pane > .intro b { color: var(--text); }
+
+  /* Command palette overlay rendered inside terminal */
+  .overlay {
+    display: inline-block;
+  }
+</style>
+</head>
+<body>
+
+<header class="page">
+  <h1>Conduit — TUI Multi-Fidelity Mockups</h1>
+  <p>Three fidelity passes (wireframe → grayscale → color) covering the six review surfaces called out in <a href="https://github.com/jabreeflor/conduit/issues/5" style="color:#7cc4ff">issue #5</a>: three-panel layout, status bar, tool call blocks, context panel views (workflow / memory / hooks / session tree), diff view, and command palette overlay. Same content in every fidelity — only the visual treatment changes — so each review pass isolates a different category of feedback.</p>
+  <div class="meta">issue #5 · phase 1 · review-before-build</div>
+</header>
+
+<nav class="tabs" role="tablist" aria-label="Fidelity">
+  <button class="tab" role="tab" aria-selected="false" data-target="wf">Wireframe <span class="badge">structure</span></button>
+  <button class="tab" role="tab" aria-selected="false" data-target="gs">Grayscale <span class="badge">hierarchy</span></button>
+  <button class="tab" role="tab" aria-selected="true"  data-target="clr">Color <span class="badge">locked spec</span></button>
+</nav>
+
+<!-- ============================================================
+     PANE: WIREFRAME
+     ============================================================ -->
+<section class="pane wf" id="wf" data-active="false" role="tabpanel" aria-label="Wireframe fidelity">
+
+  <div class="intro">
+    <b>What to look for.</b> Block sizing, panel ratios, info density, and where each surface lives. Ignore color and typography weight — those are the next two passes.
+  </div>
+
+  <!-- 1. Three-panel layout + status bar -->
+  <div class="section-title"><div class="num">01</div><h2>Three-panel layout + status bar</h2><div class="desc">conversation · context · input · top status bar</div></div>
+  <div class="mockup">
+    <div class="mockup-head">
+      <div><span class="dots"><i></i><i></i><i></i></span><span class="title">conduit — ~/projects/conduit</span></div>
+      <div class="sub">100 × 32 cols</div>
+    </div>
+<pre class="term"><span class="row">┌────────────────────────────────────────────────────────────────────────────────────────────────┐</span>
+<span class="row">│  <span class="label">CONDUIT</span>   [ MODEL ]   [ COST ]   [ SESSION ]   [ TIER ]                       <span class="dim">status bar</span>  │</span>
+<span class="row">├──────────────────────────────────────────────────────────────────┬─────────────────────────────┤</span>
+<span class="row">│                                                                  │                             │</span>
+<span class="row">│   <span class="label">CONVERSATION</span>                                                   │   <span class="label">CONTEXT PANEL</span>             │</span>
+<span class="row">│   <span class="ph">▔▔▔▔▔▔▔▔▔▔▔▔</span>                                                   │   <span class="ph">▔▔▔▔▔▔▔▔▔▔▔▔▔</span>             │</span>
+<span class="row">│                                                                  │   ( workflow / memory /     │</span>
+<span class="row">│   <span class="ph">user message ………………………………………………………………</span>                   │     hooks / session tree )  │</span>
+<span class="row">│                                                                  │                             │</span>
+<span class="row">│   <span class="ph">agent reply ……………………………………………………………………</span>                   │   <span class="ph">— content area —</span>            │</span>
+<span class="row">│   <span class="ph">…………………………………………………………………………………………</span>                   │                             │</span>
+<span class="row">│                                                                  │   <span class="ph">………………………………………………</span>      │</span>
+<span class="row">│   ┌─ tool call ──────────────────────────────────────────┐       │   <span class="ph">………………………………………………</span>      │</span>
+<span class="row">│   │ <span class="ph">name(args)</span>                                  [ ⟳ ]    │       │   <span class="ph">………………………………………………</span>      │</span>
+<span class="row">│   │ <span class="ph">………………………………………………………………………………………</span>      │       │                             │</span>
+<span class="row">│   └──────────────────────────────────────────────────────┘       │                             │</span>
+<span class="row">│                                                                  │                             │</span>
+<span class="row">│   <span class="ph">agent reply continues ……………………………………………………</span>                  │                             │</span>
+<span class="row">│                                                                  │                             │</span>
+<span class="row">│                                                                  │                             │</span>
+<span class="row">│                                                                  │                             │</span>
+<span class="row">├──────────────────────────────────────────────────────────────────┴─────────────────────────────┤</span>
+<span class="row">│ &gt; <span class="ph">_  input ……………………………………………………………………………………………………………………………………………</span>     │</span>
+<span class="row">└────────────────────────────────────────────────────────────────────────────────────────────────┘</span>
+<span class="row">  <span class="dim">[mod+k] palette   [mod+p] toggle context   [mod+/] commands   [esc] cancel</span>                   </span></pre>
+    <div class="legend">
+      <span>Panel ratio: <code>conversation 65% / context 35%</code></span>
+      <span>Status bar: <code>1 row, top-fixed</code></span>
+      <span>Input: <code>1 row default, expands shift+enter</code></span>
+      <span>Keybinding hints: <code>bottom row, dim</code></span>
+    </div>
+  </div>
+  <div class="note">Open question: do keybinding hints live <b>persistently</b> at the bottom (T3 Code style) or only after <code>?</code> is pressed (Vim style)? The wireframe shows the persistent variant — costs one row, saves a discoverability problem.</div>
+
+  <!-- 2. Tool call blocks -->
+  <div class="section-title" style="margin-top:32px"><div class="num">02</div><h2>Tool call blocks</h2><div class="desc">collapsed · running · expanded · failed</div></div>
+  <div class="mockup">
+    <div class="mockup-head">
+      <div><span class="dots"><i></i><i></i><i></i></span><span class="title">tool call states</span></div>
+      <div class="sub">four states · same width</div>
+    </div>
+<pre class="term"><span class="row">  ┌─ collapsed ───────────────────────────────────────────────────────────┐</span>
+<span class="row">  │  <span class="label">▶</span>  read_file(path="src/router.py")                              [ ✓ ] │</span>
+<span class="row">  └───────────────────────────────────────────────────────────────────────┘</span>
+<span class="row"></span>
+<span class="row">  ┌─ running ─────────────────────────────────────────────────────────────┐</span>
+<span class="row">  │  <span class="label">▼</span>  shell(cmd="pytest -k router")                                 [ ⟳ ] │</span>
+<span class="row">  │  <span class="ph">…………………………………… streaming stdout ……………………………</span>      │</span>
+<span class="row">  │  <span class="ph">…………………………………………………………………………………………</span>      │</span>
+<span class="row">  └───────────────────────────────────────────────────────────────────────┘</span>
+<span class="row"></span>
+<span class="row">  ┌─ expanded done ───────────────────────────────────────────────────────┐</span>
+<span class="row">  │  <span class="label">▼</span>  edit_file(path="src/router.py")                               [ ✓ ] │</span>
+<span class="row">  │  <span class="ph">— diff preview, 6 lines added, 2 removed —</span>                          │</span>
+<span class="row">  │  <span class="ph">+ ……………………………………………………………………………………</span>          │</span>
+<span class="row">  │  <span class="ph">- ……………………………………………………………………………………</span>          │</span>
+<span class="row">  │  <span class="dim">duration 312ms · cost $0.0008</span>                                       │</span>
+<span class="row">  └───────────────────────────────────────────────────────────────────────┘</span>
+<span class="row"></span>
+<span class="row">  ┌─ failed ──────────────────────────────────────────────────────────────┐</span>
+<span class="row">  │  <span class="label">▼</span>  browser.fetch(url="…")                                        [ ✗ ] │</span>
+<span class="row">  │  <span class="ph">error: ………………………………………………………………………………</span>            │</span>
+<span class="row">  │  <span class="dim">retry · ignore · escalate</span>                                            │</span>
+<span class="row">  └───────────────────────────────────────────────────────────────────────┘</span></pre>
+    <div class="legend">
+      <span>Status glyphs: <code>⟳ running · ✓ done · ✗ failed</code></span>
+      <span>Toggle: <code>▶ collapsed · ▼ expanded</code></span>
+      <span>Default: <code>collapsed</code></span>
+    </div>
+  </div>
+
+  <!-- 3. Context panel — four views -->
+  <div class="section-title" style="margin-top:32px"><div class="num">03</div><h2>Context panel — four views</h2><div class="desc">workflow · memory · hooks · session tree</div></div>
+  <div class="grid two">
+    <!-- workflow -->
+    <div class="mockup">
+      <div class="mockup-head"><span class="title">context: workflow</span><span class="sub">mod+p → 1</span></div>
+<pre class="term"><span class="row">  ┌─ workflow: nightly-eval ─────────────────────────────┐</span>
+<span class="row">  │                                                      │</span>
+<span class="row">  │   1. <span class="label">▣</span> load fixtures                    <span class="dim">done</span>     │</span>
+<span class="row">  │   2. <span class="label">▣</span> run model A                       <span class="dim">done</span>     │</span>
+<span class="row">  │   3. <span class="label">▣</span> run model B                       <span class="dim">running</span>  │</span>
+<span class="row">  │   4. <span class="label">□</span> compare outputs                   <span class="dim">queued</span>   │</span>
+<span class="row">  │   5. <span class="label">□</span> write report                      <span class="dim">queued</span>   │</span>
+<span class="row">  │   6. <span class="label">□</span> notify                             <span class="dim">queued</span>   │</span>
+<span class="row">  │                                                      │</span>
+<span class="row">  │   <span class="dim">checkpoint: step 2 · resumable</span>                    │</span>
+<span class="row">  └──────────────────────────────────────────────────────┘</span></pre>
+    </div>
+    <!-- memory -->
+    <div class="mockup">
+      <div class="mockup-head"><span class="title">context: memory</span><span class="sub">mod+p → 2</span></div>
+<pre class="term"><span class="row">  ┌─ memory: flat-file (Spotlight indexed) ──────────────┐</span>
+<span class="row">  │                                                      │</span>
+<span class="row">  │   <span class="label">▼</span> SOUL.md                          <span class="dim">static</span>      │</span>
+<span class="row">  │   <span class="label">▼</span> USER.md                          <span class="dim">static</span>      │</span>
+<span class="row">  │   <span class="label">▼</span> notes/                           <span class="dim">142 entries</span> │</span>
+<span class="row">  │      <span class="ph">— preview of selected entry —</span>                  │</span>
+<span class="row">  │      <span class="ph">………………………………………………………………</span>             │</span>
+<span class="row">  │      <span class="ph">………………………………………………………………</span>             │</span>
+<span class="row">  │                                                      │</span>
+<span class="row">  │   <span class="dim">/ search    e edit    n new    d delete</span>             │</span>
+<span class="row">  └──────────────────────────────────────────────────────┘</span></pre>
+    </div>
+    <!-- hooks -->
+    <div class="mockup">
+      <div class="mockup-head"><span class="title">context: hooks</span><span class="sub">mod+p → 3</span></div>
+<pre class="term"><span class="row">  ┌─ hooks: live event log ──────────────────────────────┐</span>
+<span class="row">  │                                                      │</span>
+<span class="row">  │   <span class="dim">14:02:11</span>  pre_tool_call    audit.sh       <span class="label">[allow]</span> │</span>
+<span class="row">  │   <span class="dim">14:02:14</span>  on_memory_write  backup.sh      <span class="label">[ok]</span>    │</span>
+<span class="row">  │   <span class="dim">14:02:19</span>  pre_llm_call     injection.py   <span class="label">[allow]</span> │</span>
+<span class="row">  │   <span class="dim">14:03:01</span>  pre_tool_call    audit.sh       <span class="label">[deny]</span>  │</span>
+<span class="row">  │                                                      │</span>
+<span class="row">  │   <span class="dim">filter: all · allow · deny · err</span>                  │</span>
+<span class="row">  │   <span class="dim">enter: open script   r: re-run   c: clear</span>           │</span>
+<span class="row">  └──────────────────────────────────────────────────────┘</span></pre>
+    </div>
+    <!-- session tree -->
+    <div class="mockup">
+      <div class="mockup-head"><span class="title">context: session tree</span><span class="sub">mod+p → 4</span></div>
+<pre class="term"><span class="row">  ┌─ session tree (git for conversations) ───────────────┐</span>
+<span class="row">  │                                                      │</span>
+<span class="row">  │   ● 14:01  start   "investigate router timeout"      │</span>
+<span class="row">  │   │                                                  │</span>
+<span class="row">  │   ●─┐ 14:08  fork    branch a                        │</span>
+<span class="row">  │   │ │                                                │</span>
+<span class="row">  │   │ ● 14:11  reply   ran pytest, 2 failures          │</span>
+<span class="row">  │   │ │                                                │</span>
+<span class="row">  │   │ ● 14:14  current ◀                               │</span>
+<span class="row">  │   │                                                  │</span>
+<span class="row">  │   ● 14:09  reply   skipped, asked for logs           │</span>
+<span class="row">  │                                                      │</span>
+<span class="row">  │   <span class="dim">f: fork    r: replay    enter: jump</span>                 │</span>
+<span class="row">  └──────────────────────────────────────────────────────┘</span></pre>
+    </div>
+  </div>
+  <div class="note">All four context views share the same <b>outer frame</b> and <b>footer hint row</b>. Switching between them changes only the body — the eye doesn't have to re-anchor.</div>
+
+  <!-- 4. Diff view -->
+  <div class="section-title" style="margin-top:32px"><div class="num">04</div><h2>Diff view</h2><div class="desc">unified diff inside the conversation panel · approvable per hunk</div></div>
+  <div class="mockup">
+    <div class="mockup-head"><span class="title">diff view (inside conversation)</span><span class="sub">a / r / esc</span></div>
+<pre class="term"><span class="row">  ┌─ proposed change · src/router.py · 1 of 3 hunks ───────────────────────────────────┐</span>
+<span class="row">  │                                                                                    │</span>
+<span class="row">  │   <span class="dim">@@ -42,9 +42,12 @@ class Router:</span>                                                  │</span>
+<span class="row">  │       def route(self, request):                                                    │</span>
+<span class="row">  │   <span class="ph">-       provider = self.primary</span>                                                  │</span>
+<span class="row">  │   <span class="ph">-       return provider.call(request)</span>                                            │</span>
+<span class="row">  │   <span class="ph">+       for provider in self.chain:</span>                                              │</span>
+<span class="row">  │   <span class="ph">+           try:</span>                                                                  │</span>
+<span class="row">  │   <span class="ph">+               return provider.call(request)</span>                                     │</span>
+<span class="row">  │   <span class="ph">+           except ProviderError:</span>                                                 │</span>
+<span class="row">  │   <span class="ph">+               continue</span>                                                          │</span>
+<span class="row">  │   <span class="ph">+       raise NoProvidersAvailable()</span>                                              │</span>
+<span class="row">  │                                                                                    │</span>
+<span class="row">  │   <span class="dim">[ a ] approve hunk   [ r ] reject hunk   [ tab ] next hunk   [ c ] comment</span>           │</span>
+<span class="row">  └────────────────────────────────────────────────────────────────────────────────────┘</span></pre>
+    <div class="legend">
+      <span>Hunk navigation: <code>tab / shift-tab</code></span>
+      <span>Approve all: <code>shift+a</code></span>
+      <span>Annotate: <code>c → opens line comment</code></span>
+    </div>
+  </div>
+
+  <!-- 5. Command palette -->
+  <div class="section-title" style="margin-top:32px"><div class="num">05</div><h2>Command palette overlay</h2><div class="desc">mod+k summon, fuzzy filter, modal over the whole TUI</div></div>
+  <div class="mockup">
+    <div class="mockup-head"><span class="title">command palette (mod+k)</span><span class="sub">centered overlay · 60×16</span></div>
+<pre class="term"><span class="row">┌────────────────────────────────────────────────────────────────────────────────────────────────┐</span>
+<span class="row">│  CONDUIT   <span class="dim">claude-opus-4-6   $0.12   sess#a3f9   tier: write</span>                              │</span>
+<span class="row">├──────────────────────────────────────────────────────────────────┬─────────────────────────────┤</span>
+<span class="row">│   <span class="ph">conversation dimmed ………</span>            ┌───────────────────────────────────────────┐ │       │</span>
+<span class="row">│   <span class="ph">…………………………………………</span>             │  <span class="label">⌘K</span>  &gt; <span class="b">fork</span><span class="ph">_</span>                           │ │       │</span>
+<span class="row">│   <span class="ph">…………………………………………</span>             ├───────────────────────────────────────────┤ │       │</span>
+<span class="row">│   <span class="ph">…………………………………………</span>             │  ▸ <span class="b">/sessions fork</span> &lt;turn&gt;       <span class="dim">git for chat</span>│ │       │</span>
+<span class="row">│   <span class="ph">…………………………………………</span>             │    /sessions list                         │ │       │</span>
+<span class="row">│   <span class="ph">…………………………………………</span>             │    /sessions replay &lt;id&gt;                  │ │       │</span>
+<span class="row">│   <span class="ph">…………………………………………</span>             │    /workflow run nightly-eval             │ │       │</span>
+<span class="row">│   <span class="ph">…………………………………………</span>             │    /memory search "router"                │ │       │</span>
+<span class="row">│   <span class="ph">…………………………………………</span>             │    /hooks log                             │ │       │</span>
+<span class="row">│                                            ├───────────────────────────────────────────┤ │       │</span>
+<span class="row">│                                            │  <span class="dim">↑↓ select   ⏎ run   esc cancel</span>          │ │       │</span>
+<span class="row">│                                            └───────────────────────────────────────────┘ │       │</span>
+<span class="row">├──────────────────────────────────────────────────────────────────┴─────────────────────────────┤</span>
+<span class="row">│ &gt; <span class="ph">_</span>                                                                                            │</span>
+<span class="row">└────────────────────────────────────────────────────────────────────────────────────────────────┘</span></pre>
+    <div class="legend">
+      <span>Summon: <code>mod+k</code></span>
+      <span>Dim factor: <code>everything behind overlay</code></span>
+      <span>First match: <code>auto-highlighted</code></span>
+    </div>
+  </div>
+
+</section>
+
+
+<!-- ============================================================
+     PANE: GRAYSCALE
+     ============================================================ -->
+<section class="pane gs" id="gs" data-active="false" role="tabpanel" aria-label="Grayscale fidelity">
+
+  <div class="intro">
+    <b>What to look for.</b> Visual hierarchy via weight and contrast — does your eye land where it should? Same blocks as the wireframe, now with real content and typographic emphasis. Color comes next.
+  </div>
+
+  <!-- 1. Three-panel layout + status bar -->
+  <div class="section-title"><div class="num">01</div><h2>Three-panel layout + status bar</h2><div class="desc">live conversation · workflow context · prompt</div></div>
+  <div class="mockup">
+    <div class="mockup-head">
+      <div><span class="dots"><i></i><i></i><i></i></span><span class="title">conduit — ~/projects/conduit</span></div>
+      <div class="sub">100 × 32 cols</div>
+    </div>
+<pre class="term"><span class="row"><span class="rule">┌────────────────────────────────────────────────────────────────────────────────────────────────┐</span></span>
+<span class="row"><span class="rule">│</span> <span class="strong">CONDUIT</span> <span class="dim">·</span> <span class="pill">claude-opus-4-6</span> <span class="dim">·</span> <span class="pill">$0.12</span> <span class="dim">·</span> <span class="pill">sess#a3f9</span> <span class="dim">·</span> <span class="pill">tier: write</span> <span class="dim">·</span> <span class="muted">workflow: nightly-eval (3/6)</span>     <span class="rule">│</span></span>
+<span class="row"><span class="rule">├────────────────────────────────────────────────────────────────┬───────────────────────────────┤</span></span>
+<span class="row"><span class="rule">│</span>                                                                <span class="rule">│</span> <span class="strong">CONTEXT · workflow</span>            <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="muted">14:02</span>  <span class="strong">you</span>                                                       <span class="rule">│</span>                               <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> investigate the router timeout under load                       <span class="rule">│</span> <span class="strong">nightly-eval</span>                  <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                                                <span class="rule">│</span> <span class="muted">started 14:01 · resumable</span>    <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="muted">14:02</span>  <span class="strong">conduit</span>                                                   <span class="rule">│</span>                               <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> reading <span class="strong">src/router.py</span> first to map the call path…             <span class="rule">│</span> ▣ 1. load fixtures   <span class="dim">done</span>     <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                                                <span class="rule">│</span> ▣ 2. run model A     <span class="dim">done</span>     <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">┌─</span> <span class="strong">read_file</span><span class="muted">(path="src/router.py")</span>                  <span class="strong">✓</span> <span class="rule">─┐</span>      <span class="rule">│</span> <span class="bg-sel">▶ 3. run model B     <span class="dim">running</span></span>  <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">└─</span> <span class="muted">98 lines · 312ms · $0.0008</span>                       <span class="rule">─┘</span>      <span class="rule">│</span> □ 4. compare         <span class="dim">queued</span>   <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                                                <span class="rule">│</span> □ 5. write report    <span class="dim">queued</span>   <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">┌─</span> <span class="strong">shell</span><span class="muted">(cmd="pytest -k router")</span>                   <span class="strong">⟳</span> <span class="rule">─┐</span>      <span class="rule">│</span> □ 6. notify          <span class="dim">queued</span>   <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">│</span> <span class="muted">collected 12 items …</span>                              <span class="rule">│</span>      <span class="rule">│</span>                               <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">│</span> <span class="muted">test_route_failover PASSED  [  8%]</span>                <span class="rule">│</span>      <span class="rule">│</span> <span class="muted">checkpoint: step 2</span>            <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">│</span> <span class="muted">test_pool_health   PASSED  [ 16%]</span>                 <span class="rule">│</span>      <span class="rule">│</span> <span class="muted">model: claude-opus-4-6</span>        <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">└─</span> <span class="muted">streaming…</span>                                       <span class="rule">─┘</span>      <span class="rule">│</span>                               <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                                                <span class="rule">│</span> <span class="muted">[1] workflow [2] memory</span>       <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                                                <span class="rule">│</span> <span class="muted">[3] hooks    [4] session</span>      <span class="rule">│</span></span>
+<span class="row"><span class="rule">├────────────────────────────────────────────────────────────────┴───────────────────────────────┤</span></span>
+<span class="row"><span class="rule">│</span> &gt; <span class="strong">_</span> <span class="dim">type a message · ↵ send · ⇧↵ newline · / for commands</span>                                      <span class="rule">│</span></span>
+<span class="row"><span class="rule">└────────────────────────────────────────────────────────────────────────────────────────────────┘</span></span>
+<span class="row">  <span class="dim">[mod+k] palette   [mod+p] toggle context   [mod+/] commands   [esc] cancel</span></span></pre>
+    <div class="legend">
+      <span>User name <code>strong+white</code>, agent <code>strong+white</code>, body <code>default</code></span>
+      <span>Tool calls in‑line, indented under the message that triggered them</span>
+      <span>Status pills group at the left, contextual workflow at the right</span>
+    </div>
+  </div>
+
+  <!-- 2. Tool call blocks -->
+  <div class="section-title" style="margin-top:32px"><div class="num">02</div><h2>Tool call blocks</h2><div class="desc">collapsed · running · expanded · failed</div></div>
+  <div class="mockup">
+    <div class="mockup-head"><span class="title">tool call states</span><span class="sub">collapse-by-default</span></div>
+<pre class="term"><span class="row">  <span class="rule">┌─</span> <span class="strong">read_file</span><span class="muted">(path="src/router.py")</span>                                            <span class="strong">✓</span> <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">└─</span> <span class="muted">98 lines · 312ms · $0.0008</span>                                                  <span class="rule">─┘</span></span>
+<span class="row"></span>
+<span class="row">  <span class="rule">┌─</span> <span class="strong">shell</span><span class="muted">(cmd="pytest -k router")</span>                                              <span class="strong">⟳</span> <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span> <span class="muted">collected 12 items</span>                                                            <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="muted">test_route_failover PASSED  [  8%]</span>                                            <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="muted">test_pool_health   PASSED  [ 16%]</span>                                             <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="muted">test_router_timeout RUNNING …</span>                                                 <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└─</span> <span class="dim">streaming · 4.2s · est $0.003</span>                                              <span class="rule">─┘</span></span>
+<span class="row"></span>
+<span class="row">  <span class="rule">┌─</span> <span class="strong">edit_file</span><span class="muted">(path="src/router.py")</span>                                            <span class="strong">✓</span> <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span> <span class="muted">+6 −2 lines · 1 hunk pending review</span>                                           <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="strong">+</span>       for provider in self.chain:                                            <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="strong">+</span>           try:                                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="strong">+</span>               return provider.call(request)                                 <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="bad">−</span>       provider = self.primary                                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="bad">−</span>       return provider.call(request)                                          <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└─</span> <span class="dim">[ a ] approve · [ r ] reject · [ d ] open diff view</span>                            <span class="rule">─┘</span></span>
+<span class="row"></span>
+<span class="row">  <span class="rule">┌─</span> <span class="strong">browser.fetch</span><span class="muted">(url="https://api.x/…")</span>                                       <span class="bad">✗</span> <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span> <span class="bad">ConnectionTimeout</span><span class="muted">: dns lookup failed after 5s</span>                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└─</span> <span class="dim">[ retry ] · [ ignore ] · [ escalate to fallback model ]</span>                       <span class="rule">─┘</span></span></pre>
+  </div>
+
+  <!-- 3. Context panel — four views -->
+  <div class="section-title" style="margin-top:32px"><div class="num">03</div><h2>Context panel — four views</h2><div class="desc">workflow · memory · hooks · session tree</div></div>
+  <div class="grid two">
+    <div class="mockup">
+      <div class="mockup-head"><span class="title">context · workflow</span><span class="sub">mod+p → 1</span></div>
+<pre class="term"><span class="row">  <span class="rule">┌─</span> <span class="strong">workflow · nightly-eval</span> <span class="muted">· yaml</span>           <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  ▣ 1. load fixtures            <span class="dim">done   12s</span>   <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  ▣ 2. run model A              <span class="dim">done  4m02</span>   <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="bg-sel">▶ 3. run model B              <span class="dim">running</span>   </span>  <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  □ 4. compare outputs          <span class="dim">queued</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  □ 5. write report             <span class="dim">queued</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  □ 6. notify                   <span class="dim">queued</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="muted">checkpoint step 2 · resumable</span>              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="muted">cost so far $0.084 · est total $0.21</span>       <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└──────────────────────────────────────────────┘</span></span></pre>
+    </div>
+    <div class="mockup">
+      <div class="mockup-head"><span class="title">context · memory</span><span class="sub">mod+p → 2</span></div>
+<pre class="term"><span class="row">  <span class="rule">┌─</span> <span class="strong">memory · flat-file</span> <span class="muted">· spotlight</span>           <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  ▼ <span class="strong">SOUL.md</span>                       <span class="dim">static</span>     <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  ▼ <span class="strong">USER.md</span>                       <span class="dim">static</span>     <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  ▼ <span class="strong">notes/</span>                        <span class="dim">142</span>        <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>     <span class="bg-sel">router-timeout-2024-11-04.md</span>           <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>     <span class="muted">> seen this before — fallback chain</span>     <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>     <span class="muted">> swallowed an exception that</span>           <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>     <span class="muted">> should have triggered escalation.</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="muted">/ search · e edit · n new · d delete</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└──────────────────────────────────────────────┘</span></span></pre>
+    </div>
+    <div class="mockup">
+      <div class="mockup-head"><span class="title">context · hooks</span><span class="sub">mod+p → 3</span></div>
+<pre class="term"><span class="row">  <span class="rule">┌─</span> <span class="strong">hooks · live event log</span>                  <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">14:02:11</span>  pre_tool_call    audit.sh    <span class="pill">allow</span>   <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">14:02:14</span>  on_memory_write  backup.sh   <span class="pill">ok</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">14:02:19</span>  pre_llm_call     inject.py    <span class="pill">allow</span>   <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">14:03:01</span>  pre_tool_call    audit.sh    <span class="strong">deny</span>    <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">14:03:01</span>  &nbsp; &nbsp; reason: shell outside project_dir   <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">14:03:24</span>  pre_tool_call    audit.sh    <span class="pill">allow</span>   <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="muted">filter: all · allow · deny · err</span>          <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="muted">↵ open script · r re-run · c clear</span>        <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└──────────────────────────────────────────────┘</span></span></pre>
+    </div>
+    <div class="mockup">
+      <div class="mockup-head"><span class="title">context · session tree</span><span class="sub">mod+p → 4</span></div>
+<pre class="term"><span class="row">  <span class="rule">┌─</span> <span class="strong">session tree · sess#a3f9</span>                <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  ● <span class="dim">14:01</span>  start  "router timeout"          <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  │                                           <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  ●─┐ <span class="dim">14:08</span>  fork  branch <span class="strong">a</span>                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  │ │                                         <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  │ ● <span class="dim">14:11</span>  pytest, 2 failures            <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  │ │                                         <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  │ <span class="bg-sel">● <span class="dim">14:14</span>  current ◀</span>                     <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  │                                           <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  ● <span class="dim">14:09</span>  reply  "skipped, asked for logs"  <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="muted">f fork · r replay · ↵ jump · / search</span>     <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└──────────────────────────────────────────────┘</span></span></pre>
+    </div>
+  </div>
+
+  <!-- 4. Diff view -->
+  <div class="section-title" style="margin-top:32px"><div class="num">04</div><h2>Diff view</h2><div class="desc">unified diff · per-hunk approve / reject · annotation</div></div>
+  <div class="mockup">
+    <div class="mockup-head"><span class="title">diff view</span><span class="sub">unified · 1 of 3 hunks</span></div>
+<pre class="term"><span class="row">  <span class="rule">┌─</span> <span class="strong">src/router.py</span> <span class="muted">· hunk 1 / 3 · +6 −2</span>                                          <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span>                                                                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="dim">@@ -42,9 +42,12 @@ class Router:</span>                                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="muted">  42    def route(self, request):</span>                                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="bad">  43 −      provider = self.primary</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="bad">  44 −      return provider.call(request)</span>                                        <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="strong">  43 +      for provider in self.chain:</span>                                          <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="strong">  44 +          try:</span>                                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="strong">  45 +              return provider.call(request)</span>                                 <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="strong">  46 +          except ProviderError:</span>                                             <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="strong">  47 +              continue</span>                                                      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="strong">  48 +      raise NoProvidersAvailable()</span>                                          <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>                                                                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="muted">comment 14:14:</span> <span class="strong">"good — but log the swallowed errors before continuing"</span>          <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>                                                                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="dim">[ a ] approve · [ r ] reject · [ tab ] next hunk · [ c ] comment · [ A ] all</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└────────────────────────────────────────────────────────────────────────────────┘</span></span></pre>
+  </div>
+
+  <!-- 5. Command palette -->
+  <div class="section-title" style="margin-top:32px"><div class="num">05</div><h2>Command palette overlay</h2><div class="desc">mod+k · fuzzy filter over slash commands + actions</div></div>
+  <div class="mockup">
+    <div class="mockup-head"><span class="title">command palette</span><span class="sub">centered · 60×16 · query "fork"</span></div>
+<pre class="term"><span class="row"><span class="rule">┌────────────────────────────────────────────────────────────────────────────────────────────────┐</span></span>
+<span class="row"><span class="rule">│</span> <span class="strong">CONDUIT</span> <span class="dim">·</span> <span class="muted">claude-opus-4-6 · $0.12 · sess#a3f9 · tier: write</span>                                  <span class="rule">│</span></span>
+<span class="row"><span class="rule">├────────────────────────────────────────────────────────────────┬───────────────────────────────┤</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">conversation dimmed …………</span>      <span class="rule">┌──────────────────────────────────────────┐</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span> <span class="strong">⌘K</span>  &gt; <span class="strong">fork</span>_                              <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">├──────────────────────────────────────────┤</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span> <span class="bg-sel">▸ /sessions fork &lt;turn&gt;   <span class="muted">git for chat</span>  </span> <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span>   /sessions list                          <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span>   /sessions replay &lt;id&gt;                   <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span>   /workflow run nightly-eval              <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span>   /memory search "router"                 <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span>   /hooks log                              <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                <span class="rule">├──────────────────────────────────────────┤</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                <span class="rule">│</span> <span class="muted">↑↓ select · ↵ run · esc cancel</span>          <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                <span class="rule">└──────────────────────────────────────────┘</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">├────────────────────────────────────────────────────────────────┴───────────────────────────────┤</span></span>
+<span class="row"><span class="rule">│</span> &gt; <span class="dim">_</span>                                                                                          <span class="rule">│</span></span>
+<span class="row"><span class="rule">└────────────────────────────────────────────────────────────────────────────────────────────────┘</span></span></pre>
+  </div>
+
+</section>
+
+
+<!-- ============================================================
+     PANE: COLOR
+     ============================================================ -->
+<section class="pane clr" id="clr" data-active="true" role="tabpanel" aria-label="Color fidelity">
+
+  <div class="intro">
+    <b>Locked spec.</b> This is the approved visual language for TUI build. Dark background, muted agent voice vs bright user voice, and the four status tints (running / done / failed / warn) used consistently across tool calls, workflow steps, and hooks. Decisions Q1–Q5 resolved — see section 06.
+  </div>
+
+  <!-- 1. Three-panel layout + status bar -->
+  <div class="section-title"><div class="num">01</div><h2>Three-panel layout + status bar</h2><div class="desc">live conversation · workflow context · prompt</div></div>
+  <div class="mockup">
+    <div class="mockup-head">
+      <div><span class="dots"><i></i><i></i><i></i></span><span class="title">conduit — ~/projects/conduit</span></div>
+      <div class="sub">100 × 32 cols · dark</div>
+    </div>
+<pre class="term"><span class="row"><span class="rule">┌────────────────────────────────────────────────────────────────────────────────────────────────┐</span></span>
+<span class="row"><span class="rule">│</span> <span class="user">CONDUIT</span> <span class="dim">·</span> <span class="pill">claude-opus-4-6</span> <span class="dim">·</span> <span class="pill-good">$0.12</span> <span class="dim">·</span> <span class="pill">sess#a3f9</span> <span class="dim">·</span> <span class="pill-warn">tier: write</span> <span class="dim">·</span> <span class="muted">workflow:</span> <span class="cyan">nightly-eval (3/6)</span>  <span class="rule">│</span></span>
+<span class="row"><span class="rule">├────────────────────────────────────────────────────────────────┬───────────────────────────────┤</span></span>
+<span class="row"><span class="rule">│</span>                                                                <span class="rule">│</span> <span class="user">CONTEXT</span> <span class="muted">·</span> <span class="cyan">workflow</span>            <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">14:02</span>  <span class="user">you</span>                                                       <span class="rule">│</span>                               <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> investigate the router timeout under load                       <span class="rule">│</span> <span class="user">nightly-eval</span>                  <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                                                <span class="rule">│</span> <span class="dim">started 14:01 · resumable</span>     <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">14:02</span>  <span class="magenta">conduit</span>                                                   <span class="rule">│</span>                               <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="agent">reading</span> <span class="user">src/router.py</span> <span class="agent">first to map the call path…</span>             <span class="rule">│</span> <span class="ok">▣</span> 1. load fixtures   <span class="dim">done</span>    <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                                                <span class="rule">│</span> <span class="ok">▣</span> 2. run model A     <span class="dim">done</span>    <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">┌─</span> <span class="user">read_file</span><span class="muted">(path="src/router.py")</span>                  <span class="ok">✓</span> <span class="rule">─┐</span>      <span class="rule">│</span> <span class="sel"><span class="run">▶</span> 3. run model B  <span class="run">running</span></span>   <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">└─</span> <span class="dim">98 lines · 312ms · $0.0008</span>                       <span class="rule">─┘</span>      <span class="rule">│</span> <span class="dim">□</span> 4. compare         <span class="dim">queued</span>  <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                                                <span class="rule">│</span> <span class="dim">□</span> 5. write report    <span class="dim">queued</span>  <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">┌─</span> <span class="user">shell</span><span class="muted">(cmd="pytest -k router")</span>                   <span class="run">⟳</span> <span class="rule">─┐</span>      <span class="rule">│</span> <span class="dim">□</span> 6. notify          <span class="dim">queued</span>  <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">│</span> <span class="muted">collected 12 items …</span>                              <span class="rule">│</span>      <span class="rule">│</span>                               <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">│</span> <span class="ok">test_route_failover PASSED</span>  <span class="muted">[  8%]</span>               <span class="rule">│</span>      <span class="rule">│</span> <span class="dim">checkpoint:</span> <span class="cyan">step 2</span>          <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">│</span> <span class="ok">test_pool_health   PASSED</span>  <span class="muted">[ 16%]</span>                <span class="rule">│</span>      <span class="rule">│</span> <span class="dim">model:</span> <span class="cyan">claude-opus-4-6</span>       <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="rule">└─</span> <span class="run">streaming…</span>                                       <span class="rule">─┘</span>      <span class="rule">│</span>                               <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                                                <span class="rule">│</span> <span class="muted">[1] workflow [2] memory</span>       <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                                                <span class="rule">│</span> <span class="muted">[3] hooks    [4] session</span>      <span class="rule">│</span></span>
+<span class="row"><span class="rule">├────────────────────────────────────────────────────────────────┴───────────────────────────────┤</span></span>
+<span class="row"><span class="rule">│</span> <span class="cyan">&gt;</span> <span class="user">_</span> <span class="dim">type a message · ↵ send · ⇧↵ newline · press</span> <span class="cyan">?</span> <span class="dim">for shortcuts</span>                              <span class="rule">│</span></span>
+<span class="row"><span class="rule">└────────────────────────────────────────────────────────────────────────────────────────────────┘</span></span></pre>
+    <div class="legend">
+      <span><code style="color:var(--accent)">cyan</code> = running / live</span>
+      <span><code style="color:var(--good)">green</code> = success / cost-good</span>
+      <span><code style="color:var(--bad)">red</code> = error / blocked</span>
+      <span><code style="color:var(--warn)">amber</code> = elevated tier / warning</span>
+      <span><code style="color:var(--magenta)">magenta</code> = agent identity</span>
+    </div>
+  </div>
+
+  <!-- 2. Tool call blocks -->
+  <div class="section-title" style="margin-top:32px"><div class="num">02</div><h2>Tool call blocks</h2><div class="desc">expanded while running · auto-collapse on done · manual expand on failed</div></div>
+  <div class="mockup">
+    <div class="mockup-head"><span class="title">tool call states</span><span class="sub">expand-while-running default</span></div>
+<pre class="term"><span class="row">  <span class="dim">— done: auto-collapses after 1s, click ▶ to expand —</span></span>
+<span class="row">  <span class="rule">┌─</span> <span class="user">read_file</span><span class="muted">(path="src/router.py")</span>                                            <span class="ok">✓</span> <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">└─</span> <span class="dim">98 lines · 312ms · $0.0008</span>                                                  <span class="rule">─┘</span></span>
+<span class="row"></span>
+<span class="row">  <span class="rule">┌─</span> <span class="user">shell</span><span class="muted">(cmd="pytest -k router")</span>                                              <span class="run">⟳</span> <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span> <span class="muted">collected 12 items</span>                                                            <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="ok">test_route_failover PASSED</span>  <span class="muted">[  8%]</span>                                          <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="ok">test_pool_health   PASSED</span>  <span class="muted">[ 16%]</span>                                           <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="run">test_router_timeout RUNNING …</span>                                                 <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└─</span> <span class="dim">streaming · 4.2s · est</span> <span class="warn">$0.003</span>                                              <span class="rule">─┘</span></span>
+<span class="row"></span>
+<span class="row">  <span class="rule">┌─</span> <span class="user">edit_file</span><span class="muted">(path="src/router.py")</span>                                            <span class="ok">✓</span> <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span> <span class="muted">+6 −2 lines · 1 hunk pending review</span>                                           <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="add">+       for provider in self.chain:</span>                                            <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="add">+           try:</span>                                                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="add">+               return provider.call(request)</span>                                   <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="del">−       provider = self.primary</span>                                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="del">−       return provider.call(request)</span>                                          <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└─</span> <span class="dim">[</span> <span class="ok">a</span> <span class="dim">] approve ·</span> <span class="dim">[</span> <span class="bad">r</span> <span class="dim">] reject ·</span> <span class="dim">[</span> <span class="cyan">d</span> <span class="dim">] open diff view</span>                            <span class="rule">─┘</span></span>
+<span class="row"></span>
+<span class="row">  <span class="rule">┌─</span> <span class="user">browser.fetch</span><span class="muted">(url="https://api.x/…")</span>                                       <span class="bad">✗</span> <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span> <span class="bad">ConnectionTimeout</span><span class="muted">: dns lookup failed after 5s</span>                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└─</span> <span class="dim">[</span> <span class="cyan">retry</span> <span class="dim">] · [ ignore ] · [</span> <span class="warn">escalate to fallback model</span> <span class="dim">]</span>                       <span class="rule">─┘</span></span></pre>
+  </div>
+
+  <!-- 3. Context panel — four views -->
+  <div class="section-title" style="margin-top:32px"><div class="num">03</div><h2>Context panel — four views</h2><div class="desc">workflow · memory · hooks · session tree</div></div>
+  <div class="grid two">
+    <div class="mockup">
+      <div class="mockup-head"><span class="title">context · workflow</span><span class="sub">mod+p → 1</span></div>
+<pre class="term"><span class="row">  <span class="rule">┌─</span> <span class="user">workflow</span> <span class="muted">·</span> <span class="cyan">nightly-eval</span> <span class="muted">· yaml</span>           <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="ok">▣</span> 1. load fixtures            <span class="dim">done   12s</span>   <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="ok">▣</span> 2. run model A              <span class="dim">done  4m02</span>   <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="sel"><span class="run">▶ 3. run model B              running</span>   </span> <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">□ 4. compare outputs          queued</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">□ 5. write report             queued</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">□ 6. notify                   queued</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="muted">checkpoint</span> <span class="cyan">step 2</span> <span class="muted">· resumable</span>            <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="muted">cost so far</span> <span class="ok">$0.084</span> <span class="muted">· est total</span> <span class="warn">$0.21</span>     <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└──────────────────────────────────────────────┘</span></span></pre>
+    </div>
+    <div class="mockup">
+      <div class="mockup-head"><span class="title">context · memory</span><span class="sub">mod+p → 2</span></div>
+<pre class="term"><span class="row">  <span class="rule">┌─</span> <span class="user">memory</span> <span class="muted">· flat-file ·</span> <span class="cyan">spotlight</span>           <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  ▼ <span class="user">SOUL.md</span>                       <span class="dim">static</span>     <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  ▼ <span class="user">USER.md</span>                       <span class="dim">static</span>     <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  ▼ <span class="user">notes/</span>                        <span class="cyan">142</span>        <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>     <span class="sel">router-timeout-2024-11-04.md</span>           <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>     <span class="agent">> seen this before — fallback chain</span>     <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>     <span class="agent">> swallowed an exception that</span>           <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>     <span class="agent">> should have triggered escalation.</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">/ search · e edit · n new · d delete</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└──────────────────────────────────────────────┘</span></span></pre>
+    </div>
+    <div class="mockup">
+      <div class="mockup-head"><span class="title">context · hooks</span><span class="sub">mod+p → 3</span></div>
+<pre class="term"><span class="row">  <span class="rule">┌─</span> <span class="user">hooks</span> <span class="muted">· live event log</span>                  <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">14:02:11</span>  pre_tool_call    audit.sh    <span class="pill-good">allow</span>   <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">14:02:14</span>  on_memory_write  backup.sh   <span class="pill-good">ok</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">14:02:19</span>  pre_llm_call     inject.py    <span class="pill-good">allow</span>   <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">14:03:01</span>  pre_tool_call    audit.sh    <span class="pill-bad">deny</span>    <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">14:03:01</span>  &nbsp; &nbsp;<span class="muted"> reason: shell outside project_dir</span> <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="dim">14:03:24</span>  pre_tool_call    audit.sh    <span class="pill-good">allow</span>   <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="muted">filter:</span> <span class="cyan">all</span> <span class="muted">·</span> <span class="ok">allow</span> <span class="muted">·</span> <span class="bad">deny</span> <span class="muted">·</span> <span class="warn">err</span>          <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="muted">↵ open script · r re-run · c clear</span>        <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└──────────────────────────────────────────────┘</span></span></pre>
+    </div>
+    <div class="mockup">
+      <div class="mockup-head"><span class="title">context · session tree</span><span class="sub">mod+p → 4</span></div>
+<pre class="term"><span class="row">  <span class="rule">┌─</span> <span class="user">session tree</span> <span class="muted">·</span> <span class="cyan">sess#a3f9</span>                <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="ok">●</span> <span class="dim">14:01</span>  start  "router timeout"          <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  │                                           <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="ok">●</span>─┐ <span class="dim">14:08</span>  fork  branch <span class="cyan">a</span>                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  │ │                                         <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  │ <span class="ok">●</span> <span class="dim">14:11</span>  pytest, 2 failures            <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  │ │                                         <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  │ <span class="sel"><span class="run">●</span> <span class="dim">14:14</span>  current ◀</span>                     <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  │                                           <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="ok">●</span> <span class="dim">14:09</span>  reply  "skipped, asked for logs"  <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>  <span class="muted">f fork · r replay · ↵ jump · / search</span>     <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└──────────────────────────────────────────────┘</span></span></pre>
+    </div>
+  </div>
+
+  <!-- 4. Diff view -->
+  <div class="section-title" style="margin-top:32px"><div class="num">04</div><h2>Diff view</h2><div class="desc">unified diff · per-hunk approve / reject · annotation</div></div>
+  <div class="mockup">
+    <div class="mockup-head"><span class="title">diff view</span><span class="sub">unified · 1 of 3 hunks</span></div>
+<pre class="term"><span class="row">  <span class="rule">┌─</span> <span class="user">src/router.py</span> <span class="muted">· hunk</span> <span class="cyan">1 / 3</span> <span class="muted">·</span> <span class="ok">+6</span> <span class="bad">−2</span>                                          <span class="rule">─┐</span></span>
+<span class="row">  <span class="rule">│</span>                                                                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="dim">@@ -42,9 +42,12 @@ class Router:</span>                                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="muted">  42    def route(self, request):</span>                                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="del">  43 −      provider = self.primary</span>                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="del">  44 −      return provider.call(request)</span>                                        <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="add">  43 +      for provider in self.chain:</span>                                          <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="add">  44 +          try:</span>                                                              <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="add">  45 +              return provider.call(request)</span>                                 <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="add">  46 +          except ProviderError:</span>                                             <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="add">  47 +              continue</span>                                                      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="add">  48 +      raise NoProvidersAvailable()</span>                                          <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>                                                                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="muted">comment 14:14:</span> <span class="warn">"good — but log the swallowed errors before continuing"</span>          <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span>                                                                                <span class="rule">│</span></span>
+<span class="row">  <span class="rule">│</span> <span class="dim">[</span> <span class="ok">a</span> <span class="dim">] approve · [</span> <span class="bad">r</span> <span class="dim">] reject · [</span> <span class="cyan">tab</span> <span class="dim">] next hunk · [</span> <span class="cyan">c</span> <span class="dim">] comment · [</span> <span class="ok">A</span> <span class="dim">] all</span>      <span class="rule">│</span></span>
+<span class="row">  <span class="rule">└────────────────────────────────────────────────────────────────────────────────┘</span></span></pre>
+  </div>
+
+  <!-- 5. Command palette -->
+  <div class="section-title" style="margin-top:32px"><div class="num">05</div><h2>Command palette overlay</h2><div class="desc">mod+k · fuzzy filter over slash commands + actions</div></div>
+  <div class="mockup">
+    <div class="mockup-head"><span class="title">command palette</span><span class="sub">centered · 60×16 · query "fork"</span></div>
+<pre class="term"><span class="row"><span class="rule">┌────────────────────────────────────────────────────────────────────────────────────────────────┐</span></span>
+<span class="row"><span class="rule">│</span> <span class="user">CONDUIT</span> <span class="dim">·</span> <span class="muted">claude-opus-4-6 ·</span> <span class="ok">$0.12</span> <span class="muted">· sess#a3f9 ·</span> <span class="warn">tier: write</span>                                  <span class="rule">│</span></span>
+<span class="row"><span class="rule">├────────────────────────────────────────────────────────────────┬───────────────────────────────┤</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">conversation dimmed …………</span>      <span class="rule">┌──────────────────────────────────────────┐</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span> <span class="cyan">⌘K</span>  <span class="muted">&gt;</span> <span class="user">fork</span><span class="dim">_</span>                              <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">├──────────────────────────────────────────┤</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span> <span class="sel">▸ /sessions fork &lt;turn&gt;   <span class="muted">git for chat</span>  </span> <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span>   /sessions list                          <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span>   /sessions replay &lt;id&gt;                   <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span>   /workflow run <span class="cyan">nightly-eval</span>              <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span>   /memory search <span class="warn">"router"</span>                 <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span> <span class="dim">…………………………………………</span>       <span class="rule">│</span>   /hooks log                              <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                <span class="rule">├──────────────────────────────────────────┤</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                <span class="rule">│</span> <span class="dim">↑↓ select ·</span> <span class="ok">↵</span> <span class="dim">run · esc cancel</span>          <span class="rule">│</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">│</span>                                <span class="rule">└──────────────────────────────────────────┘</span> <span class="rule">│</span>             <span class="rule">│</span></span>
+<span class="row"><span class="rule">├────────────────────────────────────────────────────────────────┴───────────────────────────────┤</span></span>
+<span class="row"><span class="rule">│</span> <span class="cyan">&gt;</span> <span class="dim">_</span>                                                                                          <span class="rule">│</span></span>
+<span class="row"><span class="rule">└────────────────────────────────────────────────────────────────────────────────────────────────┘</span></span></pre>
+  </div>
+
+  <div class="section-title" style="margin-top:40px"><div class="num">06</div><h2>Locked decisions</h2><div class="desc">resolved in design review · 2026-04-29 · binding for TUI build</div></div>
+  <div class="mockup">
+    <div class="mockup-head"><span class="title">design decisions</span><span class="sub">5 / 5 resolved</span></div>
+<pre class="term"><span class="row">  <span class="user">Q1.</span> Keybinding hints                  <span class="ok">✓</span> <span class="cyan">press</span> <span class="user">?</span> <span class="cyan">to reveal</span></span>
+<span class="row">      <span class="muted">rationale: keep the screen clean; ? is a near-universal "help" affordance.</span></span>
+<span class="row"></span>
+<span class="row">  <span class="user">Q2.</span> Tool call default state           <span class="ok">✓</span> <span class="run">expanded while running</span><span class="muted">, auto-collapse on done</span></span>
+<span class="row">      <span class="muted">rationale: live visibility into the agent matters more than reducing noise.</span></span>
+<span class="row"></span>
+<span class="row">  <span class="user">Q3.</span> Status bar order                  <span class="ok">✓</span> <span class="user">identity first</span> <span class="muted">(model · cost · session · tier)</span></span>
+<span class="row">      <span class="muted">rationale: which model is talking is the first thing you need to know.</span></span>
+<span class="row"></span>
+<span class="row">  <span class="user">Q4.</span> Diff view placement               <span class="ok">✓</span> <span class="cyan">inside conversation panel</span></span>
+<span class="row">      <span class="muted">rationale: preserve chronology; diffs belong in the message that triggered them.</span></span>
+<span class="row"></span>
+<span class="row">  <span class="user">Q5.</span> Agent identity color              <span class="ok">✓</span> <span class="magenta">magenta</span></span>
+<span class="row">      <span class="muted">rationale: distinct from system white and from all four status tints.</span></span></pre>
+  </div>
+</section>
+
+
+<script>
+  const tabs = document.querySelectorAll('.tab');
+  const panes = document.querySelectorAll('.pane');
+  tabs.forEach(t => {
+    t.addEventListener('click', () => {
+      tabs.forEach(x => x.setAttribute('aria-selected', 'false'));
+      panes.forEach(p => p.dataset.active = 'false');
+      t.setAttribute('aria-selected', 'true');
+      const id = t.dataset.target;
+      document.getElementById(id).dataset.active = 'true';
+      window.scrollTo({ top: 0, behavior: 'instant' });
+    });
+  });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `docs/mockups/tui-mockups.html` — a single-page review artifact with three fidelity passes (wireframe → grayscale → color) covering all six surfaces called out in #5: three-panel layout, status bar, tool call blocks, context panel views (workflow / memory / hooks / session tree), diff view, command palette overlay.
- Locks five design decisions in the **Color** tab (now the binding spec for TUI build):
  - **Q1.** Keybinding hints → press `?` to reveal (no persistent row).
  - **Q2.** Tool calls → expanded while running, auto-collapse on done.
  - **Q3.** Status bar → identity first (model · cost · session · tier).
  - **Q4.** Diff view → inside conversation panel (preserves chronology).
  - **Q5.** Agent identity color → magenta (distinct from system white and the four status tints).
- Wireframe + grayscale tabs are kept as the review trail; only Color is the spec.

Closes #5.

## Test plan
- [ ] Open `docs/mockups/tui-mockups.html` in a browser; verify all three fidelity tabs load and the Color tab is the default.
- [ ] Confirm all six surfaces render in each tab (three-panel, status bar, tool call states, four context views, diff view, command palette).
- [ ] Confirm section 06 in the Color tab shows the five resolved decisions.
- [ ] Sanity-check that the locked decisions match this PR description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)