### PR TITLE
feat(tui): status bar — model, cost, session ID, active workflow

### DIFF
--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -181,9 +181,11 @@ type UsageEntry struct {
 
 // UsageSummary is the running totals for the status bar.
 type UsageSummary struct {
-	Model        string
-	TotalTokens  int
-	TotalCostUSD float64
+	Model          string
+	SessionID      string
+	TotalTokens    int
+	TotalCostUSD   float64
+	ActiveWorkflow string // empty when no workflow is running
 }
 
 // NetworkMode controls how sandboxed network access is approved.

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -28,6 +28,8 @@ type Engine struct {
 	budgetEnforcer  *budget.Enforcer
 	sessionLog      []contracts.SessionLogEntry
 	usage           *usage.Tracker
+	sessionID       string
+	activeWorkflow  string
 }
 
 // New creates a core engine instance with the surfaces planned for the
@@ -53,6 +55,7 @@ func New(version string) *Engine {
 		machineProfiler: NewMachineProfiler(DefaultMachineProfilerConfig()),
 		budgetEnforcer:  newBudgetEnforcer(config.BudgetsConfig{}),
 		usage:           tracker,
+		sessionID:       sessionID,
 	}
 }
 
@@ -90,6 +93,7 @@ func NewFromConfig(version string, cfg config.Config) *Engine {
 		machineProfiler: NewMachineProfiler(DefaultMachineProfilerConfig()),
 		budgetEnforcer:  newBudgetEnforcer(cfg.Budgets),
 		usage:           tracker,
+		sessionID:       sessionID,
 	}
 }
 
@@ -133,6 +137,9 @@ func (e *Engine) EvaluatePermission(req contracts.PermissionRequest) contracts.P
 // RouteModel selects a model for an inference request and logs transparent
 // escalation events for all surfaces.
 func (e *Engine) RouteModel(req contracts.ModelRouteRequest) contracts.ModelRouteDecision {
+	if req.WorkflowType != "" {
+		e.activeWorkflow = req.WorkflowType
+	}
 	decision := e.router.Route(req)
 	if decision.Escalated {
 		e.sessionLog = append(e.sessionLog, contracts.SessionLogEntry{
@@ -166,10 +173,13 @@ func (e *Engine) RecordUsage(provider, model string, inputTokens, outputTokens i
 
 // UsageSummary returns the running session totals for the status bar.
 func (e *Engine) UsageSummary() contracts.UsageSummary {
-	if e.usage == nil {
-		return contracts.UsageSummary{}
+	var s contracts.UsageSummary
+	if e.usage != nil {
+		s = e.usage.Summary()
 	}
-	return e.usage.Summary()
+	s.SessionID = e.sessionID
+	s.ActiveWorkflow = e.activeWorkflow
+	return s
 }
 
 // SessionLog returns a copy of user-visible engine events.

--- a/internal/core/engine_test.go
+++ b/internal/core/engine_test.go
@@ -42,6 +42,30 @@ func TestEngineInfoReturnsSurfaceCopy(t *testing.T) {
 	}
 }
 
+func TestEngineUsageSummaryHasSessionID(t *testing.T) {
+	engine := New("test")
+
+	s := engine.UsageSummary()
+
+	if s.SessionID == "" {
+		t.Fatal("UsageSummary.SessionID is empty; expected a non-empty session ID")
+	}
+}
+
+func TestEngineUsageSummaryTracksActiveWorkflow(t *testing.T) {
+	engine := New("test")
+
+	if w := engine.UsageSummary().ActiveWorkflow; w != "" {
+		t.Fatalf("ActiveWorkflow = %q before any RouteModel call, want empty", w)
+	}
+
+	engine.RouteModel(contracts.ModelRouteRequest{WorkflowType: "code-review", Confidence: 1.0})
+
+	if w := engine.UsageSummary().ActiveWorkflow; w != "code-review" {
+		t.Fatalf("ActiveWorkflow = %q, want code-review", w)
+	}
+}
+
 func TestEngineSanitizesInjectedContent(t *testing.T) {
 	engine := New("test")
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -7,12 +7,24 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
 	"github.com/jabreeflor/conduit/internal/core"
 )
 
-// formatStatusBar returns the "[Model] [Tokens] [$X.XX]" string for the status line.
-func formatStatusBar(model string, totalTokens int, totalCostUSD float64) string {
-	return fmt.Sprintf("[%s] [%d tokens] [$%.4f]", model, totalTokens, totalCostUSD)
+// formatStatusBar returns the status line from a UsageSummary.
+// It always shows model, session cost, and session ID; it appends workflow
+// only when one is active.
+func formatStatusBar(s contracts.UsageSummary) string {
+	parts := []string{
+		fmt.Sprintf("[%s]", s.Model),
+		fmt.Sprintf("[$%.4f]", s.TotalCostUSD),
+		fmt.Sprintf("[session:%s]", s.SessionID),
+	}
+	if s.ActiveWorkflow != "" {
+		parts = append(parts, fmt.Sprintf("[workflow:%s]", s.ActiveWorkflow))
+	}
+	return strings.Join(parts, " ")
 }
 
 // Run is the non-interactive boot path that proves the core/surface contract.
@@ -28,7 +40,8 @@ func Run(out io.Writer) error {
 
 	modelStatus := engine.ModelStatus()
 	usageSummary := engine.UsageSummary()
-	statusBar := formatStatusBar(modelStatus.SelectedModel, usageSummary.TotalTokens, usageSummary.TotalCostUSD)
+	usageSummary.Model = modelStatus.SelectedModel
+	statusBar := formatStatusBar(usageSummary)
 
 	_, err := fmt.Fprintf(
 		out,

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
 )
 
 func TestRunBootsAgainstCore(t *testing.T) {
@@ -22,5 +24,45 @@ func TestRunBootsAgainstCore(t *testing.T) {
 	}
 	if !strings.Contains(got, "status: model claude-haiku-4-5; escalates to claude-opus-4-6") {
 		t.Fatalf("output %q does not include model escalation status", got)
+	}
+	if !strings.Contains(got, "[session:") {
+		t.Fatalf("output %q does not include session ID in status bar", got)
+	}
+}
+
+func TestFormatStatusBarAllFields(t *testing.T) {
+	s := contracts.UsageSummary{
+		Model:          "claude-sonnet-4-6",
+		SessionID:      "1746057234567",
+		TotalCostUSD:   0.0123,
+		ActiveWorkflow: "code-review",
+	}
+
+	got := formatStatusBar(s)
+
+	if !strings.Contains(got, "[claude-sonnet-4-6]") {
+		t.Errorf("status bar %q missing model", got)
+	}
+	if !strings.Contains(got, "[$0.0123]") {
+		t.Errorf("status bar %q missing cost", got)
+	}
+	if !strings.Contains(got, "[session:1746057234567]") {
+		t.Errorf("status bar %q missing session ID", got)
+	}
+	if !strings.Contains(got, "[workflow:code-review]") {
+		t.Errorf("status bar %q missing active workflow", got)
+	}
+}
+
+func TestFormatStatusBarNoWorkflow(t *testing.T) {
+	s := contracts.UsageSummary{
+		Model:     "claude-haiku-4-5",
+		SessionID: "123",
+	}
+
+	got := formatStatusBar(s)
+
+	if strings.Contains(got, "workflow") {
+		t.Errorf("status bar %q should not include workflow when idle", got)
 	}
 }

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -95,7 +95,9 @@ func (t *Tracker) Record(provider, model string, inputTokens, outputTokens int) 
 func (t *Tracker) Summary() contracts.UsageSummary {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return t.summary
+	s := t.summary
+	s.SessionID = t.sessionID
+	return s
 }
 
 func (t *Tracker) appendLine(entry contracts.UsageEntry) error {


### PR DESCRIPTION
## Summary

- Extends `UsageSummary` contract with `SessionID` and `ActiveWorkflow` fields so all surfaces share one data shape
- `Tracker.Summary()` stamps its session ID into each snapshot; engine overlays `activeWorkflow` (set on each `RouteModel` call) and its own `sessionID` for nil-tracker safety
- `formatStatusBar` renders `[model] [$cost] [session:ID] [workflow:name]`, omitting the workflow segment when no workflow is active

Closes #18

## Test plan

- [x] `TestFormatStatusBarAllFields` — verifies all four fields render correctly
- [x] `TestFormatStatusBarNoWorkflow` — verifies workflow segment is absent when idle
- [x] `TestEngineUsageSummaryHasSessionID` — session ID is always non-empty
- [x] `TestEngineUsageSummaryTracksActiveWorkflow` — workflow name appears after RouteModel call
- [x] `TestRunBootsAgainstCore` — boot output includes `[session:` in status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)