### PR TITLE
feat(#78): make local model setup resumable and verifiable

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jabreeflor/conduit/internal/endpoint"
 	evalpkg "github.com/jabreeflor/conduit/internal/eval"
+	"github.com/jabreeflor/conduit/internal/localmodel"
 	"github.com/jabreeflor/conduit/internal/mcp"
 	"github.com/jabreeflor/conduit/internal/router"
 	"github.com/jabreeflor/conduit/internal/tui"
@@ -25,6 +26,12 @@ func main() {
 		case "mcp":
 			if err := mcp.RunCLI(context.Background(), os.Args[2:], os.Stdout, os.Stderr); err != nil {
 				fmt.Fprintf(os.Stderr, "conduit mcp: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		case "models":
+			if err := localmodel.RunCLI(context.Background(), os.Args[2:], os.Stdout, os.Stderr); err != nil {
+				fmt.Fprintf(os.Stderr, "conduit models: %v\n", err)
 				os.Exit(1)
 			}
 			return

--- a/internal/localmodel/cmd.go
+++ b/internal/localmodel/cmd.go
@@ -1,0 +1,67 @@
+package localmodel
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+)
+
+// RunCLI is the entry point for `conduit models`.
+func RunCLI(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "usage: conduit models install --manifest <artifact-url> --sha256 <sha256> [--name file.gguf]")
+		return flag.ErrHelp
+	}
+	switch args[0] {
+	case "install":
+		return runInstall(ctx, args[1:], stdout, stderr)
+	default:
+		return fmt.Errorf("unknown models command %q", args[0])
+	}
+}
+
+func runInstall(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("conduit models install", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	name := fs.String("name", "model.gguf", "managed model filename")
+	url := fs.String("manifest", "", "model artifact URL")
+	sha := fs.String("sha256", "", "expected SHA-256 checksum")
+	root := fs.String("root", "", "Conduit root directory")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *url == "" || *sha == "" {
+		return fmt.Errorf("usage: conduit models install --manifest <artifact-url> --sha256 <sha256> [--name file.gguf]")
+	}
+
+	installer := Installer{
+		RootDir: *root,
+		Progress: func(event Event) {
+			if event.Stage == "runtime_adopted" || event.Stage == "verified" {
+				fmt.Fprintf(stdout, "%s: %s\n", event.Stage, event.Path)
+			}
+		},
+	}
+	result, err := installer.Install(ctx, InstallSpec{
+		Runtime: RuntimeSpec{
+			Name:        "ollama",
+			Kind:        RuntimeOllama,
+			BinaryNames: []string{"ollama"},
+		},
+		Models: []ModelSpec{{
+			Name:    *name,
+			Runtime: RuntimeOllama,
+			Artifact: Artifact{
+				Name:   *name,
+				URL:    *url,
+				SHA256: *sha,
+			},
+		}},
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "managed root: %s\n", result.ManagedRoot)
+	return nil
+}

--- a/internal/localmodel/defaults.go
+++ b/internal/localmodel/defaults.go
@@ -1,0 +1,38 @@
+package localmodel
+
+// Recommendation is static model metadata suitable for first-launch UI choices.
+type Recommendation struct {
+	Name          string
+	Runtime       RuntimeKind
+	MachineClass  string
+	EstimatedSize string
+	Description   string
+}
+
+// RecommendedModels returns the built-in model choices from PRD 7.3. The
+// installer still requires a concrete artifact URL and checksum before download.
+func RecommendedModels() []Recommendation {
+	return []Recommendation{
+		{
+			Name:          "llama3.1-8b-instruct-q4",
+			Runtime:       RuntimeOllama,
+			MachineClass:  "entry",
+			EstimatedSize: "5GB",
+			Description:   "general-purpose local chat model for 8-16GB machines",
+		},
+		{
+			Name:          "mistral-7b-instruct-q6",
+			Runtime:       RuntimeLlamaCPP,
+			MachineClass:  "mid-range",
+			EstimatedSize: "6GB",
+			Description:   "balanced quality and speed for 16-32GB machines",
+		},
+		{
+			Name:          "qwen2.5-coder-32b-q4",
+			Runtime:       RuntimeOllama,
+			MachineClass:  "high-end",
+			EstimatedSize: "20GB",
+			Description:   "code-focused local model for high-memory machines",
+		},
+	}
+}

--- a/internal/localmodel/installer.go
+++ b/internal/localmodel/installer.go
@@ -1,0 +1,322 @@
+// Package localmodel installs and adopts local inference runtimes and model
+// weights managed by Conduit.
+package localmodel
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	DefaultRootName = ".conduit"
+	ModelsDirName   = "models"
+)
+
+// RuntimeKind names the supported local inference runtime families.
+type RuntimeKind string
+
+const (
+	RuntimeOllama   RuntimeKind = "ollama"
+	RuntimeLlamaCPP RuntimeKind = "llama.cpp"
+	RuntimeLMStudio RuntimeKind = "lm_studio"
+)
+
+// Artifact is a downloadable file with an expected SHA-256 checksum.
+type Artifact struct {
+	Name   string
+	URL    string
+	SHA256 string
+}
+
+// RuntimeSpec describes the runtime Conduit should adopt or install.
+type RuntimeSpec struct {
+	Name        string
+	Kind        RuntimeKind
+	BinaryNames []string
+	Artifact    Artifact
+}
+
+// ModelSpec describes one model-weight artifact managed by Conduit.
+type ModelSpec struct {
+	Name     string
+	Runtime  RuntimeKind
+	Artifact Artifact
+}
+
+// InstallSpec is the full local inference setup plan.
+type InstallSpec struct {
+	Runtime RuntimeSpec
+	Models  []ModelSpec
+}
+
+// Event reports background installation progress to callers such as the TUI.
+type Event struct {
+	Stage string
+	Name  string
+	Path  string
+	Bytes int64
+	Total int64
+}
+
+// Result summarizes what the installer did.
+type Result struct {
+	ManagedRoot         string
+	RuntimePath         string
+	RuntimeAdopted      bool
+	DownloadedArtifacts []string
+	VerifiedArtifacts   []string
+}
+
+// Installer owns the local model installation pipeline.
+type Installer struct {
+	HomeDir  string
+	RootDir  string
+	Client   *http.Client
+	LookPath func(string) (string, error)
+	Progress func(Event)
+}
+
+// DefaultRoot returns ~/.conduit for the supplied home directory.
+func DefaultRoot(home string) string {
+	return filepath.Join(home, DefaultRootName)
+}
+
+// ManagedModelsDir returns the canonical Conduit-managed model directory.
+func ManagedModelsDir(root string) string {
+	return filepath.Join(root, ModelsDirName)
+}
+
+// Install installs or adopts a runtime and downloads model weights under
+// ~/.conduit/models. It is resumable when a previous .part file exists.
+func (i Installer) Install(ctx context.Context, spec InstallSpec) (Result, error) {
+	if spec.Runtime.Name == "" {
+		return Result{}, errors.New("local model install requires a runtime name")
+	}
+	root, err := i.root()
+	if err != nil {
+		return Result{}, err
+	}
+	result := Result{ManagedRoot: root}
+
+	if err := os.MkdirAll(ManagedModelsDir(root), 0o700); err != nil {
+		return Result{}, fmt.Errorf("creating managed models dir: %w", err)
+	}
+
+	if path, ok := i.detectRuntime(spec.Runtime); ok {
+		result.RuntimePath = path
+		result.RuntimeAdopted = true
+		i.emit(Event{Stage: "runtime_adopted", Name: spec.Runtime.Name, Path: path})
+	} else if spec.Runtime.Artifact.URL != "" {
+		path, downloaded, err := i.downloadAndVerify(ctx, spec.Runtime.Artifact, filepath.Join(root, "runtimes", spec.Runtime.Name))
+		if err != nil {
+			return Result{}, fmt.Errorf("installing runtime %s: %w", spec.Runtime.Name, err)
+		}
+		result.RuntimePath = path
+		if downloaded {
+			result.DownloadedArtifacts = append(result.DownloadedArtifacts, path)
+		}
+		result.VerifiedArtifacts = append(result.VerifiedArtifacts, path)
+	} else {
+		return Result{}, fmt.Errorf("runtime %s not found and no artifact URL configured", spec.Runtime.Name)
+	}
+
+	for _, model := range spec.Models {
+		if model.Artifact.URL == "" {
+			return Result{}, fmt.Errorf("model %s has no artifact URL", model.Name)
+		}
+		path, downloaded, err := i.downloadAndVerify(ctx, model.Artifact, ManagedModelsDir(root))
+		if err != nil {
+			return Result{}, fmt.Errorf("installing model %s: %w", model.Name, err)
+		}
+		if downloaded {
+			result.DownloadedArtifacts = append(result.DownloadedArtifacts, path)
+		}
+		result.VerifiedArtifacts = append(result.VerifiedArtifacts, path)
+	}
+	return result, nil
+}
+
+func (i Installer) root() (string, error) {
+	if i.RootDir != "" {
+		return i.RootDir, nil
+	}
+	home := i.HomeDir
+	if home == "" {
+		var err error
+		home, err = os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolving home directory: %w", err)
+		}
+	}
+	return DefaultRoot(home), nil
+}
+
+func (i Installer) detectRuntime(spec RuntimeSpec) (string, bool) {
+	lookPath := i.LookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	for _, binary := range spec.BinaryNames {
+		if strings.TrimSpace(binary) == "" {
+			continue
+		}
+		path, err := lookPath(binary)
+		if err == nil && path != "" {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+func (i Installer) downloadAndVerify(ctx context.Context, artifact Artifact, dir string) (string, bool, error) {
+	if err := validateArtifactName(artifact.Name); err != nil {
+		return "", false, err
+	}
+	if artifact.SHA256 == "" {
+		return "", false, fmt.Errorf("artifact %s is missing sha256", artifact.Name)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", false, fmt.Errorf("creating artifact dir: %w", err)
+	}
+	finalPath := filepath.Join(dir, artifact.Name)
+	if err := verifySHA256(finalPath, artifact.SHA256); err == nil {
+		i.emit(Event{Stage: "verified", Name: artifact.Name, Path: finalPath})
+		return finalPath, false, nil
+	}
+
+	partPath := finalPath + ".part"
+	offset := existingSize(partPath)
+	if err := i.download(ctx, artifact, partPath, offset); err != nil {
+		return "", false, err
+	}
+	if err := verifySHA256(partPath, artifact.SHA256); err != nil {
+		return "", true, err
+	}
+	if err := os.Rename(partPath, finalPath); err != nil {
+		return "", true, fmt.Errorf("finalizing %s: %w", artifact.Name, err)
+	}
+	i.emit(Event{Stage: "verified", Name: artifact.Name, Path: finalPath})
+	return finalPath, true, nil
+}
+
+func (i Installer) download(ctx context.Context, artifact Artifact, partPath string, offset int64) error {
+	client := i.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, artifact.URL, nil)
+	if err != nil {
+		return fmt.Errorf("building download request: %w", err)
+	}
+	if offset > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", offset))
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("downloading %s: %w", artifact.Name, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("downloading %s: HTTP %d", artifact.Name, resp.StatusCode)
+	}
+	flags := os.O_CREATE | os.O_WRONLY
+	if offset > 0 && resp.StatusCode == http.StatusPartialContent {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
+		offset = 0
+	}
+	f, err := os.OpenFile(partPath, flags, 0o600)
+	if err != nil {
+		return fmt.Errorf("opening partial artifact: %w", err)
+	}
+	defer f.Close()
+
+	i.emit(Event{Stage: "download_started", Name: artifact.Name, Path: partPath, Bytes: offset, Total: totalBytes(resp, offset)})
+	written, err := io.Copy(&progressWriter{
+		w: f,
+		onWrite: func(n int64) {
+			i.emit(Event{Stage: "download_progress", Name: artifact.Name, Path: partPath, Bytes: offset + n, Total: totalBytes(resp, offset)})
+		},
+	}, resp.Body)
+	if err != nil {
+		return fmt.Errorf("writing partial artifact: %w", err)
+	}
+	i.emit(Event{Stage: "download_finished", Name: artifact.Name, Path: partPath, Bytes: offset + written, Total: totalBytes(resp, offset)})
+	return nil
+}
+
+func validateArtifactName(name string) error {
+	if name == "" {
+		return errors.New("artifact name is required")
+	}
+	if filepath.Base(name) != name || strings.Contains(name, string(filepath.Separator)) {
+		return fmt.Errorf("artifact name %q must not contain path separators", name)
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("artifact name %q is invalid", name)
+	}
+	return nil
+}
+
+func verifySHA256(path, expected string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	sum := sha256.New()
+	if _, err := io.Copy(sum, f); err != nil {
+		return err
+	}
+	got := hex.EncodeToString(sum.Sum(nil))
+	if !strings.EqualFold(got, expected) {
+		return fmt.Errorf("checksum mismatch for %s: got %s, want %s", path, got, expected)
+	}
+	return nil
+}
+
+func existingSize(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}
+
+func totalBytes(resp *http.Response, offset int64) int64 {
+	if resp.ContentLength < 0 {
+		return -1
+	}
+	return offset + resp.ContentLength
+}
+
+func (i Installer) emit(event Event) {
+	if i.Progress != nil {
+		i.Progress(event)
+	}
+}
+
+type progressWriter struct {
+	w       io.Writer
+	written int64
+	onWrite func(int64)
+}
+
+func (p *progressWriter) Write(b []byte) (int, error) {
+	n, err := p.w.Write(b)
+	p.written += int64(n)
+	if p.onWrite != nil {
+		p.onWrite(p.written)
+	}
+	return n, err
+}

--- a/internal/localmodel/installer_test.go
+++ b/internal/localmodel/installer_test.go
@@ -1,0 +1,237 @@
+package localmodel
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func checksum(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestInstallAdoptsExistingRuntimeAndStoresModelsUnderManagedDir(t *testing.T) {
+	modelBytes := []byte("model weights")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(modelBytes)
+	}))
+	defer srv.Close()
+
+	root := filepath.Join(t.TempDir(), ".conduit")
+	result, err := Installer{
+		RootDir: root,
+		LookPath: func(name string) (string, error) {
+			if name == "ollama" {
+				return "/usr/local/bin/ollama", nil
+			}
+			return "", os.ErrNotExist
+		},
+	}.Install(context.Background(), InstallSpec{
+		Runtime: RuntimeSpec{Name: "ollama", Kind: RuntimeOllama, BinaryNames: []string{"ollama"}},
+		Models: []ModelSpec{{
+			Name:    "tiny",
+			Runtime: RuntimeOllama,
+			Artifact: Artifact{
+				Name:   "tiny.gguf",
+				URL:    srv.URL,
+				SHA256: checksum(modelBytes),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.RuntimeAdopted || result.RuntimePath != "/usr/local/bin/ollama" {
+		t.Fatalf("runtime adoption = (%v, %q), want existing ollama", result.RuntimeAdopted, result.RuntimePath)
+	}
+	modelPath := filepath.Join(root, "models", "tiny.gguf")
+	if _, err := os.Stat(modelPath); err != nil {
+		t.Fatalf("managed model missing at %s: %v", modelPath, err)
+	}
+}
+
+func TestInstallVerifiesChecksum(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("unexpected"))
+	}))
+	defer srv.Close()
+
+	root := filepath.Join(t.TempDir(), ".conduit")
+	_, err := Installer{
+		RootDir:  root,
+		LookPath: func(string) (string, error) { return "/bin/ollama", nil },
+	}.Install(context.Background(), InstallSpec{
+		Runtime: RuntimeSpec{Name: "ollama", BinaryNames: []string{"ollama"}},
+		Models: []ModelSpec{{
+			Name: "bad",
+			Artifact: Artifact{
+				Name:   "bad.gguf",
+				URL:    srv.URL,
+				SHA256: checksum([]byte("expected")),
+			},
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected checksum error")
+	}
+}
+
+func TestInstallRejectsArtifactPathTraversal(t *testing.T) {
+	_, err := Installer{
+		RootDir:  filepath.Join(t.TempDir(), ".conduit"),
+		LookPath: func(string) (string, error) { return "/bin/ollama", nil },
+	}.Install(context.Background(), InstallSpec{
+		Runtime: RuntimeSpec{Name: "ollama", BinaryNames: []string{"ollama"}},
+		Models: []ModelSpec{{
+			Name: "escape",
+			Artifact: Artifact{
+				Name:   "../escape.gguf",
+				URL:    "http://example.test/model",
+				SHA256: checksum([]byte("model")),
+			},
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected artifact path traversal error")
+	}
+}
+
+func TestInstallResumesPartialDownload(t *testing.T) {
+	full := []byte("abcdef")
+	var sawRange string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRange = r.Header.Get("Range")
+		if sawRange != "bytes=3-" {
+			t.Fatalf("Range = %q, want bytes=3-", sawRange)
+		}
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(full[3:])
+	}))
+	defer srv.Close()
+
+	root := filepath.Join(t.TempDir(), ".conduit")
+	modelDir := ManagedModelsDir(root)
+	if err := os.MkdirAll(modelDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(modelDir, "resume.gguf.part"), full[:3], 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Installer{
+		RootDir:  root,
+		LookPath: func(string) (string, error) { return "/bin/ollama", nil },
+	}.Install(context.Background(), InstallSpec{
+		Runtime: RuntimeSpec{Name: "ollama", BinaryNames: []string{"ollama"}},
+		Models: []ModelSpec{{
+			Name: "resume",
+			Artifact: Artifact{
+				Name:   "resume.gguf",
+				URL:    srv.URL,
+				SHA256: checksum(full),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(modelDir, "resume.gguf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(full) {
+		t.Fatalf("resumed file = %q, want %q", got, full)
+	}
+	if _, err := os.Stat(filepath.Join(modelDir, "resume.gguf.part")); !os.IsNotExist(err) {
+		t.Fatalf("partial file still exists: %v", err)
+	}
+}
+
+func TestInstallSkipsAlreadyVerifiedModel(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".conduit")
+	modelDir := ManagedModelsDir(root)
+	if err := os.MkdirAll(modelDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data := []byte("already here")
+	if err := os.WriteFile(filepath.Join(modelDir, "cached.gguf"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	result, err := Installer{
+		RootDir:  root,
+		LookPath: func(string) (string, error) { return "/bin/ollama", nil },
+	}.Install(context.Background(), InstallSpec{
+		Runtime: RuntimeSpec{Name: "ollama", BinaryNames: []string{"ollama"}},
+		Models: []ModelSpec{{
+			Name: "cached",
+			Artifact: Artifact{
+				Name:   "cached.gguf",
+				URL:    srv.URL,
+				SHA256: checksum(data),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if called {
+		t.Fatal("download server was called for an already verified model")
+	}
+	if len(result.DownloadedArtifacts) != 0 {
+		t.Fatalf("DownloadedArtifacts = %v, want none", result.DownloadedArtifacts)
+	}
+}
+
+func TestInstallDownloadsRuntimeWhenNoCompatibleInstallExists(t *testing.T) {
+	runtimeBytes := []byte("runtime binary")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(runtimeBytes)
+	}))
+	defer srv.Close()
+
+	root := filepath.Join(t.TempDir(), ".conduit")
+	result, err := Installer{
+		RootDir: root,
+		LookPath: func(string) (string, error) {
+			return "", fmt.Errorf("not found")
+		},
+	}.Install(context.Background(), InstallSpec{
+		Runtime: RuntimeSpec{
+			Name:        "llama.cpp",
+			Kind:        RuntimeLlamaCPP,
+			BinaryNames: []string{"llama-server"},
+			Artifact: Artifact{
+				Name:   "llama-server",
+				URL:    srv.URL,
+				SHA256: checksum(runtimeBytes),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RuntimeAdopted {
+		t.Fatal("runtime should have been downloaded, not adopted")
+	}
+	wantPath := filepath.Join(root, "runtimes", "llama.cpp", "llama-server")
+	if result.RuntimePath != wantPath {
+		t.Fatalf("RuntimePath = %q, want %q", result.RuntimePath, wantPath)
+	}
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("downloaded runtime missing: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a local model installer that adopts existing runtimes or downloads verified runtime artifacts.
- Store Conduit-managed model weights under ~/.conduit/models with checksum verification and resumable .part downloads.
- Wire a `conduit models install` CLI entry point for checked model artifact installs.

Closes #78

## Test plan
- [x] go test ./internal/localmodel
- [x] go test ./...

🤖 Generated with [Claude Code](https://claude.com/claude-code)