### PR TITLE
Add three-layer agent identity

### DIFF
--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -13,6 +13,7 @@ type Engine struct {
 	version   string
 	startedAt time.Time
 	surfaces  []contracts.Surface
+	identity  *IdentityManager
 }
 
 // New creates a core engine instance with the surfaces planned for the
@@ -27,6 +28,7 @@ func New(version string) *Engine {
 			contracts.SurfaceGUI,
 			contracts.SurfaceSpotlight,
 		},
+		identity: NewIdentityManager(DefaultIdentityConfig()),
 	}
 }
 
@@ -38,4 +40,9 @@ func (e *Engine) Info() contracts.EngineInfo {
 		Surfaces:  append([]contracts.Surface(nil), e.surfaces...),
 		StartedAt: e.startedAt,
 	}
+}
+
+// Identity returns the engine-owned three-layer identity manager.
+func (e *Engine) Identity() *IdentityManager {
+	return e.identity
 }

--- a/internal/core/identity.go
+++ b/internal/core/identity.go
@@ -1,0 +1,381 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// MemoryKind identifies which identity memory lane an entry belongs to.
+type MemoryKind string
+
+const (
+	MemoryKindShortTerm         MemoryKind = "short-term"
+	MemoryKindLongTermEpisodic  MemoryKind = "long-term-episodic"
+	MemoryKindSkill             MemoryKind = "skill"
+	defaultConduitDirectoryName            = ".conduit"
+)
+
+// IdentityConfig locates the static identity files and the flat-file memory
+// store. The default layout is ~/.conduit/{SOUL.md,USER.md,memory/*.md}.
+type IdentityConfig struct {
+	HomeDir   string
+	SoulPath  string
+	UserPath  string
+	MemoryDir string
+}
+
+// DefaultIdentityConfig returns the local-first identity layout for this user.
+func DefaultIdentityConfig() IdentityConfig {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		home = "."
+	}
+
+	conduitHome := filepath.Join(home, defaultConduitDirectoryName)
+	return IdentityConfig{
+		HomeDir:   conduitHome,
+		SoulPath:  filepath.Join(conduitHome, "SOUL.md"),
+		UserPath:  filepath.Join(conduitHome, "USER.md"),
+		MemoryDir: filepath.Join(conduitHome, "memory"),
+	}
+}
+
+func (c IdentityConfig) withDefaults() IdentityConfig {
+	if c.HomeDir == "" {
+		c.HomeDir = DefaultIdentityConfig().HomeDir
+	}
+	if c.SoulPath == "" {
+		c.SoulPath = filepath.Join(c.HomeDir, "SOUL.md")
+	}
+	if c.UserPath == "" {
+		c.UserPath = filepath.Join(c.HomeDir, "USER.md")
+	}
+	if c.MemoryDir == "" {
+		c.MemoryDir = filepath.Join(c.HomeDir, "memory")
+	}
+	return c
+}
+
+// MemoryEntry is a single memory record. Long-term and skill entries are stored
+// as flat markdown files so macOS Spotlight can index them naturally.
+type MemoryEntry struct {
+	ID        string
+	Kind      MemoryKind
+	Title     string
+	Body      string
+	Path      string
+	CreatedAt time.Time
+}
+
+// IdentitySnapshot is the loaded three-layer identity state for prompt assembly.
+type IdentitySnapshot struct {
+	Soul       string
+	User       string
+	ShortTerm  []MemoryEntry
+	LongTerm   []MemoryEntry
+	Skill      []MemoryEntry
+	LoadedFrom IdentityConfig
+}
+
+// SystemPrompt composes identity context in increasing priority. SOUL.md is
+// injected last so it can override USER.md and memory context.
+func (s IdentitySnapshot) SystemPrompt() string {
+	var sections []string
+
+	memory := formatMemorySections(s.ShortTerm, s.LongTerm, s.Skill)
+	if memory != "" {
+		sections = append(sections, "## Memory\n\n"+memory)
+	}
+	if strings.TrimSpace(s.User) != "" {
+		sections = append(sections, "## USER.md\n\n"+strings.TrimSpace(s.User))
+	}
+	if strings.TrimSpace(s.Soul) != "" {
+		sections = append(sections, "## SOUL.md\n\n"+strings.TrimSpace(s.Soul))
+	}
+
+	return strings.Join(sections, "\n\n")
+}
+
+// IdentityManager owns the static and dynamic identity layers for one engine.
+type IdentityManager struct {
+	config    IdentityConfig
+	shortTerm []MemoryEntry
+	now       func() time.Time
+}
+
+// NewIdentityManager creates an identity manager using the provided config.
+func NewIdentityManager(config IdentityConfig) *IdentityManager {
+	return &IdentityManager{
+		config: config.withDefaults(),
+		now:    func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// Config returns the resolved identity paths.
+func (m *IdentityManager) Config() IdentityConfig {
+	return m.config
+}
+
+// RememberShortTerm records session-scoped context that is never written to disk.
+func (m *IdentityManager) RememberShortTerm(title, body string) MemoryEntry {
+	entry := MemoryEntry{
+		ID:        memoryID(m.now(), title),
+		Kind:      MemoryKindShortTerm,
+		Title:     strings.TrimSpace(title),
+		Body:      strings.TrimSpace(body),
+		CreatedAt: m.now(),
+	}
+	m.shortTerm = append(m.shortTerm, entry)
+	return entry
+}
+
+// ClearShortTerm drops session-scoped memory at session end.
+func (m *IdentityManager) ClearShortTerm() {
+	m.shortTerm = nil
+}
+
+// WriteMemory persists a long-term episodic or skill memory as a flat markdown file.
+func (m *IdentityManager) WriteMemory(kind MemoryKind, title, body string) (MemoryEntry, error) {
+	if kind == MemoryKindShortTerm {
+		return MemoryEntry{}, fmt.Errorf("short-term memory is session-scoped; use RememberShortTerm")
+	}
+	if kind == "" {
+		kind = MemoryKindLongTermEpisodic
+	}
+
+	createdAt := m.now()
+	entry := MemoryEntry{
+		ID:        memoryID(createdAt, title),
+		Kind:      kind,
+		Title:     strings.TrimSpace(title),
+		Body:      strings.TrimSpace(body),
+		CreatedAt: createdAt,
+	}
+	if entry.Title == "" {
+		entry.Title = "Untitled memory"
+	}
+
+	if err := os.MkdirAll(m.config.MemoryDir, 0o755); err != nil {
+		return MemoryEntry{}, err
+	}
+
+	entry.Path = filepath.Join(m.config.MemoryDir, entry.ID+".md")
+	contents := fmt.Sprintf("---\nkind: %s\ncreated_at: %s\ntitle: %s\n---\n\n# %s\n\n%s\n",
+		entry.Kind,
+		entry.CreatedAt.Format(time.RFC3339),
+		entry.Title,
+		entry.Title,
+		entry.Body,
+	)
+
+	if err := os.WriteFile(entry.Path, []byte(contents), 0o644); err != nil {
+		return MemoryEntry{}, err
+	}
+	return entry, nil
+}
+
+// Load reads SOUL.md, USER.md, and all flat markdown files from the memory dir.
+func (m *IdentityManager) Load() (IdentitySnapshot, error) {
+	if err := os.MkdirAll(m.config.MemoryDir, 0o755); err != nil {
+		return IdentitySnapshot{}, err
+	}
+
+	soul, err := readOptionalMarkdown(m.config.SoulPath)
+	if err != nil {
+		return IdentitySnapshot{}, err
+	}
+	user, err := readOptionalMarkdown(m.config.UserPath)
+	if err != nil {
+		return IdentitySnapshot{}, err
+	}
+
+	longTerm, skill, err := m.loadMemoryFiles()
+	if err != nil {
+		return IdentitySnapshot{}, err
+	}
+
+	return IdentitySnapshot{
+		Soul:       soul,
+		User:       user,
+		ShortTerm:  append([]MemoryEntry(nil), m.shortTerm...),
+		LongTerm:   longTerm,
+		Skill:      skill,
+		LoadedFrom: m.config,
+	}, nil
+}
+
+func (m *IdentityManager) loadMemoryFiles() ([]MemoryEntry, []MemoryEntry, error) {
+	files, err := os.ReadDir(m.config.MemoryDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var entries []MemoryEntry
+	for _, file := range files {
+		if file.IsDir() || strings.ToLower(filepath.Ext(file.Name())) != ".md" {
+			continue
+		}
+
+		path := filepath.Join(m.config.MemoryDir, file.Name())
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		entry := parseMemoryMarkdown(path, strings.TrimSuffix(file.Name(), ".md"), string(contents))
+		info, err := file.Info()
+		if err == nil && entry.CreatedAt.IsZero() {
+			entry.CreatedAt = info.ModTime().UTC()
+		}
+		entries = append(entries, entry)
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].CreatedAt.Before(entries[j].CreatedAt)
+	})
+
+	var longTerm []MemoryEntry
+	var skill []MemoryEntry
+	for _, entry := range entries {
+		switch entry.Kind {
+		case MemoryKindSkill:
+			skill = append(skill, entry)
+		default:
+			if entry.Kind == "" {
+				entry.Kind = MemoryKindLongTermEpisodic
+			}
+			longTerm = append(longTerm, entry)
+		}
+	}
+
+	return longTerm, skill, nil
+}
+
+func readOptionalMarkdown(path string) (string, error) {
+	contents, err := os.ReadFile(path)
+	if err == nil {
+		return strings.TrimSpace(string(contents)), nil
+	}
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	return "", err
+}
+
+func parseMemoryMarkdown(path, id, contents string) MemoryEntry {
+	entry := MemoryEntry{
+		ID:   id,
+		Kind: MemoryKindLongTermEpisodic,
+		Path: path,
+		Body: strings.TrimSpace(contents),
+	}
+
+	if !strings.HasPrefix(contents, "---\n") {
+		entry.Title = firstMarkdownHeading(contents)
+		return entry
+	}
+
+	end := strings.Index(contents[len("---\n"):], "\n---")
+	if end == -1 {
+		entry.Title = firstMarkdownHeading(contents)
+		return entry
+	}
+
+	frontMatter := contents[len("---\n") : len("---\n")+end]
+	body := strings.TrimSpace(contents[len("---\n")+end+len("\n---"):])
+	entry.Body = body
+	for _, line := range strings.Split(frontMatter, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		switch strings.TrimSpace(key) {
+		case "kind":
+			entry.Kind = MemoryKind(value)
+		case "created_at":
+			if parsed, err := time.Parse(time.RFC3339, value); err == nil {
+				entry.CreatedAt = parsed.UTC()
+			}
+		case "title":
+			entry.Title = value
+		}
+	}
+	if entry.Title == "" {
+		entry.Title = firstMarkdownHeading(body)
+	}
+	return entry
+}
+
+func firstMarkdownHeading(contents string) string {
+	for _, line := range strings.Split(contents, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") {
+			return strings.TrimSpace(strings.TrimLeft(line, "#"))
+		}
+	}
+	return ""
+}
+
+func formatMemorySections(shortTerm, longTerm, skill []MemoryEntry) string {
+	sections := []struct {
+		title   string
+		entries []MemoryEntry
+	}{
+		{"Short-term context", shortTerm},
+		{"Long-term episodic memory", longTerm},
+		{"Skill memory", skill},
+	}
+
+	var out []string
+	for _, section := range sections {
+		if len(section.entries) == 0 {
+			continue
+		}
+
+		lines := []string{"### " + section.title}
+		for _, entry := range section.entries {
+			title := entry.Title
+			if title == "" {
+				title = entry.ID
+			}
+			lines = append(lines, fmt.Sprintf("- %s: %s", title, oneLine(entry.Body)))
+		}
+		out = append(out, strings.Join(lines, "\n"))
+	}
+
+	return strings.Join(out, "\n\n")
+}
+
+func oneLine(value string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+}
+
+func memoryID(createdAt time.Time, title string) string {
+	slug := slugify(title)
+	if slug == "" {
+		slug = "memory"
+	}
+	return createdAt.UTC().Format("20060102T150405Z") + "-" + slug
+}
+
+func slugify(value string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(value) {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r):
+			b.WriteRune(r)
+			lastDash = false
+		case !lastDash:
+			b.WriteRune('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/internal/core/identity_test.go
+++ b/internal/core/identity_test.go
@@ -1,0 +1,142 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIdentitySnapshotSystemPromptInjectsSoulLast(t *testing.T) {
+	snapshot := IdentitySnapshot{
+		Soul: "Prefer clarity over cleverness.",
+		User: "User prefers concise responses.",
+		ShortTerm: []MemoryEntry{{
+			ID:    "current-task",
+			Kind:  MemoryKindShortTerm,
+			Title: "Current task",
+			Body:  "Implement the identity stack.",
+		}},
+	}
+
+	prompt := snapshot.SystemPrompt()
+
+	memoryIndex := strings.Index(prompt, "## Memory")
+	userIndex := strings.Index(prompt, "## USER.md")
+	soulIndex := strings.Index(prompt, "## SOUL.md")
+	if memoryIndex == -1 || userIndex == -1 || soulIndex == -1 {
+		t.Fatalf("prompt missing expected layers:\n%s", prompt)
+	}
+	if !(memoryIndex < userIndex && userIndex < soulIndex) {
+		t.Fatalf("identity layers are not ordered memory -> USER.md -> SOUL.md:\n%s", prompt)
+	}
+}
+
+func TestIdentityManagerLoadsStaticFilesAndFlatMemory(t *testing.T) {
+	manager := newTestIdentityManager(t)
+	manager.now = fixedClock("2026-04-29T14:30:00Z")
+	writeFile(t, manager.config.SoulPath, "# Soul\n\nAsk before publishing.")
+	writeFile(t, manager.config.UserPath, "# User\n\nKeep responses tight.")
+
+	longTerm, err := manager.WriteMemory(MemoryKindLongTermEpisodic, "Router decision", "Use provider fallbacks.")
+	if err != nil {
+		t.Fatalf("WriteMemory(long-term) returned error: %v", err)
+	}
+	manager.now = fixedClock("2026-04-29T14:31:00Z")
+	skill, err := manager.WriteMemory(MemoryKindSkill, "Release checklist", "Run tests before PR.")
+	if err != nil {
+		t.Fatalf("WriteMemory(skill) returned error: %v", err)
+	}
+
+	snapshot, err := manager.Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+
+	if snapshot.Soul != "# Soul\n\nAsk before publishing." {
+		t.Fatalf("Soul = %q", snapshot.Soul)
+	}
+	if snapshot.User != "# User\n\nKeep responses tight." {
+		t.Fatalf("User = %q", snapshot.User)
+	}
+	if len(snapshot.LongTerm) != 1 || snapshot.LongTerm[0].Title != "Router decision" {
+		t.Fatalf("LongTerm = %#v", snapshot.LongTerm)
+	}
+	if len(snapshot.Skill) != 1 || snapshot.Skill[0].Title != "Release checklist" {
+		t.Fatalf("Skill = %#v", snapshot.Skill)
+	}
+	if filepath.Dir(longTerm.Path) != manager.config.MemoryDir || filepath.Dir(skill.Path) != manager.config.MemoryDir {
+		t.Fatalf("memory files were not written flat under %s", manager.config.MemoryDir)
+	}
+}
+
+func TestIdentityManagerKeepsShortTermMemoryInSessionOnly(t *testing.T) {
+	manager := newTestIdentityManager(t)
+
+	manager.RememberShortTerm("Active branch", "codex/identity")
+	snapshot, err := manager.Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(snapshot.ShortTerm) != 1 {
+		t.Fatalf("len(ShortTerm) = %d, want 1", len(snapshot.ShortTerm))
+	}
+
+	files, err := os.ReadDir(manager.config.MemoryDir)
+	if err != nil {
+		t.Fatalf("ReadDir returned error: %v", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("short-term memory was written to disk: %#v", files)
+	}
+
+	manager.ClearShortTerm()
+	snapshot, err = manager.Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(snapshot.ShortTerm) != 0 {
+		t.Fatalf("len(ShortTerm) after clear = %d, want 0", len(snapshot.ShortTerm))
+	}
+}
+
+func TestEngineOwnsIdentityManager(t *testing.T) {
+	engine := New("test")
+
+	if engine.Identity() == nil {
+		t.Fatal("Identity() returned nil")
+	}
+	if engine.Identity().Config().SoulPath == "" {
+		t.Fatal("identity config did not resolve SOUL.md path")
+	}
+}
+
+func newTestIdentityManager(t *testing.T) *IdentityManager {
+	t.Helper()
+
+	home := t.TempDir()
+	manager := NewIdentityManager(IdentityConfig{HomeDir: home})
+	return manager
+}
+
+func writeFile(t *testing.T, path, contents string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+}
+
+func fixedClock(value string) func() time.Time {
+	return func() time.Time {
+		parsed, err := time.Parse(time.RFC3339, value)
+		if err != nil {
+			panic(err)
+		}
+		return parsed
+	}
+}


### PR DESCRIPTION
## Summary
- Add the engine-owned identity manager for SOUL.md, USER.md, and dynamic memory.
- Persist long-term episodic and skill memories as flat markdown files under the Conduit memory directory.
- Compose identity prompts with memory first, USER.md next, and SOUL.md last so the constitution wins.

## Test plan
- [x] go test ./...

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)