### PR TITLE
Add network sandbox policy foundation

### DIFF
--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -63,3 +63,60 @@ type SessionLogEntry struct {
 	At      time.Time
 	Message string
 }
+
+// NetworkMode controls how sandboxed network access is approved.
+type NetworkMode string
+
+const (
+	NetworkModeRestricted NetworkMode = "restricted"
+	NetworkModePerRequest NetworkMode = "per_request"
+	NetworkModeOpen       NetworkMode = "open"
+	NetworkModeOffline    NetworkMode = "offline"
+)
+
+// NetworkDirection identifies the side of a network policy check.
+type NetworkDirection string
+
+const (
+	NetworkDirectionOutbound NetworkDirection = "outbound"
+	NetworkDirectionInbound  NetworkDirection = "inbound"
+)
+
+// NetworkRequest describes a network action before the sandbox allows it.
+type NetworkRequest struct {
+	Direction NetworkDirection
+	Host      string
+	Port      int
+	Protocol  string
+	URL       string
+}
+
+// NetworkDecision is the policy result for one network request.
+type NetworkDecision struct {
+	Allowed bool
+	Reason  string
+	Mode    NetworkMode
+	Host    string
+	Port    int
+}
+
+// PortForward is an explicit inbound exception into a sandbox.
+type PortForward struct {
+	Name       string
+	ListenPort int
+	TargetHost string
+	TargetPort int
+	Protocol   string
+}
+
+// NetworkEvent records DNS and traffic policy decisions for audit surfaces.
+type NetworkEvent struct {
+	At        time.Time
+	Kind      string
+	Direction NetworkDirection
+	Host      string
+	Port      int
+	Protocol  string
+	Allowed   bool
+	Reason    string
+}

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -17,6 +17,7 @@ type Engine struct {
 	surfaces   []contracts.Surface
 	identity   *IdentityManager
 	router     *ModelRouter
+	network    *NetworkSandbox
 	sessionLog []contracts.SessionLogEntry
 }
 
@@ -34,6 +35,7 @@ func New(version string) *Engine {
 		},
 		identity: NewIdentityManager(DefaultIdentityConfig()),
 		router:   NewModelRouter(DefaultEscalationConfig()),
+		network:  NewNetworkSandbox(DefaultNetworkSandboxConfig()),
 	}
 }
 

--- a/internal/core/network.go
+++ b/internal/core/network.go
@@ -1,0 +1,236 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// NetworkApprovalProvider asks the user or a surface whether a non-allowlisted
+// outbound request should be allowed in per-request mode.
+type NetworkApprovalProvider interface {
+	ApproveNetworkRequest(context.Context, contracts.NetworkRequest) (bool, string, error)
+}
+
+// NetworkSandboxConfig controls network access for sandboxed agent actions.
+type NetworkSandboxConfig struct {
+	Mode         contracts.NetworkMode
+	Allowlist    []string
+	PortForwards []contracts.PortForward
+	Approval     NetworkApprovalProvider
+	Now          func() time.Time
+}
+
+// NetworkSandbox evaluates outbound and inbound network requests and records
+// the DNS/traffic audit trail required by the security policy.
+type NetworkSandbox struct {
+	config NetworkSandboxConfig
+	events []contracts.NetworkEvent
+}
+
+// DefaultNetworkSandboxConfig returns Conduit's restricted-by-default network
+// policy from PRD section 15.3.
+func DefaultNetworkSandboxConfig() NetworkSandboxConfig {
+	return NetworkSandboxConfig{
+		Mode: contracts.NetworkModeRestricted,
+		Allowlist: []string{
+			"pypi.org",
+			"files.pythonhosted.org",
+			"registry.npmjs.org",
+			"npmjs.com",
+			"github.com",
+			"api.github.com",
+			"anthropic.com",
+			"api.anthropic.com",
+			"openai.com",
+			"api.openai.com",
+			"ollama.com",
+			"openrouter.ai",
+		},
+	}
+}
+
+// NewNetworkSandbox creates a network policy evaluator.
+func NewNetworkSandbox(config NetworkSandboxConfig) *NetworkSandbox {
+	if config.Mode == "" {
+		config.Mode = contracts.NetworkModeRestricted
+	}
+	if len(config.Allowlist) == 0 {
+		config.Allowlist = DefaultNetworkSandboxConfig().Allowlist
+	}
+	if config.Now == nil {
+		config.Now = func() time.Time { return time.Now().UTC() }
+	}
+	return &NetworkSandbox{config: config}
+}
+
+// CheckOutbound evaluates an outbound connection request.
+func (s *NetworkSandbox) CheckOutbound(ctx context.Context, req contracts.NetworkRequest) contracts.NetworkDecision {
+	req.Direction = contracts.NetworkDirectionOutbound
+	req.Host = normalizeNetworkHost(req.Host, req.URL)
+	decision := s.outboundDecision(ctx, req)
+	s.logDNS(req)
+	s.logTraffic(req, decision)
+	return decision
+}
+
+// CheckInbound evaluates an inbound request against explicit port forwards.
+func (s *NetworkSandbox) CheckInbound(req contracts.NetworkRequest) contracts.NetworkDecision {
+	req.Direction = contracts.NetworkDirectionInbound
+	req.Host = normalizeNetworkHost(req.Host, req.URL)
+	decision := s.inboundDecision(req)
+	s.logTraffic(req, decision)
+	return decision
+}
+
+// Events returns a copy of the network audit log.
+func (s *NetworkSandbox) Events() []contracts.NetworkEvent {
+	return append([]contracts.NetworkEvent(nil), s.events...)
+}
+
+// NetworkSandbox returns the engine-owned network policy evaluator.
+func (e *Engine) NetworkSandbox() *NetworkSandbox {
+	return e.network
+}
+
+func (s *NetworkSandbox) outboundDecision(ctx context.Context, req contracts.NetworkRequest) contracts.NetworkDecision {
+	base := contracts.NetworkDecision{Mode: s.config.Mode, Host: req.Host, Port: req.Port}
+	if req.Host == "" {
+		base.Reason = "network request requires a host"
+		return base
+	}
+
+	switch s.config.Mode {
+	case contracts.NetworkModeOffline:
+		base.Reason = "offline mode blocks outbound network"
+		return base
+	case contracts.NetworkModeOpen:
+		base.Allowed = true
+		base.Reason = "open mode allows outbound network"
+		return base
+	case contracts.NetworkModeRestricted:
+		if s.allowlisted(req.Host) {
+			base.Allowed = true
+			base.Reason = "host matches network allowlist"
+			return base
+		}
+		base.Reason = "host is not in the restricted-mode allowlist"
+		return base
+	case contracts.NetworkModePerRequest:
+		if s.allowlisted(req.Host) {
+			base.Allowed = true
+			base.Reason = "host matches network allowlist"
+			return base
+		}
+		if s.config.Approval == nil {
+			base.Reason = "per-request mode requires an approval provider"
+			return base
+		}
+		allowed, reason, err := s.config.Approval.ApproveNetworkRequest(ctx, req)
+		if err != nil {
+			base.Reason = fmt.Sprintf("network approval failed: %v", err)
+			return base
+		}
+		base.Allowed = allowed
+		base.Reason = strings.TrimSpace(reason)
+		if base.Reason == "" {
+			if allowed {
+				base.Reason = "approved by per-request policy"
+			} else {
+				base.Reason = "denied by per-request policy"
+			}
+		}
+		return base
+	default:
+		base.Reason = fmt.Sprintf("unknown network mode %q", s.config.Mode)
+		return base
+	}
+}
+
+func (s *NetworkSandbox) inboundDecision(req contracts.NetworkRequest) contracts.NetworkDecision {
+	decision := contracts.NetworkDecision{
+		Allowed: false,
+		Reason:  "inbound network is blocked unless a port forward matches",
+		Mode:    s.config.Mode,
+		Host:    req.Host,
+		Port:    req.Port,
+	}
+	for _, forward := range s.config.PortForwards {
+		if forward.ListenPort == req.Port && protocolMatches(forward.Protocol, req.Protocol) {
+			decision.Allowed = true
+			decision.Reason = "explicit port forward allows inbound network"
+			return decision
+		}
+	}
+	return decision
+}
+
+func (s *NetworkSandbox) allowlisted(host string) bool {
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	for _, entry := range s.config.Allowlist {
+		entry = strings.TrimPrefix(strings.TrimSuffix(strings.ToLower(entry), "."), "*.")
+		if host == entry || strings.HasSuffix(host, "."+entry) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *NetworkSandbox) logDNS(req contracts.NetworkRequest) {
+	if req.Host == "" || net.ParseIP(req.Host) != nil {
+		return
+	}
+	if slices.ContainsFunc(s.events, func(event contracts.NetworkEvent) bool {
+		return event.Kind == "dns" && event.Host == req.Host
+	}) {
+		return
+	}
+	s.events = append(s.events, contracts.NetworkEvent{
+		At:        s.config.Now(),
+		Kind:      "dns",
+		Direction: req.Direction,
+		Host:      req.Host,
+		Protocol:  req.Protocol,
+		Allowed:   true,
+		Reason:    "dns lookup recorded",
+	})
+}
+
+func (s *NetworkSandbox) logTraffic(req contracts.NetworkRequest, decision contracts.NetworkDecision) {
+	s.events = append(s.events, contracts.NetworkEvent{
+		At:        s.config.Now(),
+		Kind:      "traffic",
+		Direction: req.Direction,
+		Host:      req.Host,
+		Port:      req.Port,
+		Protocol:  req.Protocol,
+		Allowed:   decision.Allowed,
+		Reason:    decision.Reason,
+	})
+}
+
+func normalizeNetworkHost(host, rawURL string) string {
+	if host == "" && rawURL != "" {
+		parsed, err := url.Parse(rawURL)
+		if err == nil {
+			host = parsed.Hostname()
+		}
+	}
+	host = strings.TrimSpace(strings.ToLower(host))
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
+	}
+	return strings.TrimSuffix(host, ".")
+}
+
+func protocolMatches(forwardProtocol, requestProtocol string) bool {
+	forwardProtocol = strings.ToLower(strings.TrimSpace(forwardProtocol))
+	requestProtocol = strings.ToLower(strings.TrimSpace(requestProtocol))
+	return forwardProtocol == "" || requestProtocol == "" || forwardProtocol == requestProtocol
+}

--- a/internal/core/network_test.go
+++ b/internal/core/network_test.go
@@ -1,0 +1,158 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestDefaultNetworkSandboxRestrictsOutboundToAllowlist(t *testing.T) {
+	sandbox := NewNetworkSandbox(DefaultNetworkSandboxConfig())
+
+	allowed := sandbox.CheckOutbound(context.Background(), contracts.NetworkRequest{
+		URL:      "https://api.github.com/repos/jabreeflor/conduit",
+		Port:     443,
+		Protocol: "tcp",
+	})
+	blocked := sandbox.CheckOutbound(context.Background(), contracts.NetworkRequest{
+		Host:     "example.net",
+		Port:     443,
+		Protocol: "tcp",
+	})
+
+	if !allowed.Allowed {
+		t.Fatalf("github decision = %#v, want allowed", allowed)
+	}
+	if blocked.Allowed {
+		t.Fatalf("example decision = %#v, want blocked", blocked)
+	}
+	if blocked.Mode != contracts.NetworkModeRestricted {
+		t.Fatalf("blocked Mode = %q, want restricted", blocked.Mode)
+	}
+}
+
+func TestNetworkSandboxPerRequestApprovalForUnknownDomains(t *testing.T) {
+	approval := &fakeNetworkApproval{allowed: true, reason: "temporary install approved"}
+	sandbox := NewNetworkSandbox(NetworkSandboxConfig{
+		Mode:      contracts.NetworkModePerRequest,
+		Allowlist: []string{"github.com"},
+		Approval:  approval,
+	})
+
+	decision := sandbox.CheckOutbound(context.Background(), contracts.NetworkRequest{
+		Host: "downloads.example.com",
+		Port: 443,
+	})
+
+	if !decision.Allowed {
+		t.Fatalf("decision = %#v, want allowed", decision)
+	}
+	if decision.Reason != "temporary install approved" {
+		t.Fatalf("Reason = %q, want approval reason", decision.Reason)
+	}
+	if len(approval.requests) != 1 || approval.requests[0].Host != "downloads.example.com" {
+		t.Fatalf("approval requests = %#v, want one normalized host", approval.requests)
+	}
+}
+
+func TestNetworkSandboxOfflineBlocksEvenAllowlistedOutbound(t *testing.T) {
+	sandbox := NewNetworkSandbox(NetworkSandboxConfig{Mode: contracts.NetworkModeOffline})
+
+	decision := sandbox.CheckOutbound(context.Background(), contracts.NetworkRequest{Host: "github.com", Port: 443})
+
+	if decision.Allowed {
+		t.Fatalf("decision = %#v, want blocked", decision)
+	}
+	if decision.Reason != "offline mode blocks outbound network" {
+		t.Fatalf("Reason = %q, want offline block reason", decision.Reason)
+	}
+}
+
+func TestNetworkSandboxInboundRequiresPortForward(t *testing.T) {
+	sandbox := NewNetworkSandbox(NetworkSandboxConfig{
+		PortForwards: []contracts.PortForward{{
+			Name:       "preview",
+			ListenPort: 3000,
+			TargetHost: "127.0.0.1",
+			TargetPort: 3000,
+			Protocol:   "tcp",
+		}},
+	})
+
+	allowed := sandbox.CheckInbound(contracts.NetworkRequest{Port: 3000, Protocol: "tcp"})
+	blocked := sandbox.CheckInbound(contracts.NetworkRequest{Port: 3001, Protocol: "tcp"})
+
+	if !allowed.Allowed {
+		t.Fatalf("allowed decision = %#v, want allowed", allowed)
+	}
+	if blocked.Allowed {
+		t.Fatalf("blocked decision = %#v, want blocked", blocked)
+	}
+}
+
+func TestNetworkSandboxRecordsDNSAndTrafficEvents(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	sandbox := NewNetworkSandbox(NetworkSandboxConfig{
+		Mode:      contracts.NetworkModeRestricted,
+		Allowlist: []string{"github.com"},
+		Now:       func() time.Time { return now },
+	})
+
+	sandbox.CheckOutbound(context.Background(), contracts.NetworkRequest{Host: "api.github.com", Port: 443, Protocol: "tcp"})
+	sandbox.CheckOutbound(context.Background(), contracts.NetworkRequest{Host: "203.0.113.10", Port: 443, Protocol: "tcp"})
+
+	events := sandbox.Events()
+	if len(events) != 3 {
+		t.Fatalf("len(events) = %d, want dns + two traffic events: %#v", len(events), events)
+	}
+	if events[0].Kind != "dns" || events[0].Host != "api.github.com" {
+		t.Fatalf("first event = %#v, want DNS event for api.github.com", events[0])
+	}
+	if events[1].Kind != "traffic" || !events[1].Allowed {
+		t.Fatalf("second event = %#v, want allowed traffic", events[1])
+	}
+	if events[2].Kind != "traffic" || events[2].Allowed {
+		t.Fatalf("third event = %#v, want blocked IP traffic", events[2])
+	}
+}
+
+func TestEngineExposesDefaultNetworkSandbox(t *testing.T) {
+	engine := New("test")
+
+	decision := engine.NetworkSandbox().CheckOutbound(context.Background(), contracts.NetworkRequest{Host: "pypi.org", Port: 443})
+
+	if !decision.Allowed {
+		t.Fatalf("decision = %#v, want default allowlist to include pypi.org", decision)
+	}
+}
+
+func TestNetworkSandboxApprovalErrorsBlockRequest(t *testing.T) {
+	sandbox := NewNetworkSandbox(NetworkSandboxConfig{
+		Mode:     contracts.NetworkModePerRequest,
+		Approval: &fakeNetworkApproval{err: errors.New("surface unavailable")},
+	})
+
+	decision := sandbox.CheckOutbound(context.Background(), contracts.NetworkRequest{Host: "example.com"})
+
+	if decision.Allowed {
+		t.Fatalf("decision = %#v, want blocked", decision)
+	}
+	if decision.Reason != "network approval failed: surface unavailable" {
+		t.Fatalf("Reason = %q, want approval error", decision.Reason)
+	}
+}
+
+type fakeNetworkApproval struct {
+	allowed  bool
+	reason   string
+	err      error
+	requests []contracts.NetworkRequest
+}
+
+func (a *fakeNetworkApproval) ApproveNetworkRequest(_ context.Context, req contracts.NetworkRequest) (bool, string, error) {
+	a.requests = append(a.requests, req)
+	return a.allowed, a.reason, a.err
+}


### PR DESCRIPTION
## Summary
- Adds shared network sandbox contract types for modes, requests, decisions, port forwards, and audit events
- Adds the core network sandbox policy evaluator with restricted/default allowlist, per-request approval, open/offline modes, and inbound port-forward checks
- Records DNS and traffic audit events for outbound and inbound policy decisions

Closes #125

## Test plan
- [x] go test ./...

🤖 Generated with [Claude Code](https://claude.com/claude-code)