### PR TITLE
Add model router foundation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/jabreeflor/conduit
 
 go 1.22
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/router/config.go
+++ b/internal/router/config.go
@@ -1,0 +1,153 @@
+// Package router provides Conduit's unified inference API and model
+// provider failover logic.
+package router
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const defaultProviderTimeout = 60 * time.Second
+
+// TaskType describes the broad kind of work a model request should perform.
+type TaskType string
+
+const (
+	TaskGeneral TaskType = "general"
+	TaskCode    TaskType = "code"
+	TaskBrowser TaskType = "browser"
+	TaskImage   TaskType = "image"
+)
+
+// InputType identifies non-text request payloads that can require model
+// capabilities such as vision.
+type InputType string
+
+const (
+	InputText  InputType = "text"
+	InputImage InputType = "image"
+	InputPDF   InputType = "pdf"
+)
+
+// Capability describes a model/provider feature the router can require.
+type Capability string
+
+const (
+	CapabilityText        Capability = "text"
+	CapabilityVision      Capability = "vision"
+	CapabilityComputerUse Capability = "computer_use"
+)
+
+// Config mirrors the model router section in ~/.conduit/config.yaml.
+type Config struct {
+	Models ModelConfig `yaml:"models"`
+}
+
+// ModelConfig is the top-level YAML block for model routing.
+type ModelConfig struct {
+	Primary      string           `yaml:"primary"`
+	Fallbacks    []string         `yaml:"fallbacks"`
+	ComputerUse  string           `yaml:"computer_use"`
+	RoutingRules []RoutingRule    `yaml:"routing_rules"`
+	Providers    []ProviderConfig `yaml:"providers"`
+}
+
+// RoutingRule can prefer a provider/model for a task or require a capability
+// for a given input type.
+type RoutingRule struct {
+	TaskType          TaskType   `yaml:"task_type"`
+	InputType         InputType  `yaml:"input_type"`
+	RequireCapability Capability `yaml:"require_capability"`
+	Prefer            string     `yaml:"prefer"`
+}
+
+// ProviderConfig defines static provider metadata used before an API client is
+// attached.
+type ProviderConfig struct {
+	Name               string         `yaml:"name"`
+	Model              string         `yaml:"model"`
+	Capabilities       []Capability   `yaml:"capabilities"`
+	Timeout            time.Duration  `yaml:"timeout"`
+	InputCostPer1KUSD  float64        `yaml:"input_cost_per_1k_usd"`
+	OutputCostPer1KUSD float64        `yaml:"output_cost_per_1k_usd"`
+	Extra              map[string]any `yaml:",inline"`
+}
+
+// LoadConfig reads the default Conduit config from ~/.conduit/config.yaml.
+func LoadConfig() (Config, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return Config{}, err
+	}
+	return LoadConfigFile(filepath.Join(home, ".conduit", "config.yaml"))
+}
+
+// LoadConfigFile reads a router config from path.
+func LoadConfigFile(path string) (Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return Config{}, err
+	}
+	if cfg.Models.Primary == "" {
+		return Config{}, errors.New("router config requires models.primary")
+	}
+	return cfg, nil
+}
+
+func providerConfigs(cfg Config) map[string]ProviderConfig {
+	providers := make(map[string]ProviderConfig, len(cfg.Models.Providers)+len(cfg.Models.Fallbacks)+1)
+	for _, provider := range cfg.Models.Providers {
+		normalized := provider.withDefaults()
+		providers[normalized.Name] = normalized
+		if normalized.Model != "" {
+			providers[normalized.Model] = normalized
+		}
+	}
+
+	for _, name := range append([]string{cfg.Models.Primary}, cfg.Models.Fallbacks...) {
+		if _, ok := providers[name]; !ok && name != "" {
+			providers[name] = ProviderConfig{
+				Name:         name,
+				Model:        name,
+				Capabilities: []Capability{CapabilityText},
+				Timeout:      defaultProviderTimeout,
+			}
+		}
+	}
+	if cfg.Models.ComputerUse != "" {
+		if _, ok := providers[cfg.Models.ComputerUse]; !ok {
+			providers[cfg.Models.ComputerUse] = ProviderConfig{
+				Name:         cfg.Models.ComputerUse,
+				Model:        cfg.Models.ComputerUse,
+				Capabilities: []Capability{CapabilityText, CapabilityComputerUse},
+				Timeout:      defaultProviderTimeout,
+			}
+		}
+	}
+	return providers
+}
+
+func (p ProviderConfig) withDefaults() ProviderConfig {
+	if p.Name == "" {
+		p.Name = p.Model
+	}
+	if p.Model == "" {
+		p.Model = p.Name
+	}
+	if len(p.Capabilities) == 0 {
+		p.Capabilities = []Capability{CapabilityText}
+	}
+	if p.Timeout <= 0 {
+		p.Timeout = defaultProviderTimeout
+	}
+	return p
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,0 +1,354 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Provider is the narrow adapter every model integration implements.
+type Provider interface {
+	Name() string
+	Infer(context.Context, Request) (Response, error)
+}
+
+// Request is the unified inference API consumed by the rest of the engine.
+type Request struct {
+	SessionID    string
+	CheckpointID string
+	TaskType     TaskType
+	Inputs       []Input
+	Prompt       string
+}
+
+// Input is an inference request payload.
+type Input struct {
+	Type InputType
+	Ref  string
+	Text string
+}
+
+// Response is the normalized provider result returned by the router.
+type Response struct {
+	Provider     string
+	Model        string
+	Text         string
+	Usage        Usage
+	CheckpointID string
+}
+
+// Usage records token and cost data for one completed inference.
+type Usage struct {
+	InputTokens  int
+	OutputTokens int
+	CostUSD      float64
+}
+
+// Checkpoint identifies the most recent resumable state for a session.
+type Checkpoint struct {
+	SessionID string
+	ID        string
+}
+
+// CheckpointStore supplies resume points after provider failures.
+type CheckpointStore interface {
+	LastCheckpoint(context.Context, string) (Checkpoint, error)
+}
+
+// UsageSink receives per-provider accounting after successful calls.
+type UsageSink interface {
+	RecordUsage(context.Context, UsageRecord) error
+}
+
+// UsageRecord is a durable accounting event.
+type UsageRecord struct {
+	SessionID    string
+	Provider     string
+	Model        string
+	InputTokens  int
+	OutputTokens int
+	CostUSD      float64
+	RecordedAt   time.Time
+}
+
+// FailoverSink receives provider failure events before the router tries the
+// next candidate.
+type FailoverSink interface {
+	RecordFailover(context.Context, FailoverEvent) error
+}
+
+// FailoverEvent describes a failed attempt and the checkpoint used to resume.
+type FailoverEvent struct {
+	SessionID    string
+	FromProvider string
+	ToProvider   string
+	CheckpointID string
+	Err          error
+	RecordedAt   time.Time
+}
+
+// Router owns provider selection, failover, and accounting.
+type Router struct {
+	cfg         Config
+	providers   map[string]Provider
+	metadata    map[string]ProviderConfig
+	checkpoints CheckpointStore
+	usage       UsageSink
+	failovers   FailoverSink
+	now         func() time.Time
+}
+
+// Option customizes a router.
+type Option func(*Router)
+
+// WithCheckpointStore configures the store used for failover resume.
+func WithCheckpointStore(store CheckpointStore) Option {
+	return func(r *Router) {
+		r.checkpoints = store
+	}
+}
+
+// WithUsageSink configures usage accounting.
+func WithUsageSink(sink UsageSink) Option {
+	return func(r *Router) {
+		r.usage = sink
+	}
+}
+
+// WithFailoverSink configures failover event accounting.
+func WithFailoverSink(sink FailoverSink) Option {
+	return func(r *Router) {
+		r.failovers = sink
+	}
+}
+
+// New creates a model router from config and provider adapters.
+func New(cfg Config, providers []Provider, opts ...Option) (*Router, error) {
+	if cfg.Models.Primary == "" {
+		return nil, errors.New("router requires a primary model")
+	}
+
+	r := &Router{
+		cfg:       cfg,
+		providers: make(map[string]Provider, len(providers)),
+		metadata:  providerConfigs(cfg),
+		now:       func() time.Time { return time.Now().UTC() },
+	}
+	for _, provider := range providers {
+		r.providers[provider.Name()] = provider
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r, nil
+}
+
+// Infer routes a request through the preferred provider and configured
+// fallbacks, returning the first successful response.
+func (r *Router) Infer(ctx context.Context, req Request) (Response, error) {
+	chain := r.route(req)
+	if len(chain) == 0 {
+		return Response{}, errors.New("no providers configured")
+	}
+
+	var failures []error
+	for i, name := range chain {
+		provider, ok := r.providers[name]
+		if !ok {
+			failures = append(failures, fmt.Errorf("%s: provider adapter unavailable", name))
+			continue
+		}
+
+		attemptReq := req
+		if i > 0 && r.checkpoints != nil && req.SessionID != "" {
+			checkpoint, err := r.checkpoints.LastCheckpoint(ctx, req.SessionID)
+			if err != nil {
+				failures = append(failures, fmt.Errorf("%s: load checkpoint: %w", name, err))
+				continue
+			}
+			attemptReq.CheckpointID = checkpoint.ID
+		}
+
+		attemptCtx, cancel := r.contextForProvider(ctx, name)
+		resp, err := provider.Infer(attemptCtx, attemptReq)
+		cancel()
+		if err != nil {
+			failures = append(failures, fmt.Errorf("%s: %w", name, err))
+			r.recordFailover(ctx, req.SessionID, name, nextProvider(chain, i), attemptReq.CheckpointID, err)
+			continue
+		}
+
+		resp.Provider = name
+		if resp.Model == "" {
+			resp.Model = r.metadata[name].Model
+		}
+		if resp.CheckpointID == "" {
+			resp.CheckpointID = attemptReq.CheckpointID
+		}
+		resp.Usage.CostUSD = r.costFor(name, resp.Usage)
+		r.recordUsage(ctx, req.SessionID, resp)
+		return resp, nil
+	}
+
+	return Response{}, fmt.Errorf("all providers failed: %w", errors.Join(failures...))
+}
+
+func (r *Router) contextForProvider(ctx context.Context, name string) (context.Context, context.CancelFunc) {
+	timeout := r.metadata[name].Timeout
+	if timeout <= 0 {
+		timeout = defaultProviderTimeout
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+func (r *Router) route(req Request) []string {
+	var chain []string
+	seen := map[string]bool{}
+
+	add := func(name string) {
+		name = r.providerName(name)
+		if name == "" || seen[name] {
+			return
+		}
+		if r.requestNeeds(req, CapabilityVision) && !r.providerHas(name, CapabilityVision) {
+			return
+		}
+		seen[name] = true
+		chain = append(chain, name)
+	}
+
+	for _, rule := range r.cfg.Models.RoutingRules {
+		if rule.Prefer == "" {
+			continue
+		}
+		if rule.TaskType != "" && rule.TaskType != req.TaskType {
+			continue
+		}
+		if rule.InputType != "" && !requestHasInput(req, rule.InputType) {
+			continue
+		}
+		if rule.RequireCapability != "" && !r.providerHas(rule.Prefer, rule.RequireCapability) {
+			continue
+		}
+		add(rule.Prefer)
+	}
+
+	if req.TaskType == TaskBrowser && r.cfg.Models.ComputerUse != "" {
+		add(r.cfg.Models.ComputerUse)
+	}
+	add(r.cfg.Models.Primary)
+	for _, fallback := range r.cfg.Models.Fallbacks {
+		add(fallback)
+	}
+
+	return chain
+}
+
+func (r *Router) providerHas(name string, capability Capability) bool {
+	name = r.providerName(name)
+	for _, candidate := range r.metadata[name].Capabilities {
+		if candidate == capability {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Router) providerName(name string) string {
+	if meta, ok := r.metadata[name]; ok && meta.Name != "" {
+		return meta.Name
+	}
+	return name
+}
+
+func (r *Router) requestNeeds(req Request, capability Capability) bool {
+	if capability != CapabilityVision {
+		return false
+	}
+	return requestHasInput(req, InputImage) || requestHasInput(req, InputPDF)
+}
+
+func requestHasInput(req Request, inputType InputType) bool {
+	for _, input := range req.Inputs {
+		if input.Type == inputType {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Router) costFor(provider string, usage Usage) float64 {
+	meta := r.metadata[provider]
+	if usage.CostUSD > 0 {
+		return usage.CostUSD
+	}
+	return (float64(usage.InputTokens)/1000)*meta.InputCostPer1KUSD +
+		(float64(usage.OutputTokens)/1000)*meta.OutputCostPer1KUSD
+}
+
+func (r *Router) recordUsage(ctx context.Context, sessionID string, resp Response) {
+	if r.usage == nil {
+		return
+	}
+	_ = r.usage.RecordUsage(ctx, UsageRecord{
+		SessionID:    sessionID,
+		Provider:     resp.Provider,
+		Model:        resp.Model,
+		InputTokens:  resp.Usage.InputTokens,
+		OutputTokens: resp.Usage.OutputTokens,
+		CostUSD:      resp.Usage.CostUSD,
+		RecordedAt:   r.now(),
+	})
+}
+
+func (r *Router) recordFailover(ctx context.Context, sessionID, from, to, checkpointID string, err error) {
+	if r.failovers == nil || to == "" {
+		return
+	}
+	_ = r.failovers.RecordFailover(ctx, FailoverEvent{
+		SessionID:    sessionID,
+		FromProvider: from,
+		ToProvider:   to,
+		CheckpointID: checkpointID,
+		Err:          err,
+		RecordedAt:   r.now(),
+	})
+}
+
+func nextProvider(chain []string, index int) string {
+	if index+1 >= len(chain) {
+		return ""
+	}
+	return chain[index+1]
+}
+
+// MemoryUsageSink is a concurrency-safe in-memory UsageSink for tests and
+// early surfaces that have not attached durable storage yet.
+type MemoryUsageSink struct {
+	mu      sync.Mutex
+	Records []UsageRecord
+}
+
+// RecordUsage stores a usage event.
+func (s *MemoryUsageSink) RecordUsage(_ context.Context, record UsageRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Records = append(s.Records, record)
+	return nil
+}
+
+// MemoryFailoverSink is a concurrency-safe in-memory FailoverSink.
+type MemoryFailoverSink struct {
+	mu     sync.Mutex
+	Events []FailoverEvent
+}
+
+// RecordFailover stores a failover event.
+func (s *MemoryFailoverSink) RecordFailover(_ context.Context, event FailoverEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Events = append(s.Events, event)
+	return nil
+}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,0 +1,253 @@
+package router
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestRouterRoutesCodeToPreferredProvider(t *testing.T) {
+	cfg := Config{Models: ModelConfig{
+		Primary:   "openai",
+		Fallbacks: []string{"ollama"},
+		RoutingRules: []RoutingRule{{
+			TaskType: TaskCode,
+			Prefer:   "claude",
+		}},
+		Providers: []ProviderConfig{
+			{Name: "openai", Model: "gpt-4o"},
+			{Name: "claude", Model: "claude-opus-4-6"},
+			{Name: "ollama", Model: "ollama/llama3"},
+		},
+	}}
+	claude := &fakeProvider{name: "claude", response: Response{Text: "ok"}}
+	openai := &fakeProvider{name: "openai", response: Response{Text: "wrong"}}
+
+	r, err := New(cfg, []Provider{claude, openai})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := r.Infer(context.Background(), Request{TaskType: TaskCode, Prompt: "write code"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Provider != "claude" {
+		t.Fatalf("Provider = %q, want claude", resp.Provider)
+	}
+	if len(claude.requests) != 1 {
+		t.Fatalf("claude calls = %d, want 1", len(claude.requests))
+	}
+	if len(openai.requests) != 0 {
+		t.Fatalf("openai calls = %d, want 0", len(openai.requests))
+	}
+}
+
+func TestRouterFailsOverFromCheckpointAndRecordsUsage(t *testing.T) {
+	cfg := Config{Models: ModelConfig{
+		Primary:   "claude",
+		Fallbacks: []string{"openai"},
+		Providers: []ProviderConfig{
+			{
+				Name:               "claude",
+				Model:              "claude-opus-4-6",
+				Timeout:            time.Second,
+				InputCostPer1KUSD:  3,
+				OutputCostPer1KUSD: 15,
+			},
+			{
+				Name:               "openai",
+				Model:              "gpt-4o",
+				Timeout:            time.Second,
+				InputCostPer1KUSD:  2.50,
+				OutputCostPer1KUSD: 10,
+			},
+		},
+	}}
+	claude := &fakeProvider{name: "claude", err: errors.New("rate limited")}
+	openai := &fakeProvider{
+		name: "openai",
+		response: Response{
+			Text:  "resumed",
+			Usage: Usage{InputTokens: 1000, OutputTokens: 500},
+		},
+	}
+	usage := &MemoryUsageSink{}
+	failovers := &MemoryFailoverSink{}
+	checkpoints := fakeCheckpoints{checkpoint: Checkpoint{SessionID: "s1", ID: "cp-7"}}
+
+	r, err := New(
+		cfg,
+		[]Provider{claude, openai},
+		WithCheckpointStore(checkpoints),
+		WithUsageSink(usage),
+		WithFailoverSink(failovers),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := r.Infer(context.Background(), Request{SessionID: "s1", TaskType: TaskGeneral, Prompt: "hello"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Provider != "openai" {
+		t.Fatalf("Provider = %q, want openai", resp.Provider)
+	}
+	if got := openai.requests[0].CheckpointID; got != "cp-7" {
+		t.Fatalf("fallback CheckpointID = %q, want cp-7", got)
+	}
+	if got := resp.Usage.CostUSD; got != 7.5 {
+		t.Fatalf("CostUSD = %v, want 7.5", got)
+	}
+	if len(usage.Records) != 1 || usage.Records[0].Provider != "openai" {
+		t.Fatalf("usage records = %#v, want one openai record", usage.Records)
+	}
+	if len(failovers.Events) != 1 {
+		t.Fatalf("failover events = %d, want 1", len(failovers.Events))
+	}
+	if failovers.Events[0].FromProvider != "claude" || failovers.Events[0].ToProvider != "openai" {
+		t.Fatalf("failover event = %#v, want claude -> openai", failovers.Events[0])
+	}
+}
+
+func TestRouterPromotesVisionCapableProviderForImageInput(t *testing.T) {
+	cfg := Config{Models: ModelConfig{
+		Primary:   "text-only",
+		Fallbacks: []string{"vision"},
+		RoutingRules: []RoutingRule{{
+			InputType:         InputImage,
+			RequireCapability: CapabilityVision,
+			Prefer:            "vision",
+		}},
+		Providers: []ProviderConfig{
+			{Name: "text-only", Model: "cheap-text", Capabilities: []Capability{CapabilityText}},
+			{Name: "vision", Model: "claude-opus-4-6", Capabilities: []Capability{CapabilityText, CapabilityVision}},
+		},
+	}}
+	textOnly := &fakeProvider{name: "text-only", response: Response{Text: "wrong"}}
+	vision := &fakeProvider{name: "vision", response: Response{Text: "saw it"}}
+
+	r, err := New(cfg, []Provider{textOnly, vision})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := r.Infer(context.Background(), Request{
+		TaskType: TaskImage,
+		Inputs:   []Input{{Type: InputImage, Ref: "/tmp/screenshot.png"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Provider != "vision" {
+		t.Fatalf("Provider = %q, want vision", resp.Provider)
+	}
+	if len(textOnly.requests) != 0 {
+		t.Fatalf("text-only calls = %d, want 0", len(textOnly.requests))
+	}
+}
+
+func TestRouterAcceptsModelNamesInPriorityList(t *testing.T) {
+	cfg := Config{Models: ModelConfig{
+		Primary:   "claude-opus-4-6",
+		Fallbacks: []string{"gpt-4o"},
+		Providers: []ProviderConfig{
+			{Name: "anthropic", Model: "claude-opus-4-6"},
+			{Name: "openai", Model: "gpt-4o"},
+		},
+	}}
+	anthropic := &fakeProvider{name: "anthropic", response: Response{Text: "ok"}}
+
+	r, err := New(cfg, []Provider{anthropic})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := r.Infer(context.Background(), Request{TaskType: TaskGeneral})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Provider != "anthropic" {
+		t.Fatalf("Provider = %q, want anthropic", resp.Provider)
+	}
+	if resp.Model != "claude-opus-4-6" {
+		t.Fatalf("Model = %q, want claude-opus-4-6", resp.Model)
+	}
+}
+
+func TestLoadConfigFile(t *testing.T) {
+	path := t.TempDir() + "/config.yaml"
+	data := []byte(`
+models:
+  primary: claude
+  fallbacks:
+    - openai
+  computer_use: codex
+  routing_rules:
+    - task_type: code
+      prefer: claude
+    - input_type: image
+      require_capability: vision
+      prefer: claude
+  providers:
+    - name: claude
+      model: claude-opus-4-6
+      timeout: 5s
+      capabilities: [text, vision]
+      input_cost_per_1k_usd: 3
+      output_cost_per_1k_usd: 15
+`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfigFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Models.Primary != "claude" {
+		t.Fatalf("Primary = %q, want claude", cfg.Models.Primary)
+	}
+	if got := cfg.Models.Providers[0].Timeout; got != 5*time.Second {
+		t.Fatalf("Timeout = %s, want 5s", got)
+	}
+	if cfg.Models.RoutingRules[1].RequireCapability != CapabilityVision {
+		t.Fatalf("RequireCapability = %q, want vision", cfg.Models.RoutingRules[1].RequireCapability)
+	}
+}
+
+type fakeProvider struct {
+	name     string
+	response Response
+	err      error
+	requests []Request
+}
+
+func (p *fakeProvider) Name() string { return p.name }
+
+func (p *fakeProvider) Infer(_ context.Context, req Request) (Response, error) {
+	p.requests = append(p.requests, req)
+	if p.err != nil {
+		return Response{}, p.err
+	}
+	return p.response, nil
+}
+
+type fakeCheckpoints struct {
+	checkpoint Checkpoint
+	err        error
+}
+
+func (c fakeCheckpoints) LastCheckpoint(context.Context, string) (Checkpoint, error) {
+	if c.err != nil {
+		return Checkpoint{}, c.err
+	}
+	return c.checkpoint, nil
+}


### PR DESCRIPTION
## Summary
- Add an internal model router with provider priority, routing rules, capability-aware selection, and per-provider timeouts
- Add automatic failover that resumes fallback attempts from the latest checkpoint
- Add unified inference request/response types plus usage and failover sinks for cost/token accounting

Closes #6

## Test plan
- [x] go test ./...

🤖 Generated with [Claude Code](https://claude.com/claude-code)