### PR TITLE
Add sandbox architecture guardrails

### DIFF
--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -63,3 +63,63 @@ type SessionLogEntry struct {
 	At      time.Time
 	Message string
 }
+
+// SandboxBackend identifies the host runtime used to create the isolated
+// Linux execution environment.
+type SandboxBackend string
+
+const (
+	SandboxBackendAppleVirtualization SandboxBackend = "apple_virtualization"
+	SandboxBackendOCIContainer        SandboxBackend = "oci_container"
+)
+
+// SandboxNetworkPolicy controls outbound network access from agent-run code.
+type SandboxNetworkPolicy string
+
+const (
+	SandboxNetworkPolicyControlledEgress SandboxNetworkPolicy = "controlled_egress"
+	SandboxNetworkPolicyOffline          SandboxNetworkPolicy = "offline"
+)
+
+// SandboxMountMode describes how a user-approved host path appears inside the
+// sandbox.
+type SandboxMountMode string
+
+const (
+	SandboxMountReadOnly  SandboxMountMode = "read_only"
+	SandboxMountReadWrite SandboxMountMode = "read_write"
+	SandboxMountCopyIn    SandboxMountMode = "copy_in"
+	SandboxMountCopyOut   SandboxMountMode = "copy_out"
+)
+
+// SandboxMount is an explicit filesystem grant from the host into the sandbox.
+type SandboxMount struct {
+	HostPath    string
+	SandboxPath string
+	Mode        SandboxMountMode
+}
+
+// SandboxArchitecture describes the security and startup contract every agent
+// execution sandbox must satisfy.
+type SandboxArchitecture struct {
+	Backend                   SandboxBackend
+	BaseImage                 string
+	ImagePrecached            bool
+	WarmStartBudget           time.Duration
+	Shells                    []string
+	PreinstalledRuntimes      []string
+	NetworkPolicy             SandboxNetworkPolicy
+	Mounts                    []SandboxMount
+	DenyHostFilesystem        bool
+	DenyHostNetwork           bool
+	DenyHostProcesses         bool
+	DenyPrivilegeEscalation   bool
+	DenyDockerSocket          bool
+	DiscardUnexportedChanges  bool
+	RequiresExplicitMounts    bool
+	RequiresExplicitEgress    bool
+	RequiresExplicitPortFwd   bool
+	RequiresNonRootUser       bool
+	RequiresProcessNamespace  bool
+	RequiresFilesystemOverlay bool
+}

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -17,6 +17,7 @@ type Engine struct {
 	surfaces   []contracts.Surface
 	identity   *IdentityManager
 	router     *ModelRouter
+	sandbox    *SandboxManager
 	sessionLog []contracts.SessionLogEntry
 }
 
@@ -34,6 +35,7 @@ func New(version string) *Engine {
 		},
 		identity: NewIdentityManager(DefaultIdentityConfig()),
 		router:   NewModelRouter(DefaultEscalationConfig()),
+		sandbox:  NewSandboxManager(DefaultSandboxArchitecture()),
 	}
 }
 
@@ -69,6 +71,11 @@ func (e *Engine) RouteModel(req contracts.ModelRouteRequest) contracts.ModelRout
 // area without mutating workflow first-run tracking.
 func (e *Engine) ModelStatus() contracts.ModelRouteDecision {
 	return e.router.Status()
+}
+
+// SandboxArchitecture returns the engine-owned execution sandbox policy.
+func (e *Engine) SandboxArchitecture() contracts.SandboxArchitecture {
+	return e.sandbox.Architecture()
 }
 
 // SessionLog returns a copy of user-visible engine events.

--- a/internal/core/sandbox.go
+++ b/internal/core/sandbox.go
@@ -1,0 +1,117 @@
+package core
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+const warmSandboxStartupBudget = 2 * time.Second
+
+var requiredSandboxShells = []string{"bash", "sh"}
+
+// SandboxManager owns the core sandbox architecture policy. Runtime adapters
+// can use this contract to launch Apple Virtualization.framework microVMs or
+// OCI containers without weakening Conduit's isolation guarantees.
+type SandboxManager struct {
+	architecture contracts.SandboxArchitecture
+}
+
+// DefaultSandboxArchitecture captures the PRD 15.1 baseline for agent tool
+// execution: a warm Ubuntu userspace with explicit host access gates.
+func DefaultSandboxArchitecture() contracts.SandboxArchitecture {
+	return contracts.SandboxArchitecture{
+		Backend:                   contracts.SandboxBackendAppleVirtualization,
+		BaseImage:                 "ubuntu-24.04",
+		ImagePrecached:            true,
+		WarmStartBudget:           warmSandboxStartupBudget,
+		Shells:                    []string{"bash", "zsh", "sh"},
+		PreinstalledRuntimes:      []string{"go", "node", "python"},
+		NetworkPolicy:             contracts.SandboxNetworkPolicyControlledEgress,
+		DenyHostFilesystem:        true,
+		DenyHostNetwork:           true,
+		DenyHostProcesses:         true,
+		DenyPrivilegeEscalation:   true,
+		DenyDockerSocket:          true,
+		DiscardUnexportedChanges:  true,
+		RequiresExplicitMounts:    true,
+		RequiresExplicitEgress:    true,
+		RequiresExplicitPortFwd:   true,
+		RequiresNonRootUser:       true,
+		RequiresProcessNamespace:  true,
+		RequiresFilesystemOverlay: true,
+	}
+}
+
+// NewSandboxManager creates a sandbox policy manager. Invalid policies are
+// accepted so callers can surface all validation errors together.
+func NewSandboxManager(architecture contracts.SandboxArchitecture) *SandboxManager {
+	return &SandboxManager{architecture: architecture}
+}
+
+// Architecture returns a deep copy of the sandbox contract.
+func (m *SandboxManager) Architecture() contracts.SandboxArchitecture {
+	return copySandboxArchitecture(m.architecture)
+}
+
+// Validate checks whether the sandbox policy satisfies Conduit's minimum
+// isolation and startup guarantees.
+func (m *SandboxManager) Validate() error {
+	var problems []string
+
+	if m.architecture.BaseImage == "" {
+		problems = append(problems, "base image is required")
+	}
+	if !m.architecture.ImagePrecached {
+		problems = append(problems, "sandbox image must be pre-cached")
+	}
+	if m.architecture.WarmStartBudget <= 0 || m.architecture.WarmStartBudget > warmSandboxStartupBudget {
+		problems = append(problems, "warm start budget must be at most 2s")
+	}
+	for _, shell := range requiredSandboxShells {
+		if !slices.Contains(m.architecture.Shells, shell) {
+			problems = append(problems, fmt.Sprintf("required shell %q is missing", shell))
+		}
+	}
+	if len(m.architecture.PreinstalledRuntimes) == 0 {
+		problems = append(problems, "at least one runtime must be pre-installed")
+	}
+	if m.architecture.NetworkPolicy == "" {
+		problems = append(problems, "network policy is required")
+	}
+
+	requiredBooleans := map[string]bool{
+		"host filesystem access must be denied by default":          m.architecture.DenyHostFilesystem,
+		"host network access must be denied by default":             m.architecture.DenyHostNetwork,
+		"host process access must be denied by default":             m.architecture.DenyHostProcesses,
+		"privilege escalation must be denied":                       m.architecture.DenyPrivilegeEscalation,
+		"docker socket access must be denied":                       m.architecture.DenyDockerSocket,
+		"unexported sandbox changes must be discarded":              m.architecture.DiscardUnexportedChanges,
+		"host mounts must require explicit grants":                  m.architecture.RequiresExplicitMounts,
+		"network egress must require explicit grants":               m.architecture.RequiresExplicitEgress,
+		"inbound ports must require explicit forwarding":            m.architecture.RequiresExplicitPortFwd,
+		"agent commands must run as a non-root user":                m.architecture.RequiresNonRootUser,
+		"host processes must be hidden by a process namespace":      m.architecture.RequiresProcessNamespace,
+		"host changes must be isolated behind a filesystem overlay": m.architecture.RequiresFilesystemOverlay,
+	}
+	for message, ok := range requiredBooleans {
+		if !ok {
+			problems = append(problems, message)
+		}
+	}
+
+	if len(problems) > 0 {
+		return fmt.Errorf("invalid sandbox architecture: %s", strings.Join(problems, "; "))
+	}
+	return nil
+}
+
+func copySandboxArchitecture(architecture contracts.SandboxArchitecture) contracts.SandboxArchitecture {
+	architecture.Shells = append([]string(nil), architecture.Shells...)
+	architecture.PreinstalledRuntimes = append([]string(nil), architecture.PreinstalledRuntimes...)
+	architecture.Mounts = append([]contracts.SandboxMount(nil), architecture.Mounts...)
+	return architecture
+}

--- a/internal/core/sandbox_test.go
+++ b/internal/core/sandbox_test.go
@@ -1,0 +1,90 @@
+package core
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestDefaultSandboxArchitectureMatchesPRDGuarantees(t *testing.T) {
+	manager := NewSandboxManager(DefaultSandboxArchitecture())
+
+	if err := manager.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+
+	architecture := manager.Architecture()
+	if architecture.BaseImage != "ubuntu-24.04" {
+		t.Fatalf("BaseImage = %q, want ubuntu-24.04", architecture.BaseImage)
+	}
+	if !architecture.ImagePrecached {
+		t.Fatal("ImagePrecached = false, want true")
+	}
+	if architecture.WarmStartBudget > 2*time.Second {
+		t.Fatalf("WarmStartBudget = %s, want <= 2s", architecture.WarmStartBudget)
+	}
+	if architecture.NetworkPolicy != contracts.SandboxNetworkPolicyControlledEgress {
+		t.Fatalf("NetworkPolicy = %q, want controlled egress", architecture.NetworkPolicy)
+	}
+	if !architecture.DenyHostFilesystem || !architecture.DenyHostNetwork || !architecture.DenyHostProcesses {
+		t.Fatalf("host isolation flags = filesystem:%t network:%t processes:%t, want all true",
+			architecture.DenyHostFilesystem,
+			architecture.DenyHostNetwork,
+			architecture.DenyHostProcesses,
+		)
+	}
+	if !architecture.DenyPrivilegeEscalation || !architecture.DenyDockerSocket || !architecture.RequiresNonRootUser {
+		t.Fatalf("privilege controls = escalation:%t docker:%t non-root:%t, want all true",
+			architecture.DenyPrivilegeEscalation,
+			architecture.DenyDockerSocket,
+			architecture.RequiresNonRootUser,
+		)
+	}
+}
+
+func TestSandboxArchitectureReturnsCopies(t *testing.T) {
+	engine := New("test")
+
+	first := engine.SandboxArchitecture()
+	first.Shells[0] = "fish"
+	first.PreinstalledRuntimes[0] = "ruby"
+
+	next := engine.SandboxArchitecture()
+	if next.Shells[0] != "bash" {
+		t.Fatalf("Shells were mutated through Architecture: %v", next.Shells)
+	}
+	if next.PreinstalledRuntimes[0] != "go" {
+		t.Fatalf("PreinstalledRuntimes were mutated through Architecture: %v", next.PreinstalledRuntimes)
+	}
+}
+
+func TestSandboxValidationRejectsWeakenedHostIsolation(t *testing.T) {
+	architecture := DefaultSandboxArchitecture()
+	architecture.DenyHostFilesystem = false
+	architecture.DenyHostNetwork = false
+	architecture.DenyHostProcesses = false
+	architecture.DenyPrivilegeEscalation = false
+	architecture.ImagePrecached = false
+	architecture.WarmStartBudget = 3 * time.Second
+
+	err := NewSandboxManager(architecture).Validate()
+	if err == nil {
+		t.Fatal("Validate returned nil, want isolation errors")
+	}
+
+	message := err.Error()
+	for _, want := range []string{
+		"pre-cached",
+		"warm start budget",
+		"host filesystem",
+		"host network",
+		"host process",
+		"privilege escalation",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("Validate error %q does not contain %q", message, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds typed sandbox architecture contracts for backend, network policy, mount modes, and security guarantees.
- Wires the core engine to expose a validated default Ubuntu sandbox policy with explicit host access gates.
- Adds tests covering PRD 15.1 guarantees, copy safety, and rejection of weakened isolation.

Closes #123

## Test plan
- [x] go test ./...
- [x] go vet ./...
- [x] gofmt check

🤖 Generated with [Claude Code](https://claude.com/claude-code)