### PR TITLE
feat(tui): collapsible tool-call blocks with status indicators

### DIFF
--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -300,6 +300,24 @@ type DynamicMountRequest struct {
 	BlockReason          string
 }
 
+// ToolStatus identifies the execution state of a tool call.
+type ToolStatus int
+
+const (
+	ToolStatusRunning ToolStatus = iota
+	ToolStatusDone
+	ToolStatusFailed
+)
+
+// ToolCall holds the data for one tool invocation visible to the user.
+type ToolCall struct {
+	Name     string
+	Input    string
+	Output   string
+	Status   ToolStatus
+	Expanded bool
+}
+
 // SandboxArchitecture describes the security and startup contract every agent
 // execution sandbox must satisfy.
 type SandboxArchitecture struct {

--- a/internal/tui/toolblock.go
+++ b/internal/tui/toolblock.go
@@ -1,0 +1,49 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+const (
+	iconRunning   = "⟳"
+	iconDone      = "✓"
+	iconFailed    = "✗"
+	iconCollapsed = "▶"
+	iconExpanded  = "▼"
+)
+
+// RenderToolBlock returns the display string for one tool call.
+// Collapsed: "▶ ⟳ tool: name"
+// Expanded:  header + indented input (and output if present)
+func RenderToolBlock(tc contracts.ToolCall) string {
+	statusIcon := iconRunning
+	switch tc.Status {
+	case contracts.ToolStatusDone:
+		statusIcon = iconDone
+	case contracts.ToolStatusFailed:
+		statusIcon = iconFailed
+	}
+
+	toggleIcon := iconCollapsed
+	if tc.Expanded {
+		toggleIcon = iconExpanded
+	}
+
+	header := toggleIcon + " " + statusIcon + " tool: " + tc.Name
+
+	if !tc.Expanded {
+		return header
+	}
+
+	var sb strings.Builder
+	sb.WriteString(header)
+	if tc.Input != "" {
+		sb.WriteString("\n  input:  " + tc.Input)
+	}
+	if tc.Output != "" {
+		sb.WriteString("\n  output: " + tc.Output)
+	}
+	return sb.String()
+}

--- a/internal/tui/toolblock_test.go
+++ b/internal/tui/toolblock_test.go
@@ -1,0 +1,97 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestRenderToolBlock_collapsed(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     contracts.ToolStatus
+		wantIcon   string
+		wantToggle string
+	}{
+		{"running", contracts.ToolStatusRunning, iconRunning, iconCollapsed},
+		{"done", contracts.ToolStatusDone, iconDone, iconCollapsed},
+		{"failed", contracts.ToolStatusFailed, iconFailed, iconCollapsed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RenderToolBlock(contracts.ToolCall{
+				Name:   "read_file",
+				Input:  `{"path":"foo"}`,
+				Status: tc.status,
+			})
+			if !strings.Contains(got, tc.wantIcon) {
+				t.Errorf("collapsed %s: want status icon %q in %q", tc.name, tc.wantIcon, got)
+			}
+			if !strings.Contains(got, tc.wantToggle) {
+				t.Errorf("collapsed %s: want toggle icon %q in %q", tc.name, tc.wantToggle, got)
+			}
+			if strings.Contains(got, "input:") {
+				t.Errorf("collapsed: should not show input, got %q", got)
+			}
+			if strings.Contains(got, "\n") {
+				t.Errorf("collapsed: should be single line, got %q", got)
+			}
+		})
+	}
+}
+
+func TestRenderToolBlock_expanded(t *testing.T) {
+	tc := contracts.ToolCall{
+		Name:     "web_search",
+		Input:    `{"query":"bubbletea"}`,
+		Output:   `{"results":[]}`,
+		Status:   contracts.ToolStatusDone,
+		Expanded: true,
+	}
+	got := RenderToolBlock(tc)
+
+	if !strings.Contains(got, iconExpanded) {
+		t.Errorf("expanded: want toggle icon %q in %q", iconExpanded, got)
+	}
+	if !strings.Contains(got, iconDone) {
+		t.Errorf("expanded: want status icon %q in %q", iconDone, got)
+	}
+	if !strings.Contains(got, "input:") {
+		t.Errorf("expanded: want input line in %q", got)
+	}
+	if !strings.Contains(got, tc.Input) {
+		t.Errorf("expanded: want input value in %q", got)
+	}
+	if !strings.Contains(got, "output:") {
+		t.Errorf("expanded: want output line in %q", got)
+	}
+	if !strings.Contains(got, tc.Output) {
+		t.Errorf("expanded: want output value in %q", got)
+	}
+}
+
+func TestRenderToolBlock_expandedNoOutput(t *testing.T) {
+	tc := contracts.ToolCall{
+		Name:     "read_file",
+		Input:    `{"path":"foo"}`,
+		Status:   contracts.ToolStatusRunning,
+		Expanded: true,
+	}
+	got := RenderToolBlock(tc)
+
+	if !strings.Contains(got, "input:") {
+		t.Errorf("want input line in %q", got)
+	}
+	if strings.Contains(got, "output:") {
+		t.Errorf("want no output line when Output is empty, got %q", got)
+	}
+}
+
+func TestRenderToolBlock_nameInHeader(t *testing.T) {
+	tc := contracts.ToolCall{Name: "my_special_tool", Status: contracts.ToolStatusRunning}
+	got := RenderToolBlock(tc)
+	if !strings.Contains(got, "my_special_tool") {
+		t.Errorf("want tool name in header, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `ToolStatus` and `ToolCall` types to the contracts package (shared data shape)
- Adds `RenderToolBlock` renderer in `internal/tui` — collapsed shows `▶ ⟳/✓/✗ tool: name` on one line; expanded shows indented input and output (output line omitted when empty)
- Four table-driven tests cover all three status variants, expand/collapse toggle, and optional output field

Closes #19

## Test plan
- [x] `go test ./internal/tui/...` — all 5 tests pass (existing boot test + 4 new)
- [x] `go test ./...` — full suite green, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)