### PR TITLE
feat(credential): round-robin key pool with health-check rotation

### DIFF
--- a/internal/credential/doc.go
+++ b/internal/credential/doc.go
@@ -1,0 +1,7 @@
+// Package credential manages round-robin API-key pools with automatic
+// health-check rotation. A key is skipped once marked unhealthy and
+// re-enters the rotation when its backoff window expires.
+//
+// Keys are never stored in plaintext; load them from environment variables
+// (LoadFromEnv) or the macOS Keychain (LoadFromKeychain).
+package credential

--- a/internal/credential/pool.go
+++ b/internal/credential/pool.go
@@ -1,0 +1,90 @@
+package credential
+
+import (
+	"sync"
+	"time"
+)
+
+// DefaultBackoff is used when New is called with backoff ≤ 0.
+const DefaultBackoff = 30 * time.Second
+
+// Pool holds a round-robin set of API keys for one provider.
+// Concurrent calls to Next and MarkUnhealthy are safe.
+type Pool struct {
+	mu      sync.Mutex
+	entries []entry
+	cursor  int
+	backoff time.Duration
+}
+
+type entry struct {
+	key            string
+	unhealthyUntil time.Time
+}
+
+// New creates a Pool from keys with the given backoff window.
+// Pass 0 to use DefaultBackoff.
+func New(keys []string, backoff time.Duration) *Pool {
+	if backoff <= 0 {
+		backoff = DefaultBackoff
+	}
+	entries := make([]entry, len(keys))
+	for i, k := range keys {
+		entries[i] = entry{key: k}
+	}
+	return &Pool{entries: entries, backoff: backoff}
+}
+
+// Next returns the next healthy key via round-robin.
+// Returns ("", false) when every key is inside its backoff window.
+func (p *Pool) Next() (string, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	now := time.Now()
+	n := len(p.entries)
+	for range n {
+		e := &p.entries[p.cursor%n]
+		p.cursor++
+		if now.After(e.unhealthyUntil) {
+			return e.key, true
+		}
+	}
+	return "", false
+}
+
+// MarkUnhealthy suspends key for the pool's backoff window.
+// Calls with an unrecognised key are silently ignored.
+func (p *Pool) MarkUnhealthy(key string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	until := time.Now().Add(p.backoff)
+	for i := range p.entries {
+		if p.entries[i].key == key {
+			p.entries[i].unhealthyUntil = until
+			return
+		}
+	}
+}
+
+// Len returns the total key count regardless of health state.
+func (p *Pool) Len() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.entries)
+}
+
+// HealthyCount returns the number of keys currently available for use.
+func (p *Pool) HealthyCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := time.Now()
+	n := 0
+	for i := range p.entries {
+		if now.After(p.entries[i].unhealthyUntil) {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/credential/pool_test.go
+++ b/internal/credential/pool_test.go
@@ -1,0 +1,102 @@
+package credential_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/credential"
+)
+
+func TestPool_RoundRobin(t *testing.T) {
+	p := credential.New([]string{"a", "b", "c"}, 0)
+	seen := make(map[string]int)
+	for range 6 {
+		k, ok := p.Next()
+		if !ok {
+			t.Fatal("expected a healthy key")
+		}
+		seen[k]++
+	}
+	for _, key := range []string{"a", "b", "c"} {
+		if seen[key] != 2 {
+			t.Errorf("key %q: got %d calls, want 2", key, seen[key])
+		}
+	}
+}
+
+func TestPool_SkipsUnhealthyKey(t *testing.T) {
+	p := credential.New([]string{"a", "b"}, 10*time.Minute)
+	p.MarkUnhealthy("a")
+
+	k, ok := p.Next()
+	if !ok {
+		t.Fatal("expected a healthy key")
+	}
+	if k != "b" {
+		t.Errorf("got %q, want \"b\"", k)
+	}
+}
+
+func TestPool_AllUnhealthy(t *testing.T) {
+	p := credential.New([]string{"a", "b"}, 10*time.Minute)
+	p.MarkUnhealthy("a")
+	p.MarkUnhealthy("b")
+
+	_, ok := p.Next()
+	if ok {
+		t.Fatal("expected no healthy keys when all are in backoff")
+	}
+}
+
+func TestPool_BackoffExpiry(t *testing.T) {
+	p := credential.New([]string{"a"}, 1*time.Millisecond)
+	p.MarkUnhealthy("a")
+
+	if _, ok := p.Next(); ok {
+		t.Fatal("key should be within backoff window immediately after MarkUnhealthy")
+	}
+
+	time.Sleep(5 * time.Millisecond)
+
+	k, ok := p.Next()
+	if !ok {
+		t.Fatal("key should have recovered after backoff window expired")
+	}
+	if k != "a" {
+		t.Errorf("got %q, want \"a\"", k)
+	}
+}
+
+func TestPool_Empty(t *testing.T) {
+	p := credential.New(nil, 0)
+
+	if _, ok := p.Next(); ok {
+		t.Fatal("empty pool should never return a key")
+	}
+	if n := p.Len(); n != 0 {
+		t.Errorf("Len() = %d, want 0", n)
+	}
+}
+
+func TestPool_HealthyCount(t *testing.T) {
+	p := credential.New([]string{"a", "b", "c"}, 10*time.Minute)
+
+	if n := p.HealthyCount(); n != 3 {
+		t.Errorf("HealthyCount() = %d, want 3", n)
+	}
+
+	p.MarkUnhealthy("b")
+
+	if n := p.HealthyCount(); n != 2 {
+		t.Errorf("HealthyCount() after one unhealthy = %d, want 2", n)
+	}
+}
+
+func TestPool_MarkUnknownKeyIgnored(t *testing.T) {
+	p := credential.New([]string{"a"}, 0)
+	p.MarkUnhealthy("nonexistent") // must not panic
+
+	if n := p.HealthyCount(); n != 1 {
+		t.Errorf("HealthyCount() = %d, want 1 after marking unknown key", n)
+	}
+}

--- a/internal/credential/source.go
+++ b/internal/credential/source.go
@@ -1,0 +1,63 @@
+package credential
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// LoadFromEnv loads API keys for provider from environment variables.
+//
+// It first scans CONDUIT_{PROVIDER}_API_KEY_1, _2, … until one is absent,
+// then falls back to the bare CONDUIT_{PROVIDER}_API_KEY for a single key.
+// provider is case-insensitive ("anthropic", "ANTHROPIC", etc.).
+func LoadFromEnv(provider string, backoff time.Duration) *Pool {
+	upper := strings.ToUpper(provider)
+
+	var keys []string
+	for i := 1; ; i++ {
+		k := os.Getenv(fmt.Sprintf("CONDUIT_%s_API_KEY_%d", upper, i))
+		if k == "" {
+			break
+		}
+		keys = append(keys, k)
+	}
+
+	if len(keys) == 0 {
+		if k := os.Getenv(fmt.Sprintf("CONDUIT_%s_API_KEY", upper)); k != "" {
+			keys = append(keys, k)
+		}
+	}
+
+	return New(keys, backoff)
+}
+
+// LoadFromKeychain loads API keys for provider from the macOS Keychain.
+//
+// Keys are stored as generic passwords with service "conduit.{provider}"
+// and accounts "key.1", "key.2", … Scanning stops at the first missing
+// account. Returns an empty pool on non-macOS platforms or when no entries
+// are found.
+func LoadFromKeychain(provider string, backoff time.Duration) *Pool {
+	service := fmt.Sprintf("conduit.%s", strings.ToLower(provider))
+
+	var keys []string
+	for i := 1; ; i++ {
+		out, err := exec.Command( //nolint:gosec
+			"security", "find-generic-password",
+			"-s", service,
+			"-a", fmt.Sprintf("key.%d", i),
+			"-w",
+		).Output()
+		if err != nil {
+			break
+		}
+		if k := strings.TrimSpace(string(out)); k != "" {
+			keys = append(keys, k)
+		}
+	}
+
+	return New(keys, backoff)
+}

--- a/internal/credential/source_test.go
+++ b/internal/credential/source_test.go
@@ -1,0 +1,49 @@
+package credential_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/credential"
+)
+
+func TestLoadFromEnv_MultiKey(t *testing.T) {
+	t.Setenv("CONDUIT_TESTPROVIDER_API_KEY_1", "k1")
+	t.Setenv("CONDUIT_TESTPROVIDER_API_KEY_2", "k2")
+
+	p := credential.LoadFromEnv("testprovider", 0)
+	if got := p.Len(); got != 2 {
+		t.Fatalf("Len() = %d, want 2", got)
+	}
+}
+
+func TestLoadFromEnv_SingleKeyFallback(t *testing.T) {
+	t.Setenv("CONDUIT_TESTPROVIDER2_API_KEY", "solo")
+
+	p := credential.LoadFromEnv("testprovider2", 0)
+	if got := p.Len(); got != 1 {
+		t.Fatalf("Len() = %d, want 1", got)
+	}
+	k, ok := p.Next()
+	if !ok || k != "solo" {
+		t.Errorf("Next() = (%q, %v), want (\"solo\", true)", k, ok)
+	}
+}
+
+func TestLoadFromEnv_NoKeys(t *testing.T) {
+	p := credential.LoadFromEnv("nonexistent_xyz_provider", time.Minute)
+	if got := p.Len(); got != 0 {
+		t.Fatalf("Len() = %d, want 0", got)
+	}
+}
+
+func TestLoadFromEnv_CaseInsensitive(t *testing.T) {
+	t.Setenv("CONDUIT_MYPROVIDER_API_KEY", "lower")
+
+	lower := credential.LoadFromEnv("myprovider", 0)
+	upper := credential.LoadFromEnv("MYPROVIDER", 0)
+
+	if lower.Len() != 1 || upper.Len() != 1 {
+		t.Errorf("both casings should resolve to 1 key; lower=%d upper=%d", lower.Len(), upper.Len())
+	}
+}


### PR DESCRIPTION
Closes #14

## Summary
- Adds `internal/credential.Pool` — a thread-safe, round-robin API-key pool per provider
- Keys marked unhealthy (on 401 / rate-limit) are skipped until a configurable backoff window (default 30 s) expires and they automatically re-enter rotation
- `LoadFromEnv` reads `CONDUIT_{PROVIDER}_API_KEY_1/2/…` (or the bare `_API_KEY` for a single key); `LoadFromKeychain` reads from the macOS Keychain service `conduit.{provider}` — no plaintext config at any point

## Test plan
- [x] 11 unit tests covering round-robin ordering, unhealthy skip, full-pool exhaustion, backoff expiry recovery, empty pool, `HealthyCount`, unknown-key mark-unhealthy, env-var multi-key, single-key fallback, no-key, and case-insensitive provider name
- [x] `go vet ./...` clean
- [x] Full `go test ./...` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)