### PR TITLE
feat(errors): typed error classification with recovery strategies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 build/
 target/
 .conduit/
+.worktrees/

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,131 @@
+// Package errors defines typed tool and model failure categories with
+// corresponding recovery strategies for the Conduit engine.
+package errors
+
+import (
+	"errors"
+	"strings"
+)
+
+// Kind classifies a tool or model failure for recovery routing.
+type Kind string
+
+const (
+	KindNetwork          Kind = "network"
+	KindTimeout          Kind = "timeout"
+	KindRateLimited      Kind = "rate_limited"
+	KindPermission       Kind = "permission"
+	KindInvalidInput     Kind = "invalid_input"
+	KindModelUnavailable Kind = "model_unavailable"
+	KindUnknown          Kind = "unknown"
+)
+
+// Recovery describes the action the engine should take after a classified failure.
+type Recovery string
+
+const (
+	// RecoveryExponentialBackoff retries up to 3 times with exponential delay.
+	RecoveryExponentialBackoff Recovery = "exponential_backoff"
+	// RecoveryRetryLongerThenSkip retries once with an extended timeout, then skips.
+	RecoveryRetryLongerThenSkip Recovery = "retry_longer_then_skip"
+	// RecoveryBackoffOrFallback waits for retry-after, then falls back to a secondary model.
+	RecoveryBackoffOrFallback Recovery = "backoff_or_fallback"
+	// RecoveryEscalateToUser halts and surfaces the error to the user for approval.
+	RecoveryEscalateToUser Recovery = "escalate_to_user"
+	// RecoveryLogAndSkip records the failure and skips the call without retrying.
+	RecoveryLogAndSkip Recovery = "log_and_skip"
+	// RecoveryNextFallback switches to the next available model in the fallback chain.
+	RecoveryNextFallback Recovery = "next_fallback"
+	// RecoveryLogAndContinue records the failure and continues the session.
+	RecoveryLogAndContinue Recovery = "log_and_continue"
+)
+
+// recoveryTable maps each failure kind to its recovery action.
+var recoveryTable = map[Kind]Recovery{
+	KindNetwork:          RecoveryExponentialBackoff,
+	KindTimeout:          RecoveryRetryLongerThenSkip,
+	KindRateLimited:      RecoveryBackoffOrFallback,
+	KindPermission:       RecoveryEscalateToUser,
+	KindInvalidInput:     RecoveryLogAndSkip,
+	KindModelUnavailable: RecoveryNextFallback,
+	KindUnknown:          RecoveryLogAndContinue,
+}
+
+// RecoveryFor returns the recovery strategy for a given failure kind.
+func RecoveryFor(k Kind) Recovery {
+	if r, ok := recoveryTable[k]; ok {
+		return r
+	}
+	return RecoveryLogAndContinue
+}
+
+// ToolError is a typed failure that wraps an underlying error and carries its
+// classification so the engine can route recovery without re-inspecting the error.
+type ToolError struct {
+	kind Kind
+	err  error
+}
+
+// New creates a typed ToolError with the given kind and message.
+func New(k Kind, msg string) *ToolError {
+	return &ToolError{kind: k, err: errors.New(msg)}
+}
+
+// Wrap classifies an existing error and wraps it in a ToolError.
+func Wrap(k Kind, err error) *ToolError {
+	return &ToolError{kind: k, err: err}
+}
+
+// Kind returns the failure classification.
+func (e *ToolError) Kind() Kind { return e.kind }
+
+// Recovery returns the prescribed recovery action for this error.
+func (e *ToolError) Recovery() Recovery { return RecoveryFor(e.kind) }
+
+// Error satisfies the error interface.
+func (e *ToolError) Error() string { return e.err.Error() }
+
+// Unwrap exposes the inner error for errors.Is/As chains.
+func (e *ToolError) Unwrap() error { return e.err }
+
+// Classify inspects an error and returns its Kind. If the error is already a
+// ToolError its kind is returned directly; otherwise heuristics on the error
+// message are applied.
+func Classify(err error) Kind {
+	if err == nil {
+		return KindUnknown
+	}
+
+	var te *ToolError
+	if errors.As(err, &te) {
+		return te.kind
+	}
+
+	msg := strings.ToLower(err.Error())
+
+	switch {
+	case containsAny(msg, "timeout", "deadline exceeded", "context deadline"):
+		return KindTimeout
+	case containsAny(msg, "rate limit", "rate_limit", "too many requests", "429"):
+		return KindRateLimited
+	case containsAny(msg, "permission denied", "unauthorized", "forbidden", "403", "401"):
+		return KindPermission
+	case containsAny(msg, "connection refused", "no route to host", "network", "dial", "i/o timeout"):
+		return KindNetwork
+	case containsAny(msg, "model unavailable", "model not found", "overloaded", "529"):
+		return KindModelUnavailable
+	case containsAny(msg, "invalid input", "invalid argument", "bad request", "400", "validation"):
+		return KindInvalidInput
+	default:
+		return KindUnknown
+	}
+}
+
+func containsAny(s string, substrings ...string) bool {
+	for _, sub := range substrings {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,93 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestClassifyTypedErrorPassesThroughKind(t *testing.T) {
+	for _, k := range []Kind{
+		KindNetwork, KindTimeout, KindRateLimited, KindPermission,
+		KindInvalidInput, KindModelUnavailable, KindUnknown,
+	} {
+		err := New(k, "some failure")
+		if got := Classify(err); got != k {
+			t.Errorf("Classify(New(%s)) = %s, want %s", k, got, k)
+		}
+	}
+}
+
+func TestClassifyWrappedErrorPreservesKind(t *testing.T) {
+	inner := errors.New("connection refused")
+	wrapped := Wrap(KindNetwork, inner)
+	if got := Classify(wrapped); got != KindNetwork {
+		t.Errorf("Classify(Wrap(network, err)) = %s, want network", got)
+	}
+}
+
+func TestClassifyHeuristicsFromMessageSubstrings(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want Kind
+	}{
+		{"context deadline exceeded", KindTimeout},
+		{"request timeout", KindTimeout},
+		{"rate limit exceeded", KindRateLimited},
+		{"too many requests: 429", KindRateLimited},
+		{"permission denied: /etc/shadow", KindPermission},
+		{"401 unauthorized", KindPermission},
+		{"403 forbidden", KindPermission},
+		{"connection refused", KindNetwork},
+		{"no route to host", KindNetwork},
+		{"model unavailable", KindModelUnavailable},
+		{"model not found", KindModelUnavailable},
+		{"invalid input: missing field", KindInvalidInput},
+		{"bad request: 400", KindInvalidInput},
+		{"unexpected failure", KindUnknown},
+	}
+	for _, c := range cases {
+		err := fmt.Errorf("%s", c.msg)
+		if got := Classify(err); got != c.want {
+			t.Errorf("Classify(%q) = %s, want %s", c.msg, got, c.want)
+		}
+	}
+}
+
+func TestRecoveryForCoversAllKinds(t *testing.T) {
+	table := map[Kind]Recovery{
+		KindNetwork:          RecoveryExponentialBackoff,
+		KindTimeout:          RecoveryRetryLongerThenSkip,
+		KindRateLimited:      RecoveryBackoffOrFallback,
+		KindPermission:       RecoveryEscalateToUser,
+		KindInvalidInput:     RecoveryLogAndSkip,
+		KindModelUnavailable: RecoveryNextFallback,
+		KindUnknown:          RecoveryLogAndContinue,
+	}
+	for k, want := range table {
+		if got := RecoveryFor(k); got != want {
+			t.Errorf("RecoveryFor(%s) = %s, want %s", k, got, want)
+		}
+	}
+}
+
+func TestToolErrorRecoveryMatchesKind(t *testing.T) {
+	err := New(KindRateLimited, "quota exceeded")
+	if err.Recovery() != RecoveryBackoffOrFallback {
+		t.Errorf("Recovery() = %s, want backoff_or_fallback", err.Recovery())
+	}
+}
+
+func TestToolErrorUnwrapChain(t *testing.T) {
+	sentinel := errors.New("root cause")
+	wrapped := Wrap(KindNetwork, sentinel)
+	if !errors.Is(wrapped, sentinel) {
+		t.Error("errors.Is should find sentinel through Unwrap chain")
+	}
+}
+
+func TestClassifyNilReturnsUnknown(t *testing.T) {
+	if got := Classify(nil); got != KindUnknown {
+		t.Errorf("Classify(nil) = %s, want unknown", got)
+	}
+}

--- a/internal/tools/pipeline.go
+++ b/internal/tools/pipeline.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	toolerrors "github.com/jabreeflor/conduit/internal/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -36,9 +37,12 @@ type Tool struct {
 type Runner func(context.Context, json.RawMessage) (Result, error)
 
 // Result is the normalized output from a tool execution.
+// IsError is set when the run failed; Text carries the error message so the
+// agent can read what went wrong and adapt without losing the call from context.
 type Result struct {
-	Text string
-	Data map[string]any
+	Text    string
+	Data    map[string]any
+	IsError bool
 }
 
 // Call is the policy input for a pending tool invocation.
@@ -203,7 +207,12 @@ func (p *Pipeline) Execute(ctx context.Context, call Call, overrides AgentOverri
 		return Result{}, decision, err
 	}
 	result, err := p.WrapRunner(decision.Tool.Run)(ctx, input)
-	return result, decision, err
+	if err != nil {
+		classified := toolerrors.Classify(err)
+		typed := toolerrors.Wrap(classified, err)
+		return Result{Text: err.Error(), IsError: true}, decision, typed
+	}
+	return result, decision, nil
 }
 
 // PolicyConfig mirrors ~/.conduit/policies.yaml.

--- a/internal/tools/pipeline_test.go
+++ b/internal/tools/pipeline_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	toolerrors "github.com/jabreeflor/conduit/internal/errors"
 )
 
 func TestPipelineAppliesAgentOverrideBeforePolicy(t *testing.T) {
@@ -180,5 +182,39 @@ policies:
 	}
 	if cfg.Policies[1].AllowedDomains[0] != "*.github.com" {
 		t.Fatalf("AllowedDomains = %#v, want github wildcard", cfg.Policies[1].AllowedDomains)
+	}
+}
+
+func TestExecuteClassifiesRunnerErrorAndSetsIsError(t *testing.T) {
+	pipeline := NewPipeline([]Tool{
+		{
+			Name: "flaky",
+			Run: func(_ context.Context, _ json.RawMessage) (Result, error) {
+				return Result{}, errors.New("connection refused")
+			},
+		},
+	}, PolicyConfig{})
+
+	result, _, err := pipeline.Execute(context.Background(), Call{ToolName: "flaky"}, AgentOverrides{})
+
+	if err == nil {
+		t.Fatal("expected error from failing runner, got nil")
+	}
+	if !result.IsError {
+		t.Error("Result.IsError should be true when runner fails")
+	}
+	if result.Text == "" {
+		t.Error("Result.Text should carry the error message for agent visibility")
+	}
+
+	var te *toolerrors.ToolError
+	if !errors.As(err, &te) {
+		t.Fatalf("error should be a *toolerrors.ToolError, got %T", err)
+	}
+	if te.Kind() != toolerrors.KindNetwork {
+		t.Errorf("Kind = %s, want network (connection refused heuristic)", te.Kind())
+	}
+	if te.Recovery() != toolerrors.RecoveryExponentialBackoff {
+		t.Errorf("Recovery = %s, want exponential_backoff", te.Recovery())
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `internal/errors` package with seven typed error kinds (`NetworkError`, `TimeoutError`, `RateLimitedError`, `PermissionError`, `InvalidInputError`, `ModelUnavailableError`, `UnknownError`)
- Each kind maps to a prescribed recovery strategy via `RecoveryFor()` (e.g. network → 3× exponential backoff, permission → escalate to user)
- `Classify(err)` applies heuristics on error messages for untyped upstream errors; typed `ToolError` pass-through for already-classified errors
- Integrates with `tools.Pipeline.Execute`: runner errors are now wrapped as `*ToolError` and `Result.IsError` is set so the agent retains visibility of failed calls

Closes #16

## Test plan
- [ ] `go test ./internal/errors/...` — 7 classification tests + recovery table coverage
- [ ] `go test ./internal/tools/...` — new `TestExecuteClassifiesRunnerErrorAndSetsIsError` verifies `IsError`, `Result.Text`, and typed `ToolError` with correct `Kind`/`Recovery`
- [ ] `go test ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)