### PR TITLE
fix: guard darwin field test and fix mcp unreachable code

### DIFF
--- a/internal/core/machine_darwin_test.go
+++ b/internal/core/machine_darwin_test.go
@@ -1,0 +1,31 @@
+//go:build darwin
+
+package core
+
+import "testing"
+
+func TestMachineProfiler_ScanPopulatesFields(t *testing.T) {
+	cfg := testMachineProfilerConfig(t)
+	m := NewMachineProfiler(cfg)
+
+	profile, err := m.Scan()
+	if err != nil {
+		t.Fatalf("Scan() error: %v", err)
+	}
+
+	if profile.MacOSVersion == "" {
+		t.Error("MacOSVersion should be populated on macOS")
+	}
+	if profile.CPU.Brand == "" {
+		t.Error("CPU.Brand should be populated")
+	}
+	if profile.CPU.PhysicalCores == 0 {
+		t.Error("CPU.PhysicalCores should be > 0")
+	}
+	if profile.Memory.TotalBytes == 0 {
+		t.Error("Memory.TotalBytes should be > 0")
+	}
+	if profile.Disk.TotalBytes == 0 {
+		t.Error("Disk.TotalBytes should be > 0")
+	}
+}

--- a/internal/core/machine_test.go
+++ b/internal/core/machine_test.go
@@ -145,29 +145,3 @@ func TestMachineProfiler_ScanCompletesWithinBudget(t *testing.T) {
 		t.Errorf("Scan() took %v, must complete within %v", elapsed, profilingTimeout)
 	}
 }
-
-func TestMachineProfiler_ScanPopulatesFields(t *testing.T) {
-	cfg := testMachineProfilerConfig(t)
-	m := NewMachineProfiler(cfg)
-
-	profile, err := m.Scan()
-	if err != nil {
-		t.Fatalf("Scan() error: %v", err)
-	}
-
-	if profile.MacOSVersion == "" {
-		t.Error("MacOSVersion should be populated on macOS")
-	}
-	if profile.CPU.Brand == "" {
-		t.Error("CPU.Brand should be populated")
-	}
-	if profile.CPU.PhysicalCores == 0 {
-		t.Error("CPU.PhysicalCores should be > 0")
-	}
-	if profile.Memory.TotalBytes == 0 {
-		t.Error("Memory.TotalBytes should be > 0")
-	}
-	if profile.Disk.TotalBytes == 0 {
-		t.Error("Disk.TotalBytes should be > 0")
-	}
-}

--- a/internal/mcp/transport.go
+++ b/internal/mcp/transport.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Transport is the I/O contract every MCP transport must satisfy.
@@ -187,17 +188,17 @@ func (h *HTTPHandler) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	// Send a keep-alive ping every 15 seconds so proxies don't close the
 	// connection, then wait for the request context to cancel.
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-ticker.C:
+			_ = writeSSEEvent(w, "ping", "")
+			flusher.Flush()
 		}
 	}
-
-	// Drain any buffered outbound events.  Real notifications (tool-list
-	// changed, log messages) would be pushed here via a channel that the
-	// Server writes to when its state changes.
-	_ = flusher
 }
 
 // writeSSEEvent formats and writes one Server-Sent Events frame.


### PR DESCRIPTION
## Summary

Two CI regressions introduced by recent merges:

- **`TestMachineProfiler_ScanPopulatesFields`** (from PR #166): ran on ubuntu CI where `sw_vers` and `machdep.cpu.brand_string` don't exist — moved to `machine_darwin_test.go` with `//go:build darwin`
- **`internal/mcp/transport.go:200` unreachable code** (from PR #170): `_ = flusher` sat after an infinite loop — restructured `handleSSE` to implement the keep-alive ticker the comment described, using `flusher.Flush()` on each tick

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages green locally (macOS)
- [x] ubuntu CI: `TestMachineProfiler_ScanPopulatesFields` no longer runs; mcp vet error resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)