### PR TITLE
Add transparent model escalation routing

### DIFF
--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -20,3 +20,46 @@ type EngineInfo struct {
 	Surfaces  []Surface
 	StartedAt time.Time
 }
+
+// TaskTag marks inference requests that need special routing treatment.
+type TaskTag string
+
+const (
+	TaskTagDestructive TaskTag = "destructive"
+	TaskTagPublish     TaskTag = "publish"
+	TaskTagFinancial   TaskTag = "financial"
+)
+
+// EscalationReason explains why a request moved to the escalation model.
+type EscalationReason string
+
+const (
+	EscalationReasonLowConfidence    EscalationReason = "low_confidence"
+	EscalationReasonFirstWorkflowRun EscalationReason = "first_workflow_run"
+	EscalationReasonHighStakesTask   EscalationReason = "high_stakes_task"
+	EscalationReasonModelUncertainty EscalationReason = "model_uncertainty"
+)
+
+// ModelRouteRequest is the core engine's model-routing input.
+type ModelRouteRequest struct {
+	WorkflowType           string
+	Confidence             float64
+	Tags                   []TaskTag
+	SelfSignalsUncertainty bool
+}
+
+// ModelRouteDecision records the selected model and transparent escalation
+// details for surfaces and session logs.
+type ModelRouteDecision struct {
+	DefaultModel    string
+	EscalationModel string
+	SelectedModel   string
+	Escalated       bool
+	Reasons         []EscalationReason
+}
+
+// SessionLogEntry is a user-visible event emitted by the engine.
+type SessionLogEntry struct {
+	At      time.Time
+	Message string
+}

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -2,6 +2,8 @@
 package core
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jabreeflor/conduit/internal/contracts"
@@ -9,10 +11,12 @@ import (
 
 // Engine owns the long-lived runtime state for Conduit.
 type Engine struct {
-	name      string
-	version   string
-	startedAt time.Time
-	surfaces  []contracts.Surface
+	name       string
+	version    string
+	startedAt  time.Time
+	surfaces   []contracts.Surface
+	router     *ModelRouter
+	sessionLog []contracts.SessionLogEntry
 }
 
 // New creates a core engine instance with the surfaces planned for the
@@ -27,6 +31,7 @@ func New(version string) *Engine {
 			contracts.SurfaceGUI,
 			contracts.SurfaceSpotlight,
 		},
+		router: NewModelRouter(DefaultEscalationConfig()),
 	}
 }
 
@@ -38,4 +43,36 @@ func (e *Engine) Info() contracts.EngineInfo {
 		Surfaces:  append([]contracts.Surface(nil), e.surfaces...),
 		StartedAt: e.startedAt,
 	}
+}
+
+// RouteModel selects a model for an inference request and logs transparent
+// escalation events for all surfaces.
+func (e *Engine) RouteModel(req contracts.ModelRouteRequest) contracts.ModelRouteDecision {
+	decision := e.router.Route(req)
+	if decision.Escalated {
+		e.sessionLog = append(e.sessionLog, contracts.SessionLogEntry{
+			At:      time.Now().UTC(),
+			Message: fmt.Sprintf("model escalated from %s to %s (%s)", decision.DefaultModel, decision.EscalationModel, joinReasons(decision.Reasons)),
+		})
+	}
+	return decision
+}
+
+// ModelStatus returns the router state that a surface can show in its status
+// area without mutating workflow first-run tracking.
+func (e *Engine) ModelStatus() contracts.ModelRouteDecision {
+	return e.router.Status()
+}
+
+// SessionLog returns a copy of user-visible engine events.
+func (e *Engine) SessionLog() []contracts.SessionLogEntry {
+	return append([]contracts.SessionLogEntry(nil), e.sessionLog...)
+}
+
+func joinReasons(reasons []contracts.EscalationReason) string {
+	parts := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		parts = append(parts, string(reason))
+	}
+	return strings.Join(parts, ", ")
 }

--- a/internal/core/router.go
+++ b/internal/core/router.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"slices"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// EscalationConfig controls cheap-to-capable model routing.
+type EscalationConfig struct {
+	DefaultModel        string
+	EscalationModel     string
+	ConfidenceThreshold float64
+	HighStakesTags      []contracts.TaskTag
+}
+
+// DefaultEscalationConfig matches the PRD's cheap-fast to capable model path.
+func DefaultEscalationConfig() EscalationConfig {
+	return EscalationConfig{
+		DefaultModel:        "claude-haiku-4-5",
+		EscalationModel:     "claude-opus-4-6",
+		ConfidenceThreshold: 0.65,
+		HighStakesTags: []contracts.TaskTag{
+			contracts.TaskTagDestructive,
+			contracts.TaskTagPublish,
+			contracts.TaskTagFinancial,
+		},
+	}
+}
+
+// ModelRouter chooses an inference model and tracks workflow first-runs.
+type ModelRouter struct {
+	config        EscalationConfig
+	seenWorkflows map[string]bool
+}
+
+// NewModelRouter creates a router with the supplied escalation configuration.
+func NewModelRouter(config EscalationConfig) *ModelRouter {
+	return &ModelRouter{
+		config:        config,
+		seenWorkflows: make(map[string]bool),
+	}
+}
+
+// Route chooses the default model unless one or more escalation triggers fire.
+func (r *ModelRouter) Route(req contracts.ModelRouteRequest) contracts.ModelRouteDecision {
+	reasons := r.escalationReasons(req)
+	selected := r.config.DefaultModel
+	if len(reasons) > 0 {
+		selected = r.config.EscalationModel
+	}
+
+	if req.WorkflowType != "" {
+		r.seenWorkflows[req.WorkflowType] = true
+	}
+
+	return contracts.ModelRouteDecision{
+		DefaultModel:    r.config.DefaultModel,
+		EscalationModel: r.config.EscalationModel,
+		SelectedModel:   selected,
+		Escalated:       len(reasons) > 0,
+		Reasons:         reasons,
+	}
+}
+
+// Status returns a non-mutating model route summary for UI status surfaces.
+func (r *ModelRouter) Status() contracts.ModelRouteDecision {
+	return contracts.ModelRouteDecision{
+		DefaultModel:    r.config.DefaultModel,
+		EscalationModel: r.config.EscalationModel,
+		SelectedModel:   r.config.DefaultModel,
+	}
+}
+
+func (r *ModelRouter) escalationReasons(req contracts.ModelRouteRequest) []contracts.EscalationReason {
+	var reasons []contracts.EscalationReason
+
+	if req.Confidence > 0 && req.Confidence < r.config.ConfidenceThreshold {
+		reasons = append(reasons, contracts.EscalationReasonLowConfidence)
+	}
+	if req.WorkflowType != "" && !r.seenWorkflows[req.WorkflowType] {
+		reasons = append(reasons, contracts.EscalationReasonFirstWorkflowRun)
+	}
+	if hasHighStakesTag(req.Tags, r.config.HighStakesTags) {
+		reasons = append(reasons, contracts.EscalationReasonHighStakesTask)
+	}
+	if req.SelfSignalsUncertainty {
+		reasons = append(reasons, contracts.EscalationReasonModelUncertainty)
+	}
+
+	return reasons
+}
+
+func hasHighStakesTag(tags, highStakes []contracts.TaskTag) bool {
+	for _, tag := range tags {
+		if slices.Contains(highStakes, tag) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/core/router_test.go
+++ b/internal/core/router_test.go
@@ -1,0 +1,87 @@
+package core
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestRouteModelEscalatesOnConfiguredTriggers(t *testing.T) {
+	engine := New("test")
+
+	decision := engine.RouteModel(contracts.ModelRouteRequest{
+		WorkflowType:           "release",
+		Confidence:             0.42,
+		Tags:                   []contracts.TaskTag{contracts.TaskTagPublish},
+		SelfSignalsUncertainty: true,
+	})
+
+	if !decision.Escalated {
+		t.Fatal("decision did not escalate")
+	}
+	if decision.SelectedModel != "claude-opus-4-6" {
+		t.Fatalf("SelectedModel = %q, want claude-opus-4-6", decision.SelectedModel)
+	}
+
+	wantReasons := []contracts.EscalationReason{
+		contracts.EscalationReasonLowConfidence,
+		contracts.EscalationReasonFirstWorkflowRun,
+		contracts.EscalationReasonHighStakesTask,
+		contracts.EscalationReasonModelUncertainty,
+	}
+	for _, reason := range wantReasons {
+		if !slices.Contains(decision.Reasons, reason) {
+			t.Fatalf("Reasons = %v, want %q", decision.Reasons, reason)
+		}
+	}
+
+	log := engine.SessionLog()
+	if len(log) != 1 {
+		t.Fatalf("len(SessionLog) = %d, want 1", len(log))
+	}
+	if !strings.Contains(log[0].Message, "model escalated from claude-haiku-4-5 to claude-opus-4-6") {
+		t.Fatalf("log message %q does not describe escalation", log[0].Message)
+	}
+}
+
+func TestRouteModelDoesNotRepeatFirstRunEscalation(t *testing.T) {
+	engine := New("test")
+
+	first := engine.RouteModel(contracts.ModelRouteRequest{
+		WorkflowType: "daily-review",
+		Confidence:   0.9,
+	})
+	if !slices.Contains(first.Reasons, contracts.EscalationReasonFirstWorkflowRun) {
+		t.Fatalf("first Reasons = %v, want first workflow run", first.Reasons)
+	}
+
+	next := engine.RouteModel(contracts.ModelRouteRequest{
+		WorkflowType: "daily-review",
+		Confidence:   0.9,
+	})
+	if next.Escalated {
+		t.Fatalf("second decision escalated with Reasons = %v", next.Reasons)
+	}
+	if next.SelectedModel != "claude-haiku-4-5" {
+		t.Fatalf("SelectedModel = %q, want claude-haiku-4-5", next.SelectedModel)
+	}
+}
+
+func TestModelStatusDoesNotMarkWorkflowSeen(t *testing.T) {
+	engine := New("test")
+
+	status := engine.ModelStatus()
+	if status.SelectedModel != "claude-haiku-4-5" {
+		t.Fatalf("status SelectedModel = %q, want claude-haiku-4-5", status.SelectedModel)
+	}
+
+	decision := engine.RouteModel(contracts.ModelRouteRequest{
+		WorkflowType: "new-workflow",
+		Confidence:   0.9,
+	})
+	if !slices.Contains(decision.Reasons, contracts.EscalationReasonFirstWorkflowRun) {
+		t.Fatalf("Reasons = %v, want first workflow run", decision.Reasons)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -20,6 +20,15 @@ func Run(out io.Writer) error {
 		surfaces = append(surfaces, string(surface))
 	}
 
-	_, err := fmt.Fprintf(out, "%s core online (%s)\n", info.Name, strings.Join(surfaces, ", "))
+	modelStatus := engine.ModelStatus()
+
+	_, err := fmt.Fprintf(
+		out,
+		"%s core online (%s)\nstatus: model %s; escalates to %s\n",
+		info.Name,
+		strings.Join(surfaces, ", "),
+		modelStatus.SelectedModel,
+		modelStatus.EscalationModel,
+	)
 	return err
 }

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -20,4 +20,7 @@ func TestRunBootsAgainstCore(t *testing.T) {
 	if !strings.Contains(got, "tui") || !strings.Contains(got, "gui") {
 		t.Fatalf("output %q does not include expected surfaces", got)
 	}
+	if !strings.Contains(got, "status: model claude-haiku-4-5; escalates to claude-opus-4-6") {
+		t.Fatalf("output %q does not include model escalation status", got)
+	}
 }


### PR DESCRIPTION
## Summary
- Adds the core model escalation contract and router for cheap-to-capable model selection.
- Implements low-confidence, first-workflow-run, high-stakes tag, and model uncertainty escalation triggers.
- Exposes model escalation status in the TUI boot output and logs escalation events in the session log.

Closes #7

## Test plan
- [x] go test ./...
- [x] go vet ./...

🤖 Generated with [Claude Code](https://claude.com/claude-code)