### PR TITLE
Add permission gate foundation

### DIFF
--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -30,6 +30,70 @@ const (
 	TaskTagFinancial   TaskTag = "financial"
 )
 
+// PermissionCategory identifies the protected resource class for a tool or
+// workflow action.
+type PermissionCategory string
+
+const (
+	PermissionFilesystemHost    PermissionCategory = "filesystem_host"
+	PermissionFilesystemSandbox PermissionCategory = "filesystem_sandbox"
+	PermissionNetwork           PermissionCategory = "network"
+	PermissionShell             PermissionCategory = "shell"
+	PermissionComputerUse       PermissionCategory = "computer_use"
+	PermissionMobile            PermissionCategory = "mobile"
+	PermissionDestructive       PermissionCategory = "destructive"
+	PermissionExternalComms     PermissionCategory = "external_comms"
+	PermissionCredentials       PermissionCategory = "credentials"
+)
+
+// PermissionScope controls how long an approval remains valid.
+type PermissionScope string
+
+const (
+	PermissionScopeTask       PermissionScope = "task"
+	PermissionScopeSession    PermissionScope = "session"
+	PermissionScopePersistent PermissionScope = "persistent"
+)
+
+// PermissionAction records whether a permission request was allowed, denied,
+// or still needs explicit user confirmation.
+type PermissionAction string
+
+const (
+	PermissionActionAllow   PermissionAction = "allow"
+	PermissionActionDeny    PermissionAction = "deny"
+	PermissionActionConfirm PermissionAction = "confirm"
+)
+
+// PermissionRequest describes one gated resource access attempt.
+type PermissionRequest struct {
+	Category PermissionCategory
+	Resource string
+	Scope    PermissionScope
+	TaskID   string
+	Reason   string
+}
+
+// PermissionDecision is the gate's answer for a permission request.
+type PermissionDecision struct {
+	Action   PermissionAction
+	Category PermissionCategory
+	Resource string
+	Scope    PermissionScope
+	Reason   string
+}
+
+// PermissionAuditEntry is the user-visible record for a grant, denial, or
+// confirmation requirement.
+type PermissionAuditEntry struct {
+	At        time.Time
+	Request   PermissionRequest
+	Decision  PermissionDecision
+	Granted   bool
+	Denied    bool
+	Triggered string
+}
+
 // EscalationReason explains why a request moved to the escalation model.
 type EscalationReason string
 

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -11,13 +11,14 @@ import (
 
 // Engine owns the long-lived runtime state for Conduit.
 type Engine struct {
-	name       string
-	version    string
-	startedAt  time.Time
-	surfaces   []contracts.Surface
-	identity   *IdentityManager
-	router     *ModelRouter
-	sessionLog []contracts.SessionLogEntry
+	name        string
+	version     string
+	startedAt   time.Time
+	surfaces    []contracts.Surface
+	identity    *IdentityManager
+	router      *ModelRouter
+	permissions *PermissionManager
+	sessionLog  []contracts.SessionLogEntry
 }
 
 // New creates a core engine instance with the surfaces planned for the
@@ -32,8 +33,9 @@ func New(version string) *Engine {
 			contracts.SurfaceGUI,
 			contracts.SurfaceSpotlight,
 		},
-		identity: NewIdentityManager(DefaultIdentityConfig()),
-		router:   NewModelRouter(DefaultEscalationConfig()),
+		identity:    NewIdentityManager(DefaultIdentityConfig()),
+		router:      NewModelRouter(DefaultEscalationConfig()),
+		permissions: NewPermissionManager(DefaultPermissionConfig()),
 	}
 }
 
@@ -50,6 +52,22 @@ func (e *Engine) Info() contracts.EngineInfo {
 // Identity returns the engine-owned three-layer identity manager.
 func (e *Engine) Identity() *IdentityManager {
 	return e.identity
+}
+
+// Permissions returns the engine-owned permission gate.
+func (e *Engine) Permissions() *PermissionManager {
+	return e.permissions
+}
+
+// EvaluatePermission gates a protected resource access and records the decision
+// in both the permission audit trail and the session log.
+func (e *Engine) EvaluatePermission(req contracts.PermissionRequest) contracts.PermissionDecision {
+	decision := e.permissions.Evaluate(req)
+	e.sessionLog = append(e.sessionLog, contracts.SessionLogEntry{
+		At:      time.Now().UTC(),
+		Message: formatPermissionDecision(decision),
+	})
+	return decision
 }
 
 // RouteModel selects a model for an inference request and logs transparent

--- a/internal/core/permissions.go
+++ b/internal/core/permissions.go
@@ -1,0 +1,181 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// PermissionRule defines a default action for a permission category.
+type PermissionRule struct {
+	Category contracts.PermissionCategory
+	Action   contracts.PermissionAction
+	Scope    contracts.PermissionScope
+	Reason   string
+}
+
+// PermissionConfig configures safe-by-default permission decisions.
+type PermissionConfig struct {
+	DefaultScope contracts.PermissionScope
+	Rules        []PermissionRule
+}
+
+// DefaultPermissionConfig mirrors the PRD 15.4 category defaults.
+func DefaultPermissionConfig() PermissionConfig {
+	return PermissionConfig{
+		DefaultScope: contracts.PermissionScopeSession,
+		Rules: []PermissionRule{
+			{
+				Category: contracts.PermissionFilesystemHost,
+				Action:   contracts.PermissionActionDeny,
+				Scope:    contracts.PermissionScopeTask,
+				Reason:   "host filesystem access requires an explicit mount",
+			},
+			{
+				Category: contracts.PermissionFilesystemSandbox,
+				Action:   contracts.PermissionActionAllow,
+				Reason:   "sandbox-local filesystem is the agent workspace",
+			},
+			{
+				Category: contracts.PermissionNetwork,
+				Action:   contracts.PermissionActionConfirm,
+				Reason:   "network access must match an approved allowlist",
+			},
+			{
+				Category: contracts.PermissionShell,
+				Action:   contracts.PermissionActionAllow,
+				Reason:   "shell execution is allowed inside the sandbox",
+			},
+			{
+				Category: contracts.PermissionComputerUse,
+				Action:   contracts.PermissionActionConfirm,
+				Scope:    contracts.PermissionScopeTask,
+				Reason:   "desktop computer use requires separate approval",
+			},
+			{
+				Category: contracts.PermissionMobile,
+				Action:   contracts.PermissionActionConfirm,
+				Scope:    contracts.PermissionScopeTask,
+				Reason:   "mobile control requires separate approval",
+			},
+			{
+				Category: contracts.PermissionDestructive,
+				Action:   contracts.PermissionActionConfirm,
+				Scope:    contracts.PermissionScopeTask,
+				Reason:   "destructive operations require confirmation each time",
+			},
+			{
+				Category: contracts.PermissionExternalComms,
+				Action:   contracts.PermissionActionConfirm,
+				Scope:    contracts.PermissionScopeTask,
+				Reason:   "external communication requires confirmation each time",
+			},
+			{
+				Category: contracts.PermissionCredentials,
+				Action:   contracts.PermissionActionConfirm,
+				Scope:    contracts.PermissionScopeTask,
+				Reason:   "credential access must be scoped to a specific secret",
+			},
+		},
+	}
+}
+
+// PermissionManager evaluates permission requests and records every outcome.
+type PermissionManager struct {
+	config PermissionConfig
+	rules  map[contracts.PermissionCategory]PermissionRule
+	audit  []contracts.PermissionAuditEntry
+	now    func() time.Time
+}
+
+// NewPermissionManager creates a permission gate with the supplied config.
+func NewPermissionManager(config PermissionConfig) *PermissionManager {
+	if config.DefaultScope == "" {
+		config.DefaultScope = contracts.PermissionScopeSession
+	}
+
+	rules := make(map[contracts.PermissionCategory]PermissionRule, len(config.Rules))
+	for _, rule := range config.Rules {
+		if rule.Category == "" {
+			continue
+		}
+		if rule.Scope == "" {
+			rule.Scope = config.DefaultScope
+		}
+		rules[rule.Category] = rule
+	}
+
+	return &PermissionManager{
+		config: config,
+		rules:  rules,
+		now:    func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// Evaluate checks one permission request and appends its audit record.
+func (m *PermissionManager) Evaluate(req contracts.PermissionRequest) contracts.PermissionDecision {
+	rule, ok := m.rules[req.Category]
+	if !ok {
+		rule = PermissionRule{
+			Category: req.Category,
+			Action:   contracts.PermissionActionDeny,
+			Scope:    contracts.PermissionScopeTask,
+			Reason:   "unknown permission category is denied by default",
+		}
+	}
+	if rule.Scope == "" {
+		rule.Scope = m.config.DefaultScope
+	}
+	if req.Scope == "" {
+		req.Scope = rule.Scope
+	}
+
+	decision := contracts.PermissionDecision{
+		Action:   rule.Action,
+		Category: req.Category,
+		Resource: req.Resource,
+		Scope:    req.Scope,
+		Reason:   rule.Reason,
+	}
+	if decision.Scope == "" {
+		decision.Scope = m.config.DefaultScope
+	}
+	if decision.Reason == "" {
+		decision.Reason = fmt.Sprintf("%s permission %s", req.Category, decision.Action)
+	}
+
+	m.audit = append(m.audit, contracts.PermissionAuditEntry{
+		At:        m.now(),
+		Request:   req,
+		Decision:  decision,
+		Granted:   decision.Action == contracts.PermissionActionAllow,
+		Denied:    decision.Action == contracts.PermissionActionDeny,
+		Triggered: req.TaskID,
+	})
+
+	return decision
+}
+
+// AuditTrail returns a copy of every permission grant, denial, and confirmation.
+func (m *PermissionManager) AuditTrail() []contracts.PermissionAuditEntry {
+	return append([]contracts.PermissionAuditEntry(nil), m.audit...)
+}
+
+func formatPermissionDecision(decision contracts.PermissionDecision) string {
+	parts := []string{
+		fmt.Sprintf("permission %s", decision.Action),
+		string(decision.Category),
+	}
+	if strings.TrimSpace(decision.Resource) != "" {
+		parts = append(parts, decision.Resource)
+	}
+	if decision.Scope != "" {
+		parts = append(parts, fmt.Sprintf("scope=%s", decision.Scope))
+	}
+	if strings.TrimSpace(decision.Reason) != "" {
+		parts = append(parts, fmt.Sprintf("reason=%s", decision.Reason))
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/core/permissions_test.go
+++ b/internal/core/permissions_test.go
@@ -1,0 +1,150 @@
+package core
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestDefaultPermissionConfigCoversPRDCategories(t *testing.T) {
+	manager := NewPermissionManager(DefaultPermissionConfig())
+
+	cases := []struct {
+		category contracts.PermissionCategory
+		want     contracts.PermissionAction
+		scope    contracts.PermissionScope
+	}{
+		{contracts.PermissionFilesystemHost, contracts.PermissionActionDeny, contracts.PermissionScopeTask},
+		{contracts.PermissionFilesystemSandbox, contracts.PermissionActionAllow, contracts.PermissionScopeSession},
+		{contracts.PermissionNetwork, contracts.PermissionActionConfirm, contracts.PermissionScopeSession},
+		{contracts.PermissionShell, contracts.PermissionActionAllow, contracts.PermissionScopeSession},
+		{contracts.PermissionComputerUse, contracts.PermissionActionConfirm, contracts.PermissionScopeTask},
+		{contracts.PermissionMobile, contracts.PermissionActionConfirm, contracts.PermissionScopeTask},
+		{contracts.PermissionDestructive, contracts.PermissionActionConfirm, contracts.PermissionScopeTask},
+		{contracts.PermissionExternalComms, contracts.PermissionActionConfirm, contracts.PermissionScopeTask},
+		{contracts.PermissionCredentials, contracts.PermissionActionConfirm, contracts.PermissionScopeTask},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.category), func(t *testing.T) {
+			decision := manager.Evaluate(contracts.PermissionRequest{
+				Category: tc.category,
+				Resource: "target",
+				TaskID:   "task-123",
+			})
+
+			if decision.Action != tc.want {
+				t.Fatalf("Action = %q, want %q", decision.Action, tc.want)
+			}
+			if decision.Scope != tc.scope {
+				t.Fatalf("Scope = %q, want %q", decision.Scope, tc.scope)
+			}
+			if strings.TrimSpace(decision.Reason) == "" {
+				t.Fatal("Reason is empty")
+			}
+		})
+	}
+
+	audit := manager.AuditTrail()
+	if len(audit) != len(cases) {
+		t.Fatalf("len(AuditTrail) = %d, want %d", len(audit), len(cases))
+	}
+}
+
+func TestPermissionManagerHonorsExplicitScopeAndAuditsOutcome(t *testing.T) {
+	manager := NewPermissionManager(DefaultPermissionConfig())
+
+	decision := manager.Evaluate(contracts.PermissionRequest{
+		Category: contracts.PermissionNetwork,
+		Resource: "github.com:443",
+		Scope:    contracts.PermissionScopePersistent,
+		TaskID:   "clone-repo",
+		Reason:   "clone dependency",
+	})
+
+	if decision.Action != contracts.PermissionActionConfirm {
+		t.Fatalf("Action = %q, want confirm", decision.Action)
+	}
+	if decision.Scope != contracts.PermissionScopePersistent {
+		t.Fatalf("Scope = %q, want persistent", decision.Scope)
+	}
+
+	audit := manager.AuditTrail()
+	if len(audit) != 1 {
+		t.Fatalf("len(AuditTrail) = %d, want 1", len(audit))
+	}
+	if audit[0].Triggered != "clone-repo" {
+		t.Fatalf("Triggered = %q, want clone-repo", audit[0].Triggered)
+	}
+	if audit[0].Granted || audit[0].Denied {
+		t.Fatalf("confirm decision should be neither granted nor denied: %#v", audit[0])
+	}
+	if audit[0].Request.Reason != "clone dependency" {
+		t.Fatalf("Request.Reason = %q, want clone dependency", audit[0].Request.Reason)
+	}
+}
+
+func TestPermissionManagerDeniesUnknownCategory(t *testing.T) {
+	manager := NewPermissionManager(DefaultPermissionConfig())
+
+	decision := manager.Evaluate(contracts.PermissionRequest{
+		Category: contracts.PermissionCategory("quantum_tunnel"),
+		Resource: "/outside",
+	})
+
+	if decision.Action != contracts.PermissionActionDeny {
+		t.Fatalf("Action = %q, want deny", decision.Action)
+	}
+	if decision.Scope != contracts.PermissionScopeTask {
+		t.Fatalf("Scope = %q, want task", decision.Scope)
+	}
+
+	audit := manager.AuditTrail()
+	if len(audit) != 1 || !audit[0].Denied {
+		t.Fatalf("AuditTrail = %#v, want denied entry", audit)
+	}
+}
+
+func TestPermissionAuditTrailReturnsCopy(t *testing.T) {
+	manager := NewPermissionManager(DefaultPermissionConfig())
+	manager.Evaluate(contracts.PermissionRequest{Category: contracts.PermissionShell})
+
+	audit := manager.AuditTrail()
+	audit[0].Decision.Action = contracts.PermissionActionDeny
+
+	next := manager.AuditTrail()
+	if next[0].Decision.Action != contracts.PermissionActionAllow {
+		t.Fatalf("audit trail was mutated through returned slice")
+	}
+}
+
+func TestEngineOwnsPermissionManagerAndLogsDecisions(t *testing.T) {
+	engine := New("test")
+
+	if engine.Permissions() == nil {
+		t.Fatal("Permissions() returned nil")
+	}
+
+	decision := engine.EvaluatePermission(contracts.PermissionRequest{
+		Category: contracts.PermissionExternalComms,
+		Resource: "origin/main",
+		TaskID:   "publish",
+	})
+	if decision.Action != contracts.PermissionActionConfirm {
+		t.Fatalf("Action = %q, want confirm", decision.Action)
+	}
+
+	audit := engine.Permissions().AuditTrail()
+	if len(audit) != 1 || audit[0].Triggered != "publish" {
+		t.Fatalf("AuditTrail = %#v, want publish entry", audit)
+	}
+
+	log := engine.SessionLog()
+	if !slices.ContainsFunc(log, func(entry contracts.SessionLogEntry) bool {
+		return strings.Contains(entry.Message, "permission confirm external_comms origin/main")
+	}) {
+		t.Fatalf("SessionLog = %#v, want permission decision message", log)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds shared permission category, scope, decision, request, and audit contracts for PRD 15.4
- Adds a core permission manager with safe-by-default category rules and audit trail capture
- Wires permission evaluation into the engine session log for UI/session surfaces

## Test plan
- [x] go test ./...

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)