### PR TITLE
feat(hooks): shell subprocess + JSON wire protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 build/
 target/
 .conduit/
+.worktrees/

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -128,6 +128,19 @@ type SessionLogEntry struct {
 	Message string
 }
 
+// HookAuditEntry records one hook subprocess execution for observability.
+type HookAuditEntry struct {
+	At       time.Time
+	Event    string
+	Command  string
+	Decision string
+	Reason   string
+	Context  string
+	Elapsed  time.Duration
+	TimedOut bool
+	Error    string
+}
+
 // UsageEntry is one model-call record written to ~/.conduit/usage.jsonl.
 type UsageEntry struct {
 	At           time.Time `json:"at"`

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -128,6 +128,25 @@ type SessionLogEntry struct {
 	Message string
 }
 
+// UsageEntry is one model-call record written to ~/.conduit/usage.jsonl.
+type UsageEntry struct {
+	At           time.Time `json:"at"`
+	SessionID    string    `json:"session_id"`
+	Provider     string    `json:"provider"`
+	Model        string    `json:"model"`
+	InputTokens  int       `json:"input_tokens"`
+	OutputTokens int       `json:"output_tokens"`
+	TotalTokens  int       `json:"total_tokens"`
+	CostUSD      float64   `json:"cost_usd"`
+}
+
+// UsageSummary is the running totals for the status bar.
+type UsageSummary struct {
+	Model        string
+	TotalTokens  int
+	TotalCostUSD float64
+}
+
 // NetworkMode controls how sandboxed network access is approved.
 type NetworkMode string
 

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -2,11 +2,13 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/jabreeflor/conduit/internal/contracts"
+	"github.com/jabreeflor/conduit/internal/hooks"
 	"github.com/jabreeflor/conduit/internal/security"
 	"github.com/jabreeflor/conduit/internal/usage"
 )
@@ -15,6 +17,7 @@ import (
 type Engine struct {
 	name        string
 	version     string
+	sessionID   string
 	startedAt   time.Time
 	surfaces    []contracts.Surface
 	identity    *IdentityManager
@@ -22,6 +25,7 @@ type Engine struct {
 	network     *NetworkSandbox
 	permissions *PermissionManager
 	sandbox     *SandboxManager
+	hooks       *hooks.Manager
 	sessionLog  []contracts.SessionLogEntry
 	usage       *usage.Tracker
 }
@@ -32,9 +36,12 @@ func New(version string) *Engine {
 	sessionID := fmt.Sprintf("%d", time.Now().UnixMilli())
 	tracker, _ := usage.New(sessionID) // best-effort; nil tracker is handled in RecordUsage
 
+	hookCfg, _ := hooks.LoadConfig() // best-effort; empty config means no hooks run
+
 	return &Engine{
 		name:      "Conduit",
 		version:   version,
+		sessionID: sessionID,
 		startedAt: time.Now().UTC(),
 		surfaces: []contracts.Surface{
 			contracts.SurfaceTUI,
@@ -46,6 +53,7 @@ func New(version string) *Engine {
 		network:     NewNetworkSandbox(DefaultNetworkSandboxConfig()),
 		permissions: NewPermissionManager(DefaultPermissionConfig()),
 		sandbox:     NewSandboxManager(DefaultSandboxArchitecture()),
+		hooks:       hooks.New(hookCfg, sessionID),
 		usage:       tracker,
 	}
 }
@@ -127,6 +135,24 @@ func (e *Engine) UsageSummary() contracts.UsageSummary {
 		return contracts.UsageSummary{}
 	}
 	return e.usage.Summary()
+}
+
+// Hooks returns the engine-owned hook manager.
+func (e *Engine) Hooks() *hooks.Manager {
+	return e.hooks
+}
+
+// FireHook runs all hooks registered for event and records the decision in the
+// session log when the outcome is not a plain allow.
+func (e *Engine) FireHook(ctx context.Context, event hooks.EventType, input hooks.HookInput) (hooks.HookOutput, error) {
+	out, err := e.hooks.Fire(ctx, event, input)
+	if out.Decision != hooks.DecisionAllow {
+		e.sessionLog = append(e.sessionLog, contracts.SessionLogEntry{
+			At:      time.Now().UTC(),
+			Message: hooks.FormatDecision(string(event), out),
+		})
+	}
+	return out, err
 }
 
 // SessionLog returns a copy of user-visible engine events.

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jabreeflor/conduit/internal/contracts"
 	"github.com/jabreeflor/conduit/internal/security"
+	"github.com/jabreeflor/conduit/internal/usage"
 )
 
 // Engine owns the long-lived runtime state for Conduit.
@@ -22,11 +23,15 @@ type Engine struct {
 	permissions *PermissionManager
 	sandbox     *SandboxManager
 	sessionLog  []contracts.SessionLogEntry
+	usage       *usage.Tracker
 }
 
 // New creates a core engine instance with the surfaces planned for the
 // monorepo scaffold.
 func New(version string) *Engine {
+	sessionID := fmt.Sprintf("%d", time.Now().UnixMilli())
+	tracker, _ := usage.New(sessionID) // best-effort; nil tracker is handled in RecordUsage
+
 	return &Engine{
 		name:      "Conduit",
 		version:   version,
@@ -41,6 +46,7 @@ func New(version string) *Engine {
 		network:     NewNetworkSandbox(DefaultNetworkSandboxConfig()),
 		permissions: NewPermissionManager(DefaultPermissionConfig()),
 		sandbox:     NewSandboxManager(DefaultSandboxArchitecture()),
+		usage:       tracker,
 	}
 }
 
@@ -103,6 +109,24 @@ func (e *Engine) ModelStatus() contracts.ModelRouteDecision {
 // SandboxArchitecture returns the engine-owned execution sandbox policy.
 func (e *Engine) SandboxArchitecture() contracts.SandboxArchitecture {
 	return e.sandbox.Architecture()
+}
+
+// RecordUsage appends one model-call record to ~/.conduit/usage.jsonl and
+// updates the in-memory session totals shown in the status bar.
+// A nil tracker (e.g. disk unavailable at startup) is a no-op.
+func (e *Engine) RecordUsage(provider, model string, inputTokens, outputTokens int) (contracts.UsageEntry, error) {
+	if e.usage == nil {
+		return contracts.UsageEntry{}, nil
+	}
+	return e.usage.Record(provider, model, inputTokens, outputTokens)
+}
+
+// UsageSummary returns the running session totals for the status bar.
+func (e *Engine) UsageSummary() contracts.UsageSummary {
+	if e.usage == nil {
+		return contracts.UsageSummary{}
+	}
+	return e.usage.Summary()
 }
 
 // SessionLog returns a copy of user-visible engine events.

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -1,0 +1,64 @@
+// Package hooks provides the hook execution subsystem for Conduit.
+// Hooks run as shell subprocesses with a JSON wire protocol: event data on
+// stdin, a decision (allow / block / inject) on stdout.
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// EventType identifies one of the lifecycle points where hooks can fire.
+type EventType string
+
+const (
+	EventPreToolCall    EventType = "pre_tool_call"
+	EventPostToolCall   EventType = "post_tool_call"
+	EventOnSessionStart EventType = "on_session_start"
+	EventOnSessionEnd   EventType = "on_session_end"
+	EventPreLLMCall     EventType = "pre_llm_call"
+	EventPostLLMCall    EventType = "post_llm_call"
+	EventOnMemoryWrite  EventType = "on_memory_write"
+)
+
+// HookConfig is one entry from ~/.conduit/hooks.yaml.
+type HookConfig struct {
+	Event   string `yaml:"event"`
+	Command string `yaml:"command"`
+	Matcher string `yaml:"matcher"` // optional regex filter on tool_name
+	Timeout int    `yaml:"timeout"` // seconds; 0 → DefaultTimeout
+}
+
+// Config is the top-level structure of ~/.conduit/hooks.yaml.
+type Config struct {
+	Hooks []HookConfig `yaml:"hooks"`
+}
+
+const defaultConfigPath = ".conduit/hooks.yaml"
+
+// LoadConfig reads hooks from ~/.conduit/hooks.yaml. A missing file is not an error.
+func LoadConfig() (Config, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return Config{}, err
+	}
+	return LoadConfigFile(filepath.Join(home, defaultConfigPath))
+}
+
+// LoadConfigFile reads hook config from an explicit path.
+func LoadConfigFile(path string) (Config, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return Config{}, nil
+	}
+	if err != nil {
+		return Config{}, err
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}

--- a/internal/hooks/manager.go
+++ b/internal/hooks/manager.go
@@ -1,0 +1,115 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// Manager fires configured hooks at agent lifecycle events.
+// All methods are safe for concurrent use.
+type Manager struct {
+	mu        sync.Mutex
+	hooks     []HookConfig
+	sessionID string
+	now       func() time.Time
+	audit     []contracts.HookAuditEntry
+}
+
+// New creates a Manager from the supplied config.
+func New(cfg Config, sessionID string) *Manager {
+	return &Manager{
+		hooks:     cfg.Hooks,
+		sessionID: sessionID,
+		now:       func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// Fire runs every hook registered for event. Returns the most restrictive
+// decision across all matching hooks (block > inject > allow).
+func (m *Manager) Fire(ctx context.Context, event EventType, input HookInput) (HookOutput, error) {
+	input.Event = string(event)
+	input.SessionID = m.sessionID
+	if input.CWD == "" {
+		input.CWD, _ = os.Getwd()
+	}
+
+	overall := HookOutput{Decision: DecisionAllow}
+
+	for _, h := range m.hooks {
+		if EventType(h.Event) != event {
+			continue
+		}
+		if h.Command == "" {
+			continue
+		}
+		if h.Matcher != "" && input.ToolName != "" {
+			matched, err := regexp.MatchString(h.Matcher, input.ToolName)
+			if err != nil || !matched {
+				continue
+			}
+		}
+
+		timeout := timeoutFor(h)
+		hookCtx, cancel := context.WithTimeout(ctx, timeout)
+		start := m.now()
+		out, runErr := run(hookCtx, h.Command, input)
+		elapsed := m.now().Sub(start)
+		timedOut := hookCtx.Err() == context.DeadlineExceeded
+		cancel()
+
+		if out.Decision == "" {
+			out.Decision = DecisionAllow
+		}
+
+		entry := contracts.HookAuditEntry{
+			At:       start,
+			Event:    string(event),
+			Command:  h.Command,
+			Decision: string(out.Decision),
+			Reason:   out.Reason,
+			Context:  out.Context,
+			Elapsed:  elapsed,
+			TimedOut: timedOut,
+		}
+		if runErr != nil {
+			entry.Error = runErr.Error()
+		}
+
+		m.mu.Lock()
+		m.audit = append(m.audit, entry)
+		m.mu.Unlock()
+
+		// block beats inject beats allow
+		switch out.Decision {
+		case DecisionBlock:
+			overall = out
+		case DecisionInject:
+			if overall.Decision != DecisionBlock {
+				overall = out
+			}
+		}
+	}
+
+	return overall, nil
+}
+
+// AuditTrail returns a copy of every hook execution record.
+func (m *Manager) AuditTrail() []contracts.HookAuditEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]contracts.HookAuditEntry(nil), m.audit...)
+}
+
+// FormatDecision formats a hook decision for the session log.
+func FormatDecision(event string, out HookOutput) string {
+	if out.Reason != "" {
+		return fmt.Sprintf("hook %s %s: %s", event, out.Decision, out.Reason)
+	}
+	return fmt.Sprintf("hook %s %s", event, out.Decision)
+}

--- a/internal/hooks/manager_test.go
+++ b/internal/hooks/manager_test.go
@@ -1,0 +1,191 @@
+package hooks_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/hooks"
+)
+
+func TestFire_NoHooks(t *testing.T) {
+	m := hooks.New(hooks.Config{}, "sess-1")
+	out, err := m.Fire(context.Background(), hooks.EventPreToolCall, hooks.HookInput{ToolName: "read_file"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Decision != hooks.DecisionAllow {
+		t.Fatalf("expected allow, got %q", out.Decision)
+	}
+}
+
+func TestFire_AllowDecision(t *testing.T) {
+	cfg := hooks.Config{Hooks: []hooks.HookConfig{{
+		Event:   "pre_tool_call",
+		Command: `echo '{"decision":"allow"}'`,
+		Timeout: 2,
+	}}}
+	m := hooks.New(cfg, "sess-2")
+	out, err := m.Fire(context.Background(), hooks.EventPreToolCall, hooks.HookInput{ToolName: "read_file"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Decision != hooks.DecisionAllow {
+		t.Fatalf("expected allow, got %q", out.Decision)
+	}
+}
+
+func TestFire_BlockDecision(t *testing.T) {
+	cfg := hooks.Config{Hooks: []hooks.HookConfig{{
+		Event:   "pre_tool_call",
+		Command: `echo '{"decision":"block","reason":"not allowed"}'`,
+		Timeout: 2,
+	}}}
+	m := hooks.New(cfg, "sess-3")
+	out, err := m.Fire(context.Background(), hooks.EventPreToolCall, hooks.HookInput{ToolName: "write_file"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Decision != hooks.DecisionBlock {
+		t.Fatalf("expected block, got %q", out.Decision)
+	}
+	if out.Reason != "not allowed" {
+		t.Fatalf("expected reason %q, got %q", "not allowed", out.Reason)
+	}
+}
+
+func TestFire_InjectDecision(t *testing.T) {
+	cfg := hooks.Config{Hooks: []hooks.HookConfig{{
+		Event:   "pre_tool_call",
+		Command: `echo '{"decision":"inject","context":"extra context"}'`,
+		Timeout: 2,
+	}}}
+	m := hooks.New(cfg, "sess-4")
+	out, err := m.Fire(context.Background(), hooks.EventPreToolCall, hooks.HookInput{ToolName: "search"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Decision != hooks.DecisionInject {
+		t.Fatalf("expected inject, got %q", out.Decision)
+	}
+	if out.Context != "extra context" {
+		t.Fatalf("expected context %q, got %q", "extra context", out.Context)
+	}
+}
+
+func TestFire_BlockBeatsInject(t *testing.T) {
+	cfg := hooks.Config{Hooks: []hooks.HookConfig{
+		{Event: "pre_tool_call", Command: `echo '{"decision":"inject","context":"ctx"}'`, Timeout: 2},
+		{Event: "pre_tool_call", Command: `echo '{"decision":"block","reason":"denied"}'`, Timeout: 2},
+	}}
+	m := hooks.New(cfg, "sess-5")
+	out, err := m.Fire(context.Background(), hooks.EventPreToolCall, hooks.HookInput{ToolName: "write_file"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Decision != hooks.DecisionBlock {
+		t.Fatalf("expected block to win, got %q", out.Decision)
+	}
+}
+
+func TestFire_CrashIsFailSafe(t *testing.T) {
+	cfg := hooks.Config{Hooks: []hooks.HookConfig{{
+		Event:   "pre_tool_call",
+		Command: `exit 1`,
+		Timeout: 2,
+	}}}
+	m := hooks.New(cfg, "sess-6")
+	out, err := m.Fire(context.Background(), hooks.EventPreToolCall, hooks.HookInput{ToolName: "read_file"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Decision != hooks.DecisionAllow {
+		t.Fatalf("crash should default to allow, got %q", out.Decision)
+	}
+}
+
+func TestFire_TimeoutIsFailSafe(t *testing.T) {
+	cfg := hooks.Config{Hooks: []hooks.HookConfig{{
+		Event:   "pre_tool_call",
+		Command: `sleep 10 && echo '{"decision":"block"}'`,
+		Timeout: 1,
+	}}}
+	m := hooks.New(cfg, "sess-7")
+	start := time.Now()
+	out, err := m.Fire(context.Background(), hooks.EventPreToolCall, hooks.HookInput{ToolName: "read_file"})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Decision != hooks.DecisionAllow {
+		t.Fatalf("timeout should default to allow, got %q", out.Decision)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("timeout not enforced: took %v", elapsed)
+	}
+}
+
+func TestFire_MatcherFiltersHook(t *testing.T) {
+	cfg := hooks.Config{Hooks: []hooks.HookConfig{{
+		Event:   "pre_tool_call",
+		Command: `echo '{"decision":"block"}'`,
+		Matcher: `^write_`,
+		Timeout: 2,
+	}}}
+	m := hooks.New(cfg, "sess-8")
+
+	// read_file should not match the ^write_ matcher → allow
+	out, _ := m.Fire(context.Background(), hooks.EventPreToolCall, hooks.HookInput{ToolName: "read_file"})
+	if out.Decision != hooks.DecisionAllow {
+		t.Fatalf("non-matching tool should be allowed, got %q", out.Decision)
+	}
+
+	// write_file matches → block
+	out, _ = m.Fire(context.Background(), hooks.EventPreToolCall, hooks.HookInput{ToolName: "write_file"})
+	if out.Decision != hooks.DecisionBlock {
+		t.Fatalf("matching tool should be blocked, got %q", out.Decision)
+	}
+}
+
+func TestFire_WrongEventSkipped(t *testing.T) {
+	cfg := hooks.Config{Hooks: []hooks.HookConfig{{
+		Event:   "post_tool_call",
+		Command: `echo '{"decision":"block"}'`,
+		Timeout: 2,
+	}}}
+	m := hooks.New(cfg, "sess-9")
+	out, _ := m.Fire(context.Background(), hooks.EventPreToolCall, hooks.HookInput{ToolName: "any"})
+	if out.Decision != hooks.DecisionAllow {
+		t.Fatalf("wrong-event hook should be skipped, got %q", out.Decision)
+	}
+}
+
+func TestAuditTrail(t *testing.T) {
+	cfg := hooks.Config{Hooks: []hooks.HookConfig{{
+		Event:   "pre_tool_call",
+		Command: `echo '{"decision":"allow"}'`,
+		Timeout: 2,
+	}}}
+	m := hooks.New(cfg, "sess-10")
+	m.Fire(context.Background(), hooks.EventPreToolCall, hooks.HookInput{ToolName: "read_file"}) //nolint:errcheck
+	trail := m.AuditTrail()
+	if len(trail) != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", len(trail))
+	}
+	if trail[0].Event != "pre_tool_call" {
+		t.Fatalf("unexpected event %q", trail[0].Event)
+	}
+	if trail[0].Decision != "allow" {
+		t.Fatalf("unexpected decision %q", trail[0].Decision)
+	}
+}
+
+func TestLoadConfigFile_MissingFile(t *testing.T) {
+	cfg, err := hooks.LoadConfigFile("/does/not/exist/hooks.yaml")
+	if err != nil {
+		t.Fatalf("missing file should not error, got: %v", err)
+	}
+	if len(cfg.Hooks) != 0 {
+		t.Fatalf("expected empty config, got %d hooks", len(cfg.Hooks))
+	}
+}

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -1,0 +1,49 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os/exec"
+	"time"
+)
+
+// DefaultTimeout is the hook subprocess timeout when the config omits one.
+const DefaultTimeout = 5 * time.Second
+
+// run executes one hook command as a shell subprocess using the JSON wire
+// protocol. The input is written as JSON to stdin; the output is read as JSON
+// from stdout. On any failure (crash, timeout, malformed JSON) the function
+// returns a fail-safe "allow" decision so a broken hook never blocks the agent.
+func run(ctx context.Context, command string, input HookInput) (HookOutput, error) {
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return HookOutput{Decision: DecisionAllow}, err
+	}
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd.Stdin = bytes.NewReader(inputJSON)
+	// WaitDelay forces I/O goroutines to close after the context expires, so an
+	// orphaned child holding stdout open cannot block us past the hook timeout.
+	cmd.WaitDelay = 500 * time.Millisecond
+
+	out, err := cmd.Output()
+	if err != nil {
+		// crash or timeout — fail-safe
+		return HookOutput{Decision: DecisionAllow}, err
+	}
+
+	var output HookOutput
+	if err := json.Unmarshal(bytes.TrimSpace(out), &output); err != nil || output.Decision == "" {
+		return HookOutput{Decision: DecisionAllow}, err
+	}
+	return output, nil
+}
+
+// timeoutFor returns the effective timeout for a hook config entry.
+func timeoutFor(h HookConfig) time.Duration {
+	if h.Timeout > 0 {
+		return time.Duration(h.Timeout) * time.Second
+	}
+	return DefaultTimeout
+}

--- a/internal/hooks/wire.go
+++ b/internal/hooks/wire.go
@@ -1,0 +1,26 @@
+package hooks
+
+// DecisionType is the hook subprocess's verdict for a pending lifecycle event.
+type DecisionType string
+
+const (
+	DecisionAllow  DecisionType = "allow"
+	DecisionBlock  DecisionType = "block"
+	DecisionInject DecisionType = "inject"
+)
+
+// HookInput is written as JSON to the hook subprocess stdin.
+type HookInput struct {
+	Event     string         `json:"event"`
+	ToolName  string         `json:"tool_name,omitempty"`
+	ToolInput map[string]any `json:"tool_input,omitempty"`
+	SessionID string         `json:"session_id"`
+	CWD       string         `json:"cwd"`
+}
+
+// HookOutput is read as JSON from the hook subprocess stdout.
+type HookOutput struct {
+	Decision DecisionType `json:"decision"`
+	Reason   string       `json:"reason,omitempty"`
+	Context  string       `json:"context,omitempty"` // payload for inject decisions
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -9,6 +9,11 @@ import (
 	"github.com/jabreeflor/conduit/internal/core"
 )
 
+// formatStatusBar returns the "[Model] [Tokens] [$X.XX]" string for the status line.
+func formatStatusBar(model string, totalTokens int, totalCostUSD float64) string {
+	return fmt.Sprintf("[%s] [%d tokens] [$%.4f]", model, totalTokens, totalCostUSD)
+}
+
 // Run starts the terminal surface. The real Bubble Tea application will land
 // after the TUI stack decision; this boot path proves the core/surface contract.
 func Run(out io.Writer) error {
@@ -21,14 +26,17 @@ func Run(out io.Writer) error {
 	}
 
 	modelStatus := engine.ModelStatus()
+	usageSummary := engine.UsageSummary()
+	statusBar := formatStatusBar(modelStatus.SelectedModel, usageSummary.TotalTokens, usageSummary.TotalCostUSD)
 
 	_, err := fmt.Fprintf(
 		out,
-		"%s core online (%s)\nstatus: model %s; escalates to %s\n",
+		"%s core online (%s)\nstatus: model %s; escalates to %s\n%s\n",
 		info.Name,
 		strings.Join(surfaces, ", "),
 		modelStatus.SelectedModel,
 		modelStatus.EscalationModel,
+		statusBar,
 	)
 	return err
 }

--- a/internal/usage/tracker.go
+++ b/internal/usage/tracker.go
@@ -1,0 +1,127 @@
+// Package usage logs per-call token and cost data to ~/.conduit/usage.jsonl
+// and exposes running session totals for the TUI status bar.
+package usage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// modelPricing holds input/output cost per 1M tokens in USD.
+type modelPricing struct {
+	inputPer1M  float64
+	outputPer1M float64
+}
+
+// knownPricing is the versioned cost table for supported models.
+// Costs are in USD per 1 million tokens.
+var knownPricing = map[string]modelPricing{
+	"claude-haiku-4-5":  {inputPer1M: 0.80, outputPer1M: 4.00},
+	"claude-sonnet-4-6": {inputPer1M: 3.00, outputPer1M: 15.00},
+	"claude-opus-4-6":   {inputPer1M: 15.00, outputPer1M: 75.00},
+	"claude-opus-4-7":   {inputPer1M: 15.00, outputPer1M: 75.00},
+	"gpt-4o":            {inputPer1M: 5.00, outputPer1M: 15.00},
+	"gpt-4o-mini":       {inputPer1M: 0.15, outputPer1M: 0.60},
+	"gemini-1.5-pro":    {inputPer1M: 3.50, outputPer1M: 10.50},
+	"gemini-1.5-flash":  {inputPer1M: 0.075, outputPer1M: 0.30},
+}
+
+const defaultLogPath = ".conduit/usage.jsonl"
+
+// Tracker appends usage entries to disk and maintains in-memory session totals.
+// All methods are safe for concurrent use.
+type Tracker struct {
+	mu        sync.Mutex
+	sessionID string
+	logPath   string
+	summary   contracts.UsageSummary
+}
+
+// New creates a Tracker that writes to ~/.conduit/usage.jsonl.
+func New(sessionID string) (*Tracker, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("usage: resolve home dir: %w", err)
+	}
+	logPath := filepath.Join(home, defaultLogPath)
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return nil, fmt.Errorf("usage: create log dir: %w", err)
+	}
+	return &Tracker{sessionID: sessionID, logPath: logPath}, nil
+}
+
+// NewWithPath creates a Tracker writing to an explicit path (useful in tests).
+func NewWithPath(sessionID, logPath string) (*Tracker, error) {
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return nil, fmt.Errorf("usage: create log dir: %w", err)
+	}
+	return &Tracker{sessionID: sessionID, logPath: logPath}, nil
+}
+
+// Record appends one model-call entry to the JSONL log and updates session totals.
+func (t *Tracker) Record(provider, model string, inputTokens, outputTokens int) (contracts.UsageEntry, error) {
+	cost := computeCost(model, inputTokens, outputTokens)
+	entry := contracts.UsageEntry{
+		At:           time.Now().UTC(),
+		SessionID:    t.sessionID,
+		Provider:     provider,
+		Model:        model,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		TotalTokens:  inputTokens + outputTokens,
+		CostUSD:      cost,
+	}
+
+	if err := t.appendLine(entry); err != nil {
+		return entry, err
+	}
+
+	t.mu.Lock()
+	t.summary.Model = model
+	t.summary.TotalTokens += entry.TotalTokens
+	t.summary.TotalCostUSD += cost
+	t.mu.Unlock()
+
+	return entry, nil
+}
+
+// Summary returns the running session totals without blocking on disk I/O.
+func (t *Tracker) Summary() contracts.UsageSummary {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.summary
+}
+
+func (t *Tracker) appendLine(entry contracts.UsageEntry) error {
+	line, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("usage: marshal entry: %w", err)
+	}
+	line = append(line, '\n')
+
+	f, err := os.OpenFile(t.logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("usage: open log: %w", err)
+	}
+	defer f.Close()
+
+	_, err = f.Write(line)
+	return err
+}
+
+// computeCost returns the USD cost using the known pricing table.
+// Returns zero for unrecognised models so a missing entry never blocks logging.
+func computeCost(model string, inputTokens, outputTokens int) float64 {
+	p, ok := knownPricing[model]
+	if !ok {
+		return 0
+	}
+	return float64(inputTokens)/1_000_000*p.inputPer1M +
+		float64(outputTokens)/1_000_000*p.outputPer1M
+}

--- a/internal/usage/tracker_test.go
+++ b/internal/usage/tracker_test.go
@@ -1,0 +1,109 @@
+package usage
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestRecord_appendsJSONL(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "usage.jsonl")
+
+	tracker, err := NewWithPath("sess-1", logPath)
+	if err != nil {
+		t.Fatalf("NewWithPath: %v", err)
+	}
+
+	entry, err := tracker.Record("anthropic", "claude-haiku-4-5", 1000, 200)
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	if entry.SessionID != "sess-1" {
+		t.Errorf("SessionID = %q, want sess-1", entry.SessionID)
+	}
+	if entry.TotalTokens != 1200 {
+		t.Errorf("TotalTokens = %d, want 1200", entry.TotalTokens)
+	}
+	if entry.CostUSD == 0 {
+		t.Error("CostUSD should be non-zero for a known model")
+	}
+
+	f, err := os.Open(logPath)
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	defer f.Close()
+
+	var parsed contracts.UsageEntry
+	scanner := bufio.NewScanner(f)
+	if !scanner.Scan() {
+		t.Fatal("log file is empty")
+	}
+	if err := json.Unmarshal(scanner.Bytes(), &parsed); err != nil {
+		t.Fatalf("unmarshal line: %v", err)
+	}
+	if parsed.Model != "claude-haiku-4-5" {
+		t.Errorf("parsed.Model = %q, want claude-haiku-4-5", parsed.Model)
+	}
+}
+
+func TestRecord_multipleCallsAccumulate(t *testing.T) {
+	dir := t.TempDir()
+	tracker, _ := NewWithPath("sess-2", filepath.Join(dir, "usage.jsonl"))
+
+	tracker.Record("anthropic", "claude-haiku-4-5", 500, 100)  //nolint:errcheck
+	tracker.Record("anthropic", "claude-sonnet-4-6", 800, 200) //nolint:errcheck
+
+	summary := tracker.Summary()
+	if summary.TotalTokens != 1600 {
+		t.Errorf("TotalTokens = %d, want 1600", summary.TotalTokens)
+	}
+	if summary.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model = %q, want claude-sonnet-4-6 (last used)", summary.Model)
+	}
+	if summary.TotalCostUSD == 0 {
+		t.Error("TotalCostUSD should be non-zero")
+	}
+}
+
+func TestRecord_unknownModelZeroCost(t *testing.T) {
+	dir := t.TempDir()
+	tracker, _ := NewWithPath("sess-3", filepath.Join(dir, "usage.jsonl"))
+
+	entry, err := tracker.Record("mystery-corp", "grok-99", 1000, 500)
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	if entry.CostUSD != 0 {
+		t.Errorf("CostUSD = %f, want 0 for unknown model", entry.CostUSD)
+	}
+}
+
+func TestComputeCost_knownModel(t *testing.T) {
+	// claude-haiku-4-5: $0.80/1M input, $4.00/1M output
+	cost := computeCost("claude-haiku-4-5", 1_000_000, 1_000_000)
+	want := 0.80 + 4.00
+	if cost != want {
+		t.Errorf("cost = %f, want %f", cost, want)
+	}
+}
+
+func TestSummary_statusBarFormat(t *testing.T) {
+	dir := t.TempDir()
+	tracker, _ := NewWithPath("sess-4", filepath.Join(dir, "usage.jsonl"))
+	tracker.Record("anthropic", "claude-haiku-4-5", 2000, 500) //nolint:errcheck
+
+	s := tracker.Summary()
+	if s.Model == "" {
+		t.Error("Summary.Model should be populated after a Record call")
+	}
+	if s.TotalTokens <= 0 {
+		t.Error("Summary.TotalTokens should be positive")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements the hook execution subsystem from PRD §6.6: hooks run as shell subprocesses with JSON on stdin (event, tool_name, tool_input, session_id, cwd) and allow/block/inject on stdout
- Enforces per-hook timeouts via `context.WithTimeout`; any crash, timeout, or malformed output defaults to `allow` (fail-safe). Uses `cmd.WaitDelay` to prevent orphaned child processes from blocking past the deadline
- Wires `HookManager` into `Engine` with `FireHook()` that logs non-allow decisions to the session log; adds `HookAuditEntry` to contracts for observability

Closes #26

## Test plan
- [ ] `go test ./internal/hooks/...` — 11 tests: allow/block/inject decisions, block-beats-inject precedence, crash fail-safe, timeout fail-safe (completes in ~1.5s not 10s), matcher regex filtering, event type filtering, audit trail, missing config file
- [ ] `go build ./...` — full build passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)