### PR TITLE
feat(#77): machine auto-detection (CPU, GPU, RAM, disk, macOS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 build/
 target/
 .conduit/
+.worktrees/

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -4,6 +4,45 @@ package contracts
 
 import "time"
 
+// MachineProfile is the hardware snapshot cached in ~/.conduit/machine-profile.json.
+type MachineProfile struct {
+	ProfiledAt   time.Time `json:"profiled_at"`
+	MacOSVersion string    `json:"macos_version"`
+	CPU          CPUInfo   `json:"cpu"`
+	Memory       MemInfo   `json:"memory"`
+	GPU          []GPUInfo `json:"gpu"`
+	Disk         DiskInfo  `json:"disk"`
+}
+
+// CPUInfo holds processor identification and core counts.
+type CPUInfo struct {
+	Brand         string `json:"brand"`
+	PhysicalCores int    `json:"physical_cores"`
+	LogicalCores  int    `json:"logical_cores"`
+}
+
+// MemInfo holds total installed RAM.
+type MemInfo struct {
+	TotalBytes int64   `json:"total_bytes"`
+	TotalGB    float64 `json:"total_gb"`
+}
+
+// GPUInfo holds one GPU adapter's name, VRAM, and whether it is shared (Apple
+// Unified Memory) or dedicated (discrete AMD/NVIDIA).
+type GPUInfo struct {
+	Name     string  `json:"name"`
+	VRAMGB   float64 `json:"vram_gb"`
+	VRAMType string  `json:"vram_type"` // "shared" | "dedicated"
+}
+
+// DiskInfo holds capacity and free space for the root filesystem.
+type DiskInfo struct {
+	TotalBytes     int64   `json:"total_bytes"`
+	AvailableBytes int64   `json:"available_bytes"`
+	TotalGB        float64 `json:"total_gb"`
+	AvailableGB    float64 `json:"available_gb"`
+}
+
 // Surface identifies a frontend attached to the Conduit core.
 type Surface string
 

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -12,16 +12,17 @@ import (
 
 // Engine owns the long-lived runtime state for Conduit.
 type Engine struct {
-	name        string
-	version     string
-	startedAt   time.Time
-	surfaces    []contracts.Surface
-	identity    *IdentityManager
-	router      *ModelRouter
-	network     *NetworkSandbox
-	permissions *PermissionManager
-	sandbox     *SandboxManager
-	sessionLog  []contracts.SessionLogEntry
+	name            string
+	version         string
+	startedAt       time.Time
+	surfaces        []contracts.Surface
+	identity        *IdentityManager
+	router          *ModelRouter
+	network         *NetworkSandbox
+	permissions     *PermissionManager
+	sandbox         *SandboxManager
+	machineProfiler *MachineProfiler
+	sessionLog      []contracts.SessionLogEntry
 }
 
 // New creates a core engine instance with the surfaces planned for the
@@ -36,11 +37,12 @@ func New(version string) *Engine {
 			contracts.SurfaceGUI,
 			contracts.SurfaceSpotlight,
 		},
-		identity:    NewIdentityManager(DefaultIdentityConfig()),
-		router:      NewModelRouter(DefaultEscalationConfig()),
-		network:     NewNetworkSandbox(DefaultNetworkSandboxConfig()),
-		permissions: NewPermissionManager(DefaultPermissionConfig()),
-		sandbox:     NewSandboxManager(DefaultSandboxArchitecture()),
+		identity:        NewIdentityManager(DefaultIdentityConfig()),
+		router:          NewModelRouter(DefaultEscalationConfig()),
+		network:         NewNetworkSandbox(DefaultNetworkSandboxConfig()),
+		permissions:     NewPermissionManager(DefaultPermissionConfig()),
+		sandbox:         NewSandboxManager(DefaultSandboxArchitecture()),
+		machineProfiler: NewMachineProfiler(DefaultMachineProfilerConfig()),
 	}
 }
 
@@ -108,6 +110,18 @@ func (e *Engine) SandboxArchitecture() contracts.SandboxArchitecture {
 // SessionLog returns a copy of user-visible engine events.
 func (e *Engine) SessionLog() []contracts.SessionLogEntry {
 	return append([]contracts.SessionLogEntry(nil), e.sessionLog...)
+}
+
+// MachineProfile returns the cached hardware profile, running a fresh scan on
+// first call or when no cache exists.
+func (e *Engine) MachineProfile() (contracts.MachineProfile, error) {
+	return e.machineProfiler.Load()
+}
+
+// RescanMachine runs a fresh hardware probe, overwrites the cache, and returns
+// the new profile. Call this on user-triggered re-scan requests.
+func (e *Engine) RescanMachine() (contracts.MachineProfile, error) {
+	return e.machineProfiler.Scan()
 }
 
 func joinReasons(reasons []contracts.EscalationReason) string {

--- a/internal/core/machine.go
+++ b/internal/core/machine.go
@@ -1,0 +1,270 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+const (
+	machineProfileFileName = "machine-profile.json"
+	profilingTimeout       = 3 * time.Second
+)
+
+// MachineProfilerConfig locates the cache file. The default layout is
+// ~/.conduit/machine-profile.json.
+type MachineProfilerConfig struct {
+	HomeDir     string
+	ProfilePath string
+}
+
+// DefaultMachineProfilerConfig returns the standard cache location.
+func DefaultMachineProfilerConfig() MachineProfilerConfig {
+	home, _ := os.UserHomeDir()
+	conduitHome := filepath.Join(home, ".conduit")
+	return MachineProfilerConfig{
+		HomeDir:     conduitHome,
+		ProfilePath: filepath.Join(conduitHome, machineProfileFileName),
+	}
+}
+
+// MachineProfiler probes local hardware and caches the result to disk.
+type MachineProfiler struct {
+	config MachineProfilerConfig
+	now    func() time.Time
+}
+
+// NewMachineProfiler creates a profiler using the provided config.
+func NewMachineProfiler(config MachineProfilerConfig) *MachineProfiler {
+	return &MachineProfiler{
+		config: config,
+		now:    func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// Load returns the cached profile from disk, or runs a fresh scan if no cache
+// exists or the cache file is unreadable.
+func (m *MachineProfiler) Load() (contracts.MachineProfile, error) {
+	if profile, ok := m.readCache(); ok {
+		return profile, nil
+	}
+	return m.Scan()
+}
+
+// Scan runs a fresh hardware probe in parallel across all subsystems, writes
+// the result to disk, and returns it. The entire probe is bounded by a
+// 3-second deadline.
+func (m *MachineProfiler) Scan() (contracts.MachineProfile, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), profilingTimeout)
+	defer cancel()
+
+	profile := contracts.MachineProfile{ProfiledAt: m.now()}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	type probe struct {
+		run func(context.Context)
+	}
+	probes := []probe{
+		{func(ctx context.Context) {
+			v := swVers(ctx)
+			mu.Lock()
+			profile.MacOSVersion = v
+			mu.Unlock()
+		}},
+		{func(ctx context.Context) {
+			cpu := probeCPU(ctx)
+			mu.Lock()
+			profile.CPU = cpu
+			mu.Unlock()
+		}},
+		{func(ctx context.Context) {
+			mem := probeMemory(ctx)
+			mu.Lock()
+			profile.Memory = mem
+			mu.Unlock()
+		}},
+		{func(ctx context.Context) {
+			gpus := probeGPUs(ctx)
+			mu.Lock()
+			profile.GPU = gpus
+			mu.Unlock()
+		}},
+		{func(ctx context.Context) {
+			disk := probeDisk(ctx)
+			mu.Lock()
+			profile.Disk = disk
+			mu.Unlock()
+		}},
+	}
+
+	for _, p := range probes {
+		wg.Add(1)
+		go func(fn func(context.Context)) {
+			defer wg.Done()
+			fn(ctx)
+		}(p.run)
+	}
+	wg.Wait()
+
+	if err := m.writeCache(profile); err != nil {
+		return profile, err
+	}
+	return profile, nil
+}
+
+func (m *MachineProfiler) readCache() (contracts.MachineProfile, bool) {
+	data, err := os.ReadFile(m.config.ProfilePath)
+	if err != nil {
+		return contracts.MachineProfile{}, false
+	}
+	var profile contracts.MachineProfile
+	if err := json.Unmarshal(data, &profile); err != nil {
+		return contracts.MachineProfile{}, false
+	}
+	return profile, true
+}
+
+func (m *MachineProfiler) writeCache(profile contracts.MachineProfile) error {
+	if err := os.MkdirAll(m.config.HomeDir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(profile, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(m.config.ProfilePath, append(data, '\n'), 0o644)
+}
+
+// sysctl runs `sysctl -n <key>` and returns trimmed stdout.
+func sysctl(ctx context.Context, key string) string {
+	out, err := exec.CommandContext(ctx, "sysctl", "-n", key).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func swVers(ctx context.Context) string {
+	out, err := exec.CommandContext(ctx, "sw_vers", "-productVersion").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func probeCPU(ctx context.Context) contracts.CPUInfo {
+	brand := sysctl(ctx, "machdep.cpu.brand_string")
+	physical, _ := strconv.Atoi(sysctl(ctx, "hw.physicalcpu"))
+	logical, _ := strconv.Atoi(sysctl(ctx, "hw.logicalcpu"))
+	return contracts.CPUInfo{
+		Brand:         brand,
+		PhysicalCores: physical,
+		LogicalCores:  logical,
+	}
+}
+
+func probeMemory(ctx context.Context) contracts.MemInfo {
+	raw := sysctl(ctx, "hw.memsize")
+	bytes, _ := strconv.ParseInt(raw, 10, 64)
+	return contracts.MemInfo{
+		TotalBytes: bytes,
+		TotalGB:    float64(bytes) / (1 << 30),
+	}
+}
+
+// probeGPUs calls system_profiler with a JSON output flag to avoid screen
+// capture dependencies. Returns nil when the call fails or times out.
+func probeGPUs(ctx context.Context) []contracts.GPUInfo {
+	type spDisplay struct {
+		Model         string `json:"sppci_model"`
+		VRAMShared    string `json:"spdisplays_vram_shared"`
+		VRAMDedicated string `json:"spdisplays_vram"`
+	}
+	type spData struct {
+		SPDisplaysDataType []spDisplay `json:"SPDisplaysDataType"`
+	}
+
+	out, err := exec.CommandContext(ctx, "system_profiler", "SPDisplaysDataType", "-json").Output()
+	if err != nil {
+		return nil
+	}
+
+	var data spData
+	if err := json.Unmarshal(out, &data); err != nil {
+		return nil
+	}
+
+	gpus := make([]contracts.GPUInfo, 0, len(data.SPDisplaysDataType))
+	for _, d := range data.SPDisplaysDataType {
+		gpu := contracts.GPUInfo{Name: d.Model}
+		switch {
+		case d.VRAMShared != "":
+			gpu.VRAMType = "shared"
+			gpu.VRAMGB = parseVRAMString(d.VRAMShared)
+		case d.VRAMDedicated != "":
+			gpu.VRAMType = "dedicated"
+			gpu.VRAMGB = parseVRAMString(d.VRAMDedicated)
+		}
+		gpus = append(gpus, gpu)
+	}
+	return gpus
+}
+
+// parseVRAMString converts strings like "16384 MB" or "8 GB" to GB.
+func parseVRAMString(s string) float64 {
+	fields := strings.Fields(strings.TrimSpace(s))
+	if len(fields) < 2 {
+		return 0
+	}
+	val, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0
+	}
+	switch strings.ToUpper(fields[1]) {
+	case "MB":
+		return val / 1024
+	case "GB":
+		return val
+	default:
+		return val
+	}
+}
+
+// probeDisk reads capacity and availability for the root filesystem using df.
+func probeDisk(ctx context.Context) contracts.DiskInfo {
+	out, err := exec.CommandContext(ctx, "df", "-k", "/").Output()
+	if err != nil {
+		return contracts.DiskInfo{}
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return contracts.DiskInfo{}
+	}
+	fields := strings.Fields(lines[1])
+	if len(fields) < 4 {
+		return contracts.DiskInfo{}
+	}
+
+	totalKB, _ := strconv.ParseInt(fields[1], 10, 64)
+	availKB, _ := strconv.ParseInt(fields[3], 10, 64)
+
+	totalBytes := totalKB * 1024
+	availBytes := availKB * 1024
+	return contracts.DiskInfo{
+		TotalBytes:     totalBytes,
+		AvailableBytes: availBytes,
+		TotalGB:        float64(totalBytes) / (1 << 30),
+		AvailableGB:    float64(availBytes) / (1 << 30),
+	}
+}

--- a/internal/core/machine_test.go
+++ b/internal/core/machine_test.go
@@ -1,0 +1,173 @@
+package core
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func testMachineProfilerConfig(t *testing.T) MachineProfilerConfig {
+	t.Helper()
+	dir := t.TempDir()
+	return MachineProfilerConfig{
+		HomeDir:     dir,
+		ProfilePath: filepath.Join(dir, machineProfileFileName),
+	}
+}
+
+func TestMachineProfiler_ScanWritesCache(t *testing.T) {
+	cfg := testMachineProfilerConfig(t)
+	m := NewMachineProfiler(cfg)
+
+	profile, err := m.Scan()
+	if err != nil {
+		t.Fatalf("Scan() error: %v", err)
+	}
+
+	if profile.ProfiledAt.IsZero() {
+		t.Error("ProfiledAt should be set")
+	}
+
+	data, err := os.ReadFile(cfg.ProfilePath)
+	if err != nil {
+		t.Fatalf("cache file not written: %v", err)
+	}
+
+	var cached contracts.MachineProfile
+	if err := json.Unmarshal(data, &cached); err != nil {
+		t.Fatalf("cache not valid JSON: %v", err)
+	}
+	if !cached.ProfiledAt.Equal(profile.ProfiledAt) {
+		t.Errorf("cached ProfiledAt = %v, want %v", cached.ProfiledAt, profile.ProfiledAt)
+	}
+}
+
+func TestMachineProfiler_LoadReturnsCacheWithoutRescanning(t *testing.T) {
+	cfg := testMachineProfilerConfig(t)
+	m := NewMachineProfiler(cfg)
+
+	fixed := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	stub := contracts.MachineProfile{
+		ProfiledAt:   fixed,
+		MacOSVersion: "14.0.0",
+		CPU:          contracts.CPUInfo{Brand: "Test CPU", PhysicalCores: 4, LogicalCores: 8},
+		Memory:       contracts.MemInfo{TotalBytes: 16 * (1 << 30), TotalGB: 16},
+	}
+
+	data, _ := json.MarshalIndent(stub, "", "  ")
+	if err := os.WriteFile(cfg.ProfilePath, append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := m.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if !loaded.ProfiledAt.Equal(fixed) {
+		t.Errorf("Load() returned ProfiledAt %v, want %v (should use cache)", loaded.ProfiledAt, fixed)
+	}
+	if loaded.MacOSVersion != "14.0.0" {
+		t.Errorf("Load() MacOSVersion = %q, want %q", loaded.MacOSVersion, "14.0.0")
+	}
+}
+
+func TestMachineProfiler_LoadFallsBackToScanOnMissingCache(t *testing.T) {
+	cfg := testMachineProfilerConfig(t)
+	m := NewMachineProfiler(cfg)
+
+	profile, err := m.Load()
+	if err != nil {
+		t.Fatalf("Load() error when no cache exists: %v", err)
+	}
+	if profile.ProfiledAt.IsZero() {
+		t.Error("ProfiledAt should be set after fallback scan")
+	}
+
+	if _, err := os.Stat(cfg.ProfilePath); os.IsNotExist(err) {
+		t.Error("cache file should have been written after fallback scan")
+	}
+}
+
+func TestMachineProfiler_LoadFallsBackToScanOnCorruptCache(t *testing.T) {
+	cfg := testMachineProfilerConfig(t)
+	m := NewMachineProfiler(cfg)
+
+	if err := os.WriteFile(cfg.ProfilePath, []byte("not json {{{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	profile, err := m.Load()
+	if err != nil {
+		t.Fatalf("Load() error on corrupt cache: %v", err)
+	}
+	if profile.ProfiledAt.IsZero() {
+		t.Error("ProfiledAt should be set after fallback scan")
+	}
+}
+
+func TestParseVRAMString(t *testing.T) {
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"8 GB", 8},
+		{"16 GB", 16},
+		{"16384 MB", 16},
+		{"4096 MB", 4},
+		{"", 0},
+		{"bad input", 0},
+		{"12 TB", 12},
+	}
+	for _, tc := range tests {
+		got := parseVRAMString(tc.input)
+		if got != tc.want {
+			t.Errorf("parseVRAMString(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestMachineProfiler_ScanCompletesWithinBudget(t *testing.T) {
+	cfg := testMachineProfilerConfig(t)
+	m := NewMachineProfiler(cfg)
+
+	start := time.Now()
+	_, err := m.Scan()
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Scan() error: %v", err)
+	}
+	if elapsed > profilingTimeout {
+		t.Errorf("Scan() took %v, must complete within %v", elapsed, profilingTimeout)
+	}
+}
+
+func TestMachineProfiler_ScanPopulatesFields(t *testing.T) {
+	cfg := testMachineProfilerConfig(t)
+	m := NewMachineProfiler(cfg)
+
+	profile, err := m.Scan()
+	if err != nil {
+		t.Fatalf("Scan() error: %v", err)
+	}
+
+	if profile.MacOSVersion == "" {
+		t.Error("MacOSVersion should be populated on macOS")
+	}
+	if profile.CPU.Brand == "" {
+		t.Error("CPU.Brand should be populated")
+	}
+	if profile.CPU.PhysicalCores == 0 {
+		t.Error("CPU.PhysicalCores should be > 0")
+	}
+	if profile.Memory.TotalBytes == 0 {
+		t.Error("Memory.TotalBytes should be > 0")
+	}
+	if profile.Disk.TotalBytes == 0 {
+		t.Error("Disk.TotalBytes should be > 0")
+	}
+}


### PR DESCRIPTION
## Summary

- Probes CPU brand/cores, GPU/VRAM, RAM, disk capacity, and macOS version in parallel using `sysctl`, `sw_vers`, `system_profiler`, and `df`
- Caches the result in `~/.conduit/machine-profile.json` on first scan; subsequent calls return the cache instantly
- Exposes `Engine.MachineProfile()` (load or scan) and `Engine.RescanMachine()` (force fresh probe) for user-triggered re-scans
- All five probes run concurrently under a 3-second `context.WithTimeout` deadline

Closes #77

## Test plan

- [x] `TestMachineProfiler_ScanWritesCache` — verifies cache file is created
- [x] `TestMachineProfiler_LoadReturnsCacheWithoutRescanning` — verifies stub cache is returned without re-probing
- [x] `TestMachineProfiler_LoadFallsBackToScanOnMissingCache` — verifies fresh scan on cold start
- [x] `TestMachineProfiler_LoadFallsBackToScanOnCorruptCache` — verifies graceful recovery from bad JSON
- [x] `TestMachineProfiler_ScanCompletesWithinBudget` — verifies real probe finishes under 3 seconds
- [x] `TestMachineProfiler_ScanPopulatesFields` — verifies CPU brand, cores, RAM, disk are non-zero on macOS
- [x] `TestParseVRAMString` — unit-tests the MB/GB VRAM parser

🤖 Generated with [Claude Code](https://claude.com/claude-code)