### PR TITLE
feat(usage): per-session JSONL cost tracker with status bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 build/
 target/
 .conduit/
+.worktrees/

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -128,6 +128,25 @@ type SessionLogEntry struct {
 	Message string
 }
 
+// UsageEntry is one model-call record written to ~/.conduit/usage.jsonl.
+type UsageEntry struct {
+	At           time.Time `json:"at"`
+	SessionID    string    `json:"session_id"`
+	Provider     string    `json:"provider"`
+	Model        string    `json:"model"`
+	InputTokens  int       `json:"input_tokens"`
+	OutputTokens int       `json:"output_tokens"`
+	TotalTokens  int       `json:"total_tokens"`
+	CostUSD      float64   `json:"cost_usd"`
+}
+
+// UsageSummary is the running totals for the status bar.
+type UsageSummary struct {
+	Model        string
+	TotalTokens  int
+	TotalCostUSD float64
+}
+
 // NetworkMode controls how sandboxed network access is approved.
 type NetworkMode string
 

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jabreeflor/conduit/internal/contracts"
 	"github.com/jabreeflor/conduit/internal/security"
+	"github.com/jabreeflor/conduit/internal/usage"
 )
 
 // Engine owns the long-lived runtime state for Conduit.
@@ -22,11 +23,15 @@ type Engine struct {
 	permissions *PermissionManager
 	sandbox     *SandboxManager
 	sessionLog  []contracts.SessionLogEntry
+	usage       *usage.Tracker
 }
 
 // New creates a core engine instance with the surfaces planned for the
 // monorepo scaffold.
 func New(version string) *Engine {
+	sessionID := fmt.Sprintf("%d", time.Now().UnixMilli())
+	tracker, _ := usage.New(sessionID) // best-effort; nil tracker is handled in RecordUsage
+
 	return &Engine{
 		name:      "Conduit",
 		version:   version,
@@ -41,6 +46,7 @@ func New(version string) *Engine {
 		network:     NewNetworkSandbox(DefaultNetworkSandboxConfig()),
 		permissions: NewPermissionManager(DefaultPermissionConfig()),
 		sandbox:     NewSandboxManager(DefaultSandboxArchitecture()),
+		usage:       tracker,
 	}
 }
 
@@ -103,6 +109,24 @@ func (e *Engine) ModelStatus() contracts.ModelRouteDecision {
 // SandboxArchitecture returns the engine-owned execution sandbox policy.
 func (e *Engine) SandboxArchitecture() contracts.SandboxArchitecture {
 	return e.sandbox.Architecture()
+}
+
+// RecordUsage appends one model-call record to ~/.conduit/usage.jsonl and
+// updates the in-memory session totals shown in the status bar.
+// A nil tracker (e.g. disk unavailable at startup) is a no-op.
+func (e *Engine) RecordUsage(provider, model string, inputTokens, outputTokens int) (contracts.UsageEntry, error) {
+	if e.usage == nil {
+		return contracts.UsageEntry{}, nil
+	}
+	return e.usage.Record(provider, model, inputTokens, outputTokens)
+}
+
+// UsageSummary returns the running session totals for the status bar.
+func (e *Engine) UsageSummary() contracts.UsageSummary {
+	if e.usage == nil {
+		return contracts.UsageSummary{}
+	}
+	return e.usage.Summary()
 }
 
 // SessionLog returns a copy of user-visible engine events.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -9,6 +9,11 @@ import (
 	"github.com/jabreeflor/conduit/internal/core"
 )
 
+// formatStatusBar returns the "[Model] [Tokens] [$X.XX]" string for the status line.
+func formatStatusBar(model string, totalTokens int, totalCostUSD float64) string {
+	return fmt.Sprintf("[%s] [%d tokens] [$%.4f]", model, totalTokens, totalCostUSD)
+}
+
 // Run starts the terminal surface. The real Bubble Tea application will land
 // after the TUI stack decision; this boot path proves the core/surface contract.
 func Run(out io.Writer) error {
@@ -21,14 +26,17 @@ func Run(out io.Writer) error {
 	}
 
 	modelStatus := engine.ModelStatus()
+	usageSummary := engine.UsageSummary()
+	statusBar := formatStatusBar(modelStatus.SelectedModel, usageSummary.TotalTokens, usageSummary.TotalCostUSD)
 
 	_, err := fmt.Fprintf(
 		out,
-		"%s core online (%s)\nstatus: model %s; escalates to %s\n",
+		"%s core online (%s)\nstatus: model %s; escalates to %s\n%s\n",
 		info.Name,
 		strings.Join(surfaces, ", "),
 		modelStatus.SelectedModel,
 		modelStatus.EscalationModel,
+		statusBar,
 	)
 	return err
 }

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -1,0 +1,127 @@
+// Package usage logs per-call token and cost data to ~/.conduit/usage.jsonl
+// and exposes running session totals for the TUI status bar.
+package usage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// modelPricing holds input/output cost per 1M tokens in USD.
+type modelPricing struct {
+	inputPer1M  float64
+	outputPer1M float64
+}
+
+// knownPricing is the versioned cost table for supported models.
+// Costs are in USD per 1 million tokens.
+var knownPricing = map[string]modelPricing{
+	"claude-haiku-4-5":  {inputPer1M: 0.80, outputPer1M: 4.00},
+	"claude-sonnet-4-6": {inputPer1M: 3.00, outputPer1M: 15.00},
+	"claude-opus-4-6":   {inputPer1M: 15.00, outputPer1M: 75.00},
+	"claude-opus-4-7":   {inputPer1M: 15.00, outputPer1M: 75.00},
+	"gpt-4o":            {inputPer1M: 5.00, outputPer1M: 15.00},
+	"gpt-4o-mini":       {inputPer1M: 0.15, outputPer1M: 0.60},
+	"gemini-1.5-pro":    {inputPer1M: 3.50, outputPer1M: 10.50},
+	"gemini-1.5-flash":  {inputPer1M: 0.075, outputPer1M: 0.30},
+}
+
+const defaultLogPath = ".conduit/usage.jsonl"
+
+// Tracker appends usage entries to disk and maintains in-memory session totals.
+// All methods are safe for concurrent use.
+type Tracker struct {
+	mu        sync.Mutex
+	sessionID string
+	logPath   string
+	summary   contracts.UsageSummary
+}
+
+// New creates a Tracker that writes to ~/.conduit/usage.jsonl.
+func New(sessionID string) (*Tracker, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("usage: resolve home dir: %w", err)
+	}
+	logPath := filepath.Join(home, defaultLogPath)
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return nil, fmt.Errorf("usage: create log dir: %w", err)
+	}
+	return &Tracker{sessionID: sessionID, logPath: logPath}, nil
+}
+
+// NewWithPath creates a Tracker writing to an explicit path (useful in tests).
+func NewWithPath(sessionID, logPath string) (*Tracker, error) {
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return nil, fmt.Errorf("usage: create log dir: %w", err)
+	}
+	return &Tracker{sessionID: sessionID, logPath: logPath}, nil
+}
+
+// Record appends one model-call entry to the JSONL log and updates session totals.
+func (t *Tracker) Record(provider, model string, inputTokens, outputTokens int) (contracts.UsageEntry, error) {
+	cost := computeCost(model, inputTokens, outputTokens)
+	entry := contracts.UsageEntry{
+		At:           time.Now().UTC(),
+		SessionID:    t.sessionID,
+		Provider:     provider,
+		Model:        model,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		TotalTokens:  inputTokens + outputTokens,
+		CostUSD:      cost,
+	}
+
+	if err := t.appendLine(entry); err != nil {
+		return entry, err
+	}
+
+	t.mu.Lock()
+	t.summary.Model = model
+	t.summary.TotalTokens += entry.TotalTokens
+	t.summary.TotalCostUSD += cost
+	t.mu.Unlock()
+
+	return entry, nil
+}
+
+// Summary returns the running session totals without blocking on disk I/O.
+func (t *Tracker) Summary() contracts.UsageSummary {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.summary
+}
+
+func (t *Tracker) appendLine(entry contracts.UsageEntry) error {
+	line, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("usage: marshal entry: %w", err)
+	}
+	line = append(line, '\n')
+
+	f, err := os.OpenFile(t.logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("usage: open log: %w", err)
+	}
+	defer f.Close()
+
+	_, err = f.Write(line)
+	return err
+}
+
+// computeCost returns the USD cost using the known pricing table.
+// Returns zero for unrecognised models so a missing entry never blocks logging.
+func computeCost(model string, inputTokens, outputTokens int) float64 {
+	p, ok := knownPricing[model]
+	if !ok {
+		return 0
+	}
+	return float64(inputTokens)/1_000_000*p.inputPer1M +
+		float64(outputTokens)/1_000_000*p.outputPer1M
+}

--- a/internal/usage/tracker_test.go
+++ b/internal/usage/tracker_test.go
@@ -1,0 +1,109 @@
+package usage
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestRecord_appendsJSONL(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "usage.jsonl")
+
+	tracker, err := NewWithPath("sess-1", logPath)
+	if err != nil {
+		t.Fatalf("NewWithPath: %v", err)
+	}
+
+	entry, err := tracker.Record("anthropic", "claude-haiku-4-5", 1000, 200)
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	if entry.SessionID != "sess-1" {
+		t.Errorf("SessionID = %q, want sess-1", entry.SessionID)
+	}
+	if entry.TotalTokens != 1200 {
+		t.Errorf("TotalTokens = %d, want 1200", entry.TotalTokens)
+	}
+	if entry.CostUSD == 0 {
+		t.Error("CostUSD should be non-zero for a known model")
+	}
+
+	f, err := os.Open(logPath)
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	defer f.Close()
+
+	var parsed contracts.UsageEntry
+	scanner := bufio.NewScanner(f)
+	if !scanner.Scan() {
+		t.Fatal("log file is empty")
+	}
+	if err := json.Unmarshal(scanner.Bytes(), &parsed); err != nil {
+		t.Fatalf("unmarshal line: %v", err)
+	}
+	if parsed.Model != "claude-haiku-4-5" {
+		t.Errorf("parsed.Model = %q, want claude-haiku-4-5", parsed.Model)
+	}
+}
+
+func TestRecord_multipleCallsAccumulate(t *testing.T) {
+	dir := t.TempDir()
+	tracker, _ := NewWithPath("sess-2", filepath.Join(dir, "usage.jsonl"))
+
+	tracker.Record("anthropic", "claude-haiku-4-5", 500, 100)  //nolint:errcheck
+	tracker.Record("anthropic", "claude-sonnet-4-6", 800, 200) //nolint:errcheck
+
+	summary := tracker.Summary()
+	if summary.TotalTokens != 1600 {
+		t.Errorf("TotalTokens = %d, want 1600", summary.TotalTokens)
+	}
+	if summary.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model = %q, want claude-sonnet-4-6 (last used)", summary.Model)
+	}
+	if summary.TotalCostUSD == 0 {
+		t.Error("TotalCostUSD should be non-zero")
+	}
+}
+
+func TestRecord_unknownModelZeroCost(t *testing.T) {
+	dir := t.TempDir()
+	tracker, _ := NewWithPath("sess-3", filepath.Join(dir, "usage.jsonl"))
+
+	entry, err := tracker.Record("mystery-corp", "grok-99", 1000, 500)
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	if entry.CostUSD != 0 {
+		t.Errorf("CostUSD = %f, want 0 for unknown model", entry.CostUSD)
+	}
+}
+
+func TestComputeCost_knownModel(t *testing.T) {
+	// claude-haiku-4-5: $0.80/1M input, $4.00/1M output
+	cost := computeCost("claude-haiku-4-5", 1_000_000, 1_000_000)
+	want := 0.80 + 4.00
+	if cost != want {
+		t.Errorf("cost = %f, want %f", cost, want)
+	}
+}
+
+func TestSummary_statusBarFormat(t *testing.T) {
+	dir := t.TempDir()
+	tracker, _ := NewWithPath("sess-4", filepath.Join(dir, "usage.jsonl"))
+	tracker.Record("anthropic", "claude-haiku-4-5", 2000, 500) //nolint:errcheck
+
+	s := tracker.Summary()
+	if s.Model == "" {
+		t.Error("Summary.Model should be populated after a Record call")
+	}
+	if s.TotalTokens <= 0 {
+		t.Error("Summary.TotalTokens should be positive")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/usage` package: appends one JSON line per model call to `~/.conduit/usage.jsonl` (at, session_id, provider, model, input_tokens, output_tokens, total_tokens, cost_usd)
- Hardcoded pricing table for Claude, GPT-4o, and Gemini models; unknown models log zero cost rather than blocking
- Engine gains `RecordUsage` / `UsageSummary` methods; TUI status bar renders `[Model] [Tokens] [$X.XX]`

Closes #15

## Test plan
- [x] `TestRecord_appendsJSONL` — verifies file is created and contains valid JSON
- [x] `TestRecord_multipleCallsAccumulate` — verifies session totals accumulate across calls
- [x] `TestRecord_unknownModelZeroCost` — verifies unknown models don't error, just log $0
- [x] `TestComputeCost_knownModel` — spot-checks pricing arithmetic
- [x] `TestSummary_statusBarFormat` — verifies Summary fields are populated after a Record

🤖 Generated with [Claude Code](https://claude.com/claude-code)