### PR TITLE
feat(#79): recommend local models from machine profile

### DIFF
--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -63,6 +63,54 @@ type DiskInfo struct {
 	AvailableGB    float64 `json:"available_gb"`
 }
 
+// MachineClass is the local-inference capability tier inferred from a machine
+// profile.
+type MachineClass string
+
+const (
+	MachineClassHighEnd     MachineClass = "high_end"
+	MachineClassMidRange    MachineClass = "mid_range"
+	MachineClassEntryLevel  MachineClass = "entry_level"
+	MachineClassConstrained MachineClass = "constrained"
+)
+
+// LocalModelUse identifies why a model is recommended.
+type LocalModelUse string
+
+const (
+	LocalModelUseGeneral LocalModelUse = "general"
+	LocalModelUseCode    LocalModelUse = "code"
+)
+
+// LocalModelRecommendation describes a locally bundled heuristic candidate.
+type LocalModelRecommendation struct {
+	Rank                  int           `json:"rank"`
+	ID                    string        `json:"id"`
+	Name                  string        `json:"name"`
+	Use                   LocalModelUse `json:"use"`
+	MachineClass          MachineClass  `json:"machine_class"`
+	Quantization          string        `json:"quantization"`
+	DownloadSizeGB        float64       `json:"download_size_gb"`
+	DiskFootprintGB       float64       `json:"disk_footprint_gb"`
+	EstimatedTokensPerSec float64       `json:"estimated_tokens_per_sec"`
+	Recommended           bool          `json:"recommended"`
+	FitsAvailableDisk     bool          `json:"fits_available_disk"`
+	Notes                 []string      `json:"notes,omitempty"`
+}
+
+// LocalModelRecommendationOptions controls optional recommendation lanes.
+type LocalModelRecommendationOptions struct {
+	IncludeCodeModel bool
+}
+
+// LocalModelRecommendationSet is the ranked local-model recommendation result.
+type LocalModelRecommendationSet struct {
+	MachineClass    MachineClass               `json:"machine_class"`
+	Recommendations []LocalModelRecommendation `json:"recommendations"`
+	FallbackReason  string                     `json:"fallback_reason,omitempty"`
+	GeneratedAt     time.Time                  `json:"generated_at"`
+}
+
 // MemoryProviderKind names a bundled memory provider implementation.
 type MemoryProviderKind string
 

--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -358,6 +358,17 @@ func (e *Engine) RescanMachine() (contracts.MachineProfile, error) {
 	return e.machineProfiler.Scan()
 }
 
+// LocalModelRecommendations returns ranked local-model install choices derived
+// from the cached machine profile. The heuristic is fully local and never phones
+// home.
+func (e *Engine) LocalModelRecommendations(opts contracts.LocalModelRecommendationOptions) (contracts.LocalModelRecommendationSet, error) {
+	profile, err := e.machineProfiler.Load()
+	if err != nil {
+		return contracts.LocalModelRecommendationSet{}, err
+	}
+	return RecommendLocalModels(profile, opts), nil
+}
+
 // CheckBudget evaluates whether a model call with the given estimated cost is
 // allowed under the configured monthly budgets. Returns ErrHardStop when the
 // call would breach a hard-stop limit.

--- a/internal/core/recommendations.go
+++ b/internal/core/recommendations.go
@@ -1,0 +1,294 @@
+package core
+
+import (
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+type localModelCandidate struct {
+	id             string
+	name           string
+	use            contracts.LocalModelUse
+	minClass       contracts.MachineClass
+	quantization   string
+	downloadGB     float64
+	footprintGB    float64
+	baseTokensSec  float64
+	classTokensSec map[contracts.MachineClass]float64
+	notes          []string
+}
+
+var machineClassRank = map[contracts.MachineClass]int{
+	contracts.MachineClassConstrained: 0,
+	contracts.MachineClassEntryLevel:  1,
+	contracts.MachineClassMidRange:    2,
+	contracts.MachineClassHighEnd:     3,
+}
+
+var bundledLocalModelCandidates = []localModelCandidate{
+	{
+		id:           "llama3:70b-q5",
+		name:         "Llama 3 70B",
+		use:          contracts.LocalModelUseGeneral,
+		minClass:     contracts.MachineClassHighEnd,
+		quantization: "Q5",
+		downloadGB:   40,
+		footprintGB:  45,
+		classTokensSec: map[contracts.MachineClass]float64{
+			contracts.MachineClassHighEnd: 15,
+		},
+		notes: []string{"Best quality general-purpose local model when memory allows."},
+	},
+	{
+		id:           "qwen2.5-coder:32b-q4",
+		name:         "Qwen2.5 Coder 32B",
+		use:          contracts.LocalModelUseCode,
+		minClass:     contracts.MachineClassHighEnd,
+		quantization: "Q4",
+		downloadGB:   20,
+		footprintGB:  24,
+		classTokensSec: map[contracts.MachineClass]float64{
+			contracts.MachineClassHighEnd: 24,
+		},
+		notes: []string{"Code-focused companion for high-memory Apple Silicon machines."},
+	},
+	{
+		id:           "llama3:8b-q8",
+		name:         "Llama 3 8B",
+		use:          contracts.LocalModelUseGeneral,
+		minClass:     contracts.MachineClassMidRange,
+		quantization: "Q8",
+		downloadGB:   8,
+		footprintGB:  10,
+		classTokensSec: map[contracts.MachineClass]float64{
+			contracts.MachineClassMidRange: 30,
+			contracts.MachineClassHighEnd:  55,
+		},
+		notes: []string{"Balanced default for interactive local use."},
+	},
+	{
+		id:           "mistral:7b-q6",
+		name:         "Mistral 7B",
+		use:          contracts.LocalModelUseGeneral,
+		minClass:     contracts.MachineClassMidRange,
+		quantization: "Q6",
+		downloadGB:   5,
+		footprintGB:  7,
+		classTokensSec: map[contracts.MachineClass]float64{
+			contracts.MachineClassMidRange: 36,
+			contracts.MachineClassHighEnd:  60,
+		},
+		notes: []string{"Fast fallback when disk or download size matters."},
+	},
+	{
+		id:           "qwen2.5-coder:7b-q6",
+		name:         "Qwen2.5 Coder 7B",
+		use:          contracts.LocalModelUseCode,
+		minClass:     contracts.MachineClassMidRange,
+		quantization: "Q6",
+		downloadGB:   6,
+		footprintGB:  8,
+		classTokensSec: map[contracts.MachineClass]float64{
+			contracts.MachineClassMidRange: 32,
+			contracts.MachineClassHighEnd:  58,
+		},
+		notes: []string{"Code-focused recommendation for mainstream laptops."},
+	},
+	{
+		id:           "phi3:mini-q4",
+		name:         "Phi-3 Mini",
+		use:          contracts.LocalModelUseGeneral,
+		minClass:     contracts.MachineClassEntryLevel,
+		quantization: "Q4",
+		downloadGB:   2.4,
+		footprintGB:  3.2,
+		classTokensSec: map[contracts.MachineClass]float64{
+			contracts.MachineClassEntryLevel: 18,
+			contracts.MachineClassMidRange:   42,
+			contracts.MachineClassHighEnd:    70,
+		},
+		notes: []string{"Small, quick install with lower quality expectations."},
+	},
+	{
+		id:           "llama3:8b-q4",
+		name:         "Llama 3 8B",
+		use:          contracts.LocalModelUseGeneral,
+		minClass:     contracts.MachineClassEntryLevel,
+		quantization: "Q4",
+		downloadGB:   4.7,
+		footprintGB:  6,
+		classTokensSec: map[contracts.MachineClass]float64{
+			contracts.MachineClassEntryLevel: 10,
+			contracts.MachineClassMidRange:   28,
+			contracts.MachineClassHighEnd:    48,
+		},
+		notes: []string{"Better quality than tiny models, but slower on 8GB systems."},
+	},
+	{
+		id:           "starcoder2:3b-q4",
+		name:         "StarCoder2 3B",
+		use:          contracts.LocalModelUseCode,
+		minClass:     contracts.MachineClassEntryLevel,
+		quantization: "Q4",
+		downloadGB:   2,
+		footprintGB:  2.8,
+		classTokensSec: map[contracts.MachineClass]float64{
+			contracts.MachineClassEntryLevel: 16,
+			contracts.MachineClassMidRange:   38,
+			contracts.MachineClassHighEnd:    64,
+		},
+		notes: []string{"Small code-focused model for low-memory machines."},
+	},
+}
+
+// RecommendLocalModels ranks local model candidates using only the cached
+// machine profile. It never calls external services; download sizes are bundled
+// heuristics for the install UI.
+func RecommendLocalModels(profile contracts.MachineProfile, opts contracts.LocalModelRecommendationOptions) contracts.LocalModelRecommendationSet {
+	class := ClassifyMachine(profile)
+	set := contracts.LocalModelRecommendationSet{
+		MachineClass: class,
+		GeneratedAt:  time.Now().UTC(),
+	}
+
+	if class == contracts.MachineClassConstrained {
+		set.FallbackReason = "Local models are not recommended on machines with less than 8GB RAM or very old hardware; use an external endpoint fallback instead."
+		return set
+	}
+
+	candidates := make([]contracts.LocalModelRecommendation, 0, len(bundledLocalModelCandidates))
+	for _, candidate := range bundledLocalModelCandidates {
+		if candidate.use == contracts.LocalModelUseCode && !opts.IncludeCodeModel {
+			continue
+		}
+		if machineClassRank[candidate.minClass] > machineClassRank[class] {
+			continue
+		}
+		rec := candidate.toRecommendation(class, profile)
+		candidates = append(candidates, rec)
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].Use != candidates[j].Use {
+			return candidates[i].Use == contracts.LocalModelUseGeneral
+		}
+		if candidates[i].MachineClass != candidates[j].MachineClass {
+			return machineClassRank[candidates[i].MachineClass] > machineClassRank[candidates[j].MachineClass]
+		}
+		return candidates[i].EstimatedTokensPerSec > candidates[j].EstimatedTokensPerSec
+	})
+
+	markTopByUse(candidates)
+	for i := range candidates {
+		candidates[i].Rank = i + 1
+	}
+	set.Recommendations = candidates
+	return set
+}
+
+// ClassifyMachine maps a hardware profile into the PRD §7.3 recommendation
+// tiers using local-only heuristics.
+func ClassifyMachine(profile contracts.MachineProfile) contracts.MachineClass {
+	memGB := profile.Memory.TotalGB
+	if memGB == 0 && profile.Memory.TotalBytes > 0 {
+		memGB = float64(profile.Memory.TotalBytes) / (1 << 30)
+	}
+	if memGB < 8 || isVeryOldIntel(profile.CPU.Brand) {
+		return contracts.MachineClassConstrained
+	}
+	if isAppleSilicon(profile) && memGB >= 64 {
+		return contracts.MachineClassHighEnd
+	}
+	if memGB >= 48 && bestVRAMGB(profile) >= 16 {
+		return contracts.MachineClassHighEnd
+	}
+	if memGB >= 16 {
+		return contracts.MachineClassMidRange
+	}
+	return contracts.MachineClassEntryLevel
+}
+
+func (c localModelCandidate) toRecommendation(class contracts.MachineClass, profile contracts.MachineProfile) contracts.LocalModelRecommendation {
+	tokensSec := c.classTokensSec[class]
+	if tokensSec == 0 {
+		tokensSec = c.baseTokensSec
+	}
+	if tokensSec == 0 {
+		tokensSec = 8
+	}
+
+	fitsDisk := profile.Disk.AvailableGB == 0 || profile.Disk.AvailableGB >= c.footprintGB*1.15
+	notes := append([]string(nil), c.notes...)
+	if !fitsDisk {
+		notes = append(notes, "Requires freeing disk space before installation.")
+	}
+
+	return contracts.LocalModelRecommendation{
+		ID:                    c.id,
+		Name:                  c.name,
+		Use:                   c.use,
+		MachineClass:          c.minClass,
+		Quantization:          c.quantization,
+		DownloadSizeGB:        round1(c.downloadGB),
+		DiskFootprintGB:       round1(c.footprintGB),
+		EstimatedTokensPerSec: estimateTokensPerSec(tokensSec, profile),
+		FitsAvailableDisk:     fitsDisk,
+		Notes:                 notes,
+	}
+}
+
+func markTopByUse(recs []contracts.LocalModelRecommendation) {
+	seen := map[contracts.LocalModelUse]bool{}
+	for i := range recs {
+		if !seen[recs[i].Use] {
+			recs[i].Recommended = true
+			seen[recs[i].Use] = true
+		}
+	}
+}
+
+func estimateTokensPerSec(base float64, profile contracts.MachineProfile) float64 {
+	if !isAppleSilicon(profile) && bestVRAMGB(profile) == 0 {
+		base *= 0.65
+	}
+	if profile.CPU.PhysicalCores > 0 && profile.CPU.PhysicalCores < 6 {
+		base *= 0.8
+	}
+	return round1(base)
+}
+
+func isAppleSilicon(profile contracts.MachineProfile) bool {
+	brand := strings.ToLower(profile.CPU.Brand)
+	if strings.Contains(brand, "apple") {
+		return true
+	}
+	for _, gpu := range profile.GPU {
+		if strings.Contains(strings.ToLower(gpu.Name), "apple") {
+			return true
+		}
+	}
+	return false
+}
+
+func isVeryOldIntel(brand string) bool {
+	brand = strings.ToLower(brand)
+	return strings.Contains(brand, "core 2") || strings.Contains(brand, "2012")
+}
+
+func bestVRAMGB(profile contracts.MachineProfile) float64 {
+	best := 0.0
+	for _, gpu := range profile.GPU {
+		if gpu.VRAMGB > best {
+			best = gpu.VRAMGB
+		}
+	}
+	return best
+}
+
+func round1(v float64) float64 {
+	return math.Round(v*10) / 10
+}

--- a/internal/core/recommendations_test.go
+++ b/internal/core/recommendations_test.go
@@ -1,0 +1,185 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestClassifyMachine(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile contracts.MachineProfile
+		want    contracts.MachineClass
+	}{
+		{
+			name: "high end apple silicon",
+			profile: contracts.MachineProfile{
+				CPU:    contracts.CPUInfo{Brand: "Apple M3 Max", PhysicalCores: 12},
+				Memory: contracts.MemInfo{TotalGB: 64},
+				GPU:    []contracts.GPUInfo{{Name: "Apple M3 Max", VRAMGB: 48, VRAMType: "shared"}},
+			},
+			want: contracts.MachineClassHighEnd,
+		},
+		{
+			name: "mid range apple silicon",
+			profile: contracts.MachineProfile{
+				CPU:    contracts.CPUInfo{Brand: "Apple M2 Pro", PhysicalCores: 10},
+				Memory: contracts.MemInfo{TotalGB: 16},
+				GPU:    []contracts.GPUInfo{{Name: "Apple M2 Pro", VRAMGB: 16, VRAMType: "shared"}},
+			},
+			want: contracts.MachineClassMidRange,
+		},
+		{
+			name: "entry level",
+			profile: contracts.MachineProfile{
+				CPU:    contracts.CPUInfo{Brand: "Apple M1", PhysicalCores: 8},
+				Memory: contracts.MemInfo{TotalGB: 8},
+			},
+			want: contracts.MachineClassEntryLevel,
+		},
+		{
+			name: "constrained memory",
+			profile: contracts.MachineProfile{
+				CPU:    contracts.CPUInfo{Brand: "Intel Core i5", PhysicalCores: 4},
+				Memory: contracts.MemInfo{TotalGB: 4},
+			},
+			want: contracts.MachineClassConstrained,
+		},
+		{
+			name: "constrained old intel",
+			profile: contracts.MachineProfile{
+				CPU:    contracts.CPUInfo{Brand: "Intel Core 2 Duo", PhysicalCores: 2},
+				Memory: contracts.MemInfo{TotalGB: 16},
+			},
+			want: contracts.MachineClassConstrained,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyMachine(tc.profile)
+			if got != tc.want {
+				t.Fatalf("ClassifyMachine() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRecommendLocalModels_highEndRanksLargeGeneralModel(t *testing.T) {
+	profile := contracts.MachineProfile{
+		CPU:    contracts.CPUInfo{Brand: "Apple M3 Max", PhysicalCores: 12},
+		Memory: contracts.MemInfo{TotalGB: 64},
+		GPU:    []contracts.GPUInfo{{Name: "Apple M3 Max", VRAMGB: 48, VRAMType: "shared"}},
+		Disk:   contracts.DiskInfo{AvailableGB: 200},
+	}
+
+	set := RecommendLocalModels(profile, contracts.LocalModelRecommendationOptions{})
+
+	if set.MachineClass != contracts.MachineClassHighEnd {
+		t.Fatalf("MachineClass = %q, want high_end", set.MachineClass)
+	}
+	if len(set.Recommendations) == 0 {
+		t.Fatal("expected recommendations")
+	}
+	top := set.Recommendations[0]
+	if top.ID != "llama3:70b-q5" {
+		t.Fatalf("top recommendation = %q, want llama3:70b-q5", top.ID)
+	}
+	if !top.Recommended {
+		t.Fatal("top recommendation should be one-click recommended")
+	}
+	if top.EstimatedTokensPerSec != 15 {
+		t.Fatalf("EstimatedTokensPerSec = %v, want 15", top.EstimatedTokensPerSec)
+	}
+	if !top.FitsAvailableDisk {
+		t.Fatal("top recommendation should fit available disk")
+	}
+}
+
+func TestRecommendLocalModels_midRangeIncludesManualBrowseCandidates(t *testing.T) {
+	profile := contracts.MachineProfile{
+		CPU:    contracts.CPUInfo{Brand: "Apple M3", PhysicalCores: 8},
+		Memory: contracts.MemInfo{TotalGB: 24},
+		GPU:    []contracts.GPUInfo{{Name: "Apple M3", VRAMGB: 24, VRAMType: "shared"}},
+		Disk:   contracts.DiskInfo{AvailableGB: 40},
+	}
+
+	set := RecommendLocalModels(profile, contracts.LocalModelRecommendationOptions{})
+
+	if set.MachineClass != contracts.MachineClassMidRange {
+		t.Fatalf("MachineClass = %q, want mid_range", set.MachineClass)
+	}
+	if got := set.Recommendations[0].ID; got != "mistral:7b-q6" {
+		t.Fatalf("top recommendation = %q, want mistral:7b-q6", got)
+	}
+	if len(set.Recommendations) < 4 {
+		t.Fatalf("expected manual browse choices, got %d", len(set.Recommendations))
+	}
+	for _, rec := range set.Recommendations {
+		if rec.MachineClass == contracts.MachineClassHighEnd {
+			t.Fatalf("mid-range machine should not receive high-end candidate %+v", rec)
+		}
+	}
+}
+
+func TestRecommendLocalModels_codeOptionPreselectsCodeCompanion(t *testing.T) {
+	profile := contracts.MachineProfile{
+		CPU:    contracts.CPUInfo{Brand: "Apple M2 Pro", PhysicalCores: 10},
+		Memory: contracts.MemInfo{TotalGB: 32},
+		Disk:   contracts.DiskInfo{AvailableGB: 100},
+	}
+
+	set := RecommendLocalModels(profile, contracts.LocalModelRecommendationOptions{IncludeCodeModel: true})
+
+	var codeRecommended contracts.LocalModelRecommendation
+	for _, rec := range set.Recommendations {
+		if rec.Use == contracts.LocalModelUseCode && rec.Recommended {
+			codeRecommended = rec
+			break
+		}
+	}
+	if codeRecommended.ID != "qwen2.5-coder:7b-q6" {
+		t.Fatalf("recommended code model = %q, want qwen2.5-coder:7b-q6", codeRecommended.ID)
+	}
+}
+
+func TestRecommendLocalModels_constrainedReturnsFallback(t *testing.T) {
+	profile := contracts.MachineProfile{
+		CPU:    contracts.CPUInfo{Brand: "Intel Core i5", PhysicalCores: 2},
+		Memory: contracts.MemInfo{TotalGB: 4},
+	}
+
+	set := RecommendLocalModels(profile, contracts.LocalModelRecommendationOptions{})
+
+	if set.MachineClass != contracts.MachineClassConstrained {
+		t.Fatalf("MachineClass = %q, want constrained", set.MachineClass)
+	}
+	if len(set.Recommendations) != 0 {
+		t.Fatalf("constrained machine recommendations = %d, want 0", len(set.Recommendations))
+	}
+	if set.FallbackReason == "" {
+		t.Fatal("FallbackReason should guide users to external endpoints")
+	}
+	if !strings.Contains(set.FallbackReason, "external endpoint") {
+		t.Fatalf("FallbackReason = %q, want external endpoint guidance", set.FallbackReason)
+	}
+}
+
+func TestRecommendLocalModels_marksDiskShortage(t *testing.T) {
+	profile := contracts.MachineProfile{
+		CPU:    contracts.CPUInfo{Brand: "Apple M1", PhysicalCores: 8},
+		Memory: contracts.MemInfo{TotalGB: 8},
+		Disk:   contracts.DiskInfo{AvailableGB: 3},
+	}
+
+	set := RecommendLocalModels(profile, contracts.LocalModelRecommendationOptions{})
+
+	if len(set.Recommendations) == 0 {
+		t.Fatal("expected entry-level recommendation")
+	}
+	if set.Recommendations[0].FitsAvailableDisk {
+		t.Fatal("recommendation should be flagged when disk is too low")
+	}
+}


### PR DESCRIPTION
## Summary
- Add hardware-tier contracts and local model recommendation metadata for first-run setup surfaces
- Rank bundled local model candidates by machine class, use case, disk fit, and estimated tokens/sec
- Expose engine recommendations from the cached machine profile with coverage for high-end, mid-range, entry-level, constrained, code, and disk-shortage paths

Closes #79

## Test plan
- [x] go test ./...

🤖 Generated with [Claude Code](https://claude.com/claude-code)