### PR TITLE
feat(#120): privacy controls — purge / export / aggregate-only

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jabreeflor/conduit/internal/mcp"
 	"github.com/jabreeflor/conduit/internal/router"
 	"github.com/jabreeflor/conduit/internal/tui"
+	"github.com/jabreeflor/conduit/internal/usage"
 )
 
 var version = "dev"
@@ -38,6 +39,12 @@ func main() {
 		case "eval":
 			if err := runEvalCLI(context.Background(), os.Args[2:], os.Stdout, os.Stderr); err != nil {
 				fmt.Fprintf(os.Stderr, "conduit eval: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		case "usage":
+			if err := usage.RunCLI(context.Background(), os.Args[2:], os.Stdout, os.Stderr); err != nil {
+				fmt.Fprintf(os.Stderr, "conduit usage: %v\n", err)
 				os.Exit(1)
 			}
 			return

--- a/internal/usage/cli.go
+++ b/internal/usage/cli.go
@@ -1,0 +1,57 @@
+package usage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// RunCLI is the entry point for `conduit usage`.
+func RunCLI(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		return printUsage(stdout)
+	}
+	dir, err := defaultLogDirAbs()
+	if err != nil {
+		return err
+	}
+
+	switch args[0] {
+	case "purge":
+		return runPurge(args[1:], stdout, stderr, dir)
+	case "export":
+		return runExport(args[1:], stdout, stderr, dir)
+	case "report":
+		return runReport(args[1:], stdout, stderr, dir)
+	case "dashboard":
+		return runDashboard(args[1:], stdout, stderr, dir)
+	case "-h", "--help", "help":
+		return printUsage(stdout)
+	default:
+		return fmt.Errorf("unknown usage subcommand %q; try: purge, export, report, dashboard", args[0])
+	}
+}
+
+func printUsage(w io.Writer) error {
+	_, err := fmt.Fprint(w, `usage: conduit usage <command>
+
+Commands:
+  purge      delete entries (--before <date> | --model <name>) [--dry-run | --yes]
+  export     write raw entries as csv or json (--format, --from, --to, --out)
+  report     aggregate-only report (--group day|month|model|provider, --json)
+  dashboard  render self-contained HTML report (--out)
+
+All commands operate on ~/.conduit/logs/usage. No data leaves the machine.
+`)
+	return err
+}
+
+func defaultLogDirAbs() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("usage: resolve home dir: %w", err)
+	}
+	return filepath.Join(home, defaultLogDir), nil
+}

--- a/internal/usage/cli_test.go
+++ b/internal/usage/cli_test.go
@@ -1,0 +1,304 @@
+package usage
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// writeJSONL writes one entry per line to a fresh log file.
+func writeJSONL(t *testing.T, dir, name string, entries []contracts.UsageEntry, gz bool) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	defer f.Close()
+	var w interface{ Write([]byte) (int, error) } = f
+	var gzw *gzip.Writer
+	if gz {
+		gzw = gzip.NewWriter(f)
+		w = gzw
+	}
+	for _, e := range entries {
+		buf, err := json.Marshal(e)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if _, err := w.Write(append(buf, '\n')); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if gzw != nil {
+		if err := gzw.Close(); err != nil {
+			t.Fatalf("gzip close: %v", err)
+		}
+	}
+}
+
+func mkEntry(ts time.Time, model string, tokensIn, tokensOut int, cost float64) contracts.UsageEntry {
+	return contracts.UsageEntry{
+		Timestamp:   ts,
+		SessionID:   "sess-test",
+		Provider:    "anthropic",
+		Model:       model,
+		TokensIn:    tokensIn,
+		TokensOut:   tokensOut,
+		TotalTokens: tokensIn + tokensOut,
+		Status:      "success",
+		CostUSD:     cost,
+	}
+}
+
+func TestPurge_byDate_dropsOlderEntries(t *testing.T) {
+	dir := t.TempDir()
+	entries := []contracts.UsageEntry{
+		mkEntry(time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC), "haiku", 100, 50, 0.01),
+		mkEntry(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "haiku", 200, 100, 0.02),
+	}
+	writeJSONL(t, dir, "2026-01-05.jsonl", entries[:1], false)
+	writeJSONL(t, dir, "2026-04-01.jsonl", entries[1:], false)
+
+	report, err := Purge(dir, PurgeOptions{Before: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("Purge: %v", err)
+	}
+	if report.Dropped != 1 || report.Kept != 1 {
+		t.Fatalf("dropped=%d kept=%d, want 1/1", report.Dropped, report.Kept)
+	}
+	// Older file should be removed entirely.
+	if _, err := os.Stat(filepath.Join(dir, "2026-01-05.jsonl")); !os.IsNotExist(err) {
+		t.Errorf("expected 2026-01-05.jsonl removed, stat err = %v", err)
+	}
+	// Newer file should still exist with one entry.
+	logs, _ := ListLogs(dir)
+	if len(logs) != 1 {
+		t.Fatalf("logs = %d, want 1", len(logs))
+	}
+}
+
+func TestPurge_byModel_handlesGzippedFiles(t *testing.T) {
+	dir := t.TempDir()
+	entries := []contracts.UsageEntry{
+		mkEntry(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "haiku", 100, 50, 0.01),
+		mkEntry(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "sonnet", 200, 100, 0.05),
+	}
+	writeJSONL(t, dir, "2026-04-01.jsonl.gz", entries, true)
+
+	report, err := Purge(dir, PurgeOptions{Model: "sonnet"})
+	if err != nil {
+		t.Fatalf("Purge: %v", err)
+	}
+	if report.Dropped != 1 || report.Kept != 1 {
+		t.Fatalf("dropped=%d kept=%d, want 1/1", report.Dropped, report.Kept)
+	}
+
+	// File should still be gzipped after rewrite.
+	logs, _ := ListLogs(dir)
+	if len(logs) != 1 || !logs[0].Compressed {
+		t.Fatalf("expected gzipped log retained, got %+v", logs)
+	}
+	var got []contracts.UsageEntry
+	_ = ScanLog(logs[0], func(e contracts.UsageEntry) bool {
+		got = append(got, e)
+		return true
+	})
+	if len(got) != 1 || got[0].Model != "haiku" {
+		t.Errorf("kept entries = %+v, want [haiku]", got)
+	}
+}
+
+func TestPurge_dryRun_doesNotMutate(t *testing.T) {
+	dir := t.TempDir()
+	entries := []contracts.UsageEntry{
+		mkEntry(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "haiku", 100, 50, 0.01),
+	}
+	writeJSONL(t, dir, "2026-04-01.jsonl", entries, false)
+
+	report, err := Purge(dir, PurgeOptions{Model: "haiku", DryRun: true})
+	if err != nil {
+		t.Fatalf("Purge: %v", err)
+	}
+	if report.Dropped != 1 {
+		t.Errorf("Dropped = %d, want 1", report.Dropped)
+	}
+	// File still present.
+	if _, err := os.Stat(filepath.Join(dir, "2026-04-01.jsonl")); err != nil {
+		t.Errorf("file should still exist after dry run: %v", err)
+	}
+}
+
+func TestPurge_requiresScope(t *testing.T) {
+	if _, err := Purge(t.TempDir(), PurgeOptions{}); err == nil {
+		t.Error("expected error for unscoped purge, got nil")
+	}
+}
+
+func TestRunPurge_requiresYesFlagForDestructive(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(t, dir, "2026-04-01.jsonl",
+		[]contracts.UsageEntry{mkEntry(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "haiku", 1, 1, 0)},
+		false)
+
+	var out, errBuf bytes.Buffer
+	err := runPurge([]string{"--model", "haiku"}, &out, &errBuf, dir)
+	if err == nil || !strings.Contains(err.Error(), "--yes") {
+		t.Fatalf("expected --yes error, got %v", err)
+	}
+}
+
+func TestExport_csv_filtersByDateRange(t *testing.T) {
+	dir := t.TempDir()
+	entries := []contracts.UsageEntry{
+		mkEntry(time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC), "haiku", 100, 50, 0.01),
+		mkEntry(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "sonnet", 200, 100, 0.05),
+		mkEntry(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), "opus", 300, 150, 0.5),
+	}
+	writeJSONL(t, dir, "2026-01-05.jsonl", entries[:1], false)
+	writeJSONL(t, dir, "2026-04-01.jsonl", entries[1:2], false)
+	writeJSONL(t, dir, "2026-05-01.jsonl", entries[2:], false)
+
+	var buf bytes.Buffer
+	err := Export(dir, ExportOptions{
+		From:   time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		To:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		Format: ExportFormatCSV,
+	}, &buf)
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "sonnet") {
+		t.Errorf("output missing sonnet entry: %q", got)
+	}
+	if strings.Contains(got, "haiku") || strings.Contains(got, "opus") {
+		t.Errorf("output should exclude out-of-range entries: %q", got)
+	}
+	// Header row must be present.
+	if !strings.HasPrefix(got, "timestamp,session_id,") {
+		t.Errorf("missing CSV header: %q", got[:60])
+	}
+}
+
+func TestExport_json_emitsValidArray(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(t, dir, "2026-04-01.jsonl",
+		[]contracts.UsageEntry{
+			mkEntry(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "haiku", 1, 1, 0.01),
+			mkEntry(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "sonnet", 1, 1, 0.05),
+		}, false)
+
+	var buf bytes.Buffer
+	if err := Export(dir, ExportOptions{Format: ExportFormatJSON}, &buf); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	var entries []contracts.UsageEntry
+	if err := json.Unmarshal(buf.Bytes(), &entries); err != nil {
+		t.Fatalf("output not valid JSON: %v\n%s", err, buf.String())
+	}
+	if len(entries) != 2 {
+		t.Errorf("entries = %d, want 2", len(entries))
+	}
+}
+
+func TestAggregate_groupByDay_dropsPerCallFields(t *testing.T) {
+	dir := t.TempDir()
+	day := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	writeJSONL(t, dir, "2026-04-01.jsonl",
+		[]contracts.UsageEntry{
+			mkEntry(day, "haiku", 100, 50, 0.01),
+			mkEntry(day, "haiku", 200, 100, 0.02),
+			mkEntry(day.Add(24*time.Hour), "haiku", 300, 150, 0.03),
+		}, false)
+	writeJSONL(t, dir, "2026-04-02.jsonl",
+		[]contracts.UsageEntry{
+			mkEntry(day.Add(24*time.Hour), "sonnet", 100, 50, 0.10),
+		}, false)
+
+	buckets, err := Aggregate(dir, AggregateOptions{GroupBy: GroupDay})
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	if len(buckets) != 3 {
+		t.Fatalf("buckets = %d, want 3 (4-01 haiku, 4-02 haiku, 4-02 sonnet)", len(buckets))
+	}
+	// First bucket should be the 4-01 haiku rollup with 2 calls.
+	if buckets[0].Period != "2026-04-01" || buckets[0].Calls != 2 || buckets[0].TotalTokens != 450 {
+		t.Errorf("bucket[0] = %+v", buckets[0])
+	}
+}
+
+func TestAggregate_groupByProvider_isCoarsest(t *testing.T) {
+	dir := t.TempDir()
+	day := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	writeJSONL(t, dir, "2026-04-01.jsonl",
+		[]contracts.UsageEntry{
+			mkEntry(day, "haiku", 100, 50, 0.01),
+			mkEntry(day, "sonnet", 200, 100, 0.05),
+		}, false)
+
+	buckets, err := Aggregate(dir, AggregateOptions{GroupBy: GroupProvider})
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	if len(buckets) != 1 {
+		t.Fatalf("buckets = %d, want 1 (single provider)", len(buckets))
+	}
+	if buckets[0].Provider != "anthropic" || buckets[0].Calls != 2 {
+		t.Errorf("bucket = %+v", buckets[0])
+	}
+	if buckets[0].Model != "" || buckets[0].Period != "" {
+		t.Errorf("provider bucket leaked finer fields: %+v", buckets[0])
+	}
+}
+
+func TestDashboard_isSelfContained(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(t, dir, "2026-04-01.jsonl",
+		[]contracts.UsageEntry{mkEntry(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "haiku", 100, 50, 0.01)},
+		false)
+
+	var buf bytes.Buffer
+	if err := Dashboard(dir, DashboardOptions{}, &buf); err != nil {
+		t.Fatalf("Dashboard: %v", err)
+	}
+	html := buf.String()
+	if !strings.HasPrefix(html, "<!DOCTYPE html>") {
+		t.Errorf("not an HTML document: %q", html[:80])
+	}
+	for _, forbidden := range []string{"<script src=", "<link rel=\"stylesheet\""} {
+		if strings.Contains(html, forbidden) {
+			t.Errorf("dashboard references external asset %q", forbidden)
+		}
+	}
+	if !strings.Contains(html, "haiku") {
+		t.Error("dashboard missing entry data")
+	}
+}
+
+func TestRunCLI_unknownSubcommand(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	err := RunCLI(context.Background(), []string{"bogus"}, &out, &errBuf)
+	if err == nil {
+		t.Error("expected error for unknown subcommand")
+	}
+}
+
+func TestRunCLI_helpPrintsUsage(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if err := RunCLI(context.Background(), []string{}, &out, &errBuf); err != nil {
+		t.Fatalf("RunCLI: %v", err)
+	}
+	if !strings.Contains(out.String(), "purge") || !strings.Contains(out.String(), "dashboard") {
+		t.Errorf("usage missing subcommands: %q", out.String())
+	}
+}

--- a/internal/usage/dashboard.go
+++ b/internal/usage/dashboard.go
@@ -1,0 +1,196 @@
+package usage
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"html/template"
+	"io"
+	"os"
+	"time"
+)
+
+// DashboardOptions controls the dashboard date range. Output is always a
+// single self-contained HTML file with no external assets.
+type DashboardOptions struct {
+	From time.Time
+	To   time.Time
+}
+
+// Dashboard renders aggregate buckets to a self-contained HTML page on out.
+// The page embeds its data as inline JSON and uses no external scripts or
+// styles — viewable offline, safe to attach to expense reports.
+func Dashboard(dir string, opts DashboardOptions, out io.Writer) error {
+	dayBuckets, err := Aggregate(dir, AggregateOptions{From: opts.From, To: opts.To, GroupBy: GroupDay})
+	if err != nil {
+		return err
+	}
+	modelBuckets, err := Aggregate(dir, AggregateOptions{From: opts.From, To: opts.To, GroupBy: GroupModel})
+	if err != nil {
+		return err
+	}
+	providerBuckets, err := Aggregate(dir, AggregateOptions{From: opts.From, To: opts.To, GroupBy: GroupProvider})
+	if err != nil {
+		return err
+	}
+
+	var totalCost float64
+	var totalCalls, totalTokens int
+	for _, b := range dayBuckets {
+		totalCost += b.CostUSD
+		totalCalls += b.Calls
+		totalTokens += b.TotalTokens
+	}
+
+	dayJSON, _ := json.Marshal(dayBuckets)
+	modelJSON, _ := json.Marshal(modelBuckets)
+	providerJSON, _ := json.Marshal(providerBuckets)
+
+	data := struct {
+		Generated      string
+		From, To       string
+		TotalCost      string
+		TotalCalls     int
+		TotalTokens    int
+		ByDayJSON      template.JS
+		ByModelJSON    template.JS
+		ByProviderJSON template.JS
+	}{
+		Generated:      time.Now().UTC().Format(time.RFC3339),
+		From:           rangeLabel(opts.From),
+		To:             rangeLabel(opts.To),
+		TotalCost:      fmt.Sprintf("$%.4f", totalCost),
+		TotalCalls:     totalCalls,
+		TotalTokens:    totalTokens,
+		ByDayJSON:      template.JS(dayJSON),
+		ByModelJSON:    template.JS(modelJSON),
+		ByProviderJSON: template.JS(providerJSON),
+	}
+	return dashboardTemplate.Execute(out, data)
+}
+
+func rangeLabel(t time.Time) string {
+	if t.IsZero() {
+		return "all"
+	}
+	return t.Format("2006-01-02")
+}
+
+func runDashboard(args []string, stdout, stderr io.Writer, dir string) error {
+	fs := flag.NewFlagSet("usage dashboard", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	from := fs.String("from", "", "include entries on/after this date (YYYY-MM-DD, UTC)")
+	to := fs.String("to", "", "include entries strictly before this date (YYYY-MM-DD, UTC)")
+	outPath := fs.String("out", "", "write to this HTML file (default: stdout)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	opts := DashboardOptions{}
+	if *from != "" {
+		t, err := time.Parse("2006-01-02", *from)
+		if err != nil {
+			return fmt.Errorf("usage dashboard: --from must be YYYY-MM-DD: %w", err)
+		}
+		opts.From = t.UTC()
+	}
+	if *to != "" {
+		t, err := time.Parse("2006-01-02", *to)
+		if err != nil {
+			return fmt.Errorf("usage dashboard: --to must be YYYY-MM-DD: %w", err)
+		}
+		opts.To = t.UTC()
+	}
+
+	out := stdout
+	if *outPath != "" {
+		f, err := os.Create(*outPath)
+		if err != nil {
+			return fmt.Errorf("usage dashboard: create output: %w", err)
+		}
+		defer f.Close()
+		out = f
+	}
+	if err := Dashboard(dir, opts, out); err != nil {
+		return err
+	}
+	if *outPath != "" {
+		fmt.Fprintf(stdout, "wrote dashboard to %s\n", *outPath)
+	}
+	return nil
+}
+
+var dashboardTemplate = template.Must(template.New("dashboard").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Conduit usage report</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 14px/1.4 system-ui, sans-serif; margin: 2rem; max-width: 960px; }
+  h1 { margin-bottom: .25rem; }
+  .meta { color: #666; margin-bottom: 1.5rem; font-size: .9em; }
+  .cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; margin-bottom: 2rem; }
+  .card { padding: 1rem; border: 1px solid #8884; border-radius: 8px; }
+  .card h2 { margin: 0 0 .25rem; font-size: .85em; color: #888; font-weight: 500; text-transform: uppercase; letter-spacing: .04em; }
+  .card .value { font-size: 1.6em; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 2rem; }
+  th, td { text-align: left; padding: .35rem .5rem; border-bottom: 1px solid #8884; }
+  th { font-size: .8em; text-transform: uppercase; letter-spacing: .04em; color: #888; font-weight: 500; }
+  td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  section { margin-bottom: 2rem; }
+  h2.section { font-size: 1em; text-transform: uppercase; letter-spacing: .04em; color: #888; margin-bottom: .5rem; }
+  footer { color: #888; font-size: .8em; border-top: 1px solid #8884; padding-top: 1rem; }
+</style>
+</head>
+<body>
+<h1>Conduit usage</h1>
+<div class="meta">Generated {{.Generated}} · range {{.From}} → {{.To}} · all data local, no telemetry</div>
+
+<div class="cards">
+  <div class="card"><h2>Total cost</h2><div class="value">{{.TotalCost}}</div></div>
+  <div class="card"><h2>Calls</h2><div class="value">{{.TotalCalls}}</div></div>
+  <div class="card"><h2>Tokens</h2><div class="value">{{.TotalTokens}}</div></div>
+</div>
+
+<section><h2 class="section">By provider</h2><table id="byProvider"><thead><tr><th>Provider</th><th class="num">Calls</th><th class="num">Tokens</th><th class="num">Cost (USD)</th></tr></thead><tbody></tbody></table></section>
+<section><h2 class="section">By model</h2><table id="byModel"><thead><tr><th>Provider</th><th>Model</th><th class="num">Calls</th><th class="num">Tokens</th><th class="num">Cost (USD)</th></tr></thead><tbody></tbody></table></section>
+<section><h2 class="section">By day</h2><table id="byDay"><thead><tr><th>Date</th><th>Provider</th><th>Model</th><th class="num">Calls</th><th class="num">Tokens</th><th class="num">Cost (USD)</th></tr></thead><tbody></tbody></table></section>
+
+<footer>conduit usage dashboard · stored at ~/.conduit/logs/usage · run <code>conduit usage purge --before YYYY-MM-DD --yes</code> to delete history</footer>
+
+<script>
+const data = {
+  byDay: {{.ByDayJSON}},
+  byModel: {{.ByModelJSON}},
+  byProvider: {{.ByProviderJSON}},
+};
+const usd = (n) => "$" + (n || 0).toFixed(4);
+const num = (n) => (n || 0).toLocaleString();
+function row(cells) {
+  const tr = document.createElement("tr");
+  cells.forEach(([text, isNum]) => {
+    const td = document.createElement("td");
+    td.textContent = text;
+    if (isNum) td.className = "num";
+    tr.appendChild(td);
+  });
+  return tr;
+}
+function fill(id, rows) {
+  const tbody = document.querySelector("#" + id + " tbody");
+  rows.forEach(r => tbody.appendChild(row(r)));
+}
+fill("byProvider", data.byProvider.map(b => [
+  [b.provider || "(unknown)", false], [num(b.calls), true], [num(b.total_tokens), true], [usd(b.cost_usd), true],
+]));
+fill("byModel", data.byModel.map(b => [
+  [b.provider || "", false], [b.model || "", false], [num(b.calls), true], [num(b.total_tokens), true], [usd(b.cost_usd), true],
+]));
+fill("byDay", data.byDay.map(b => [
+  [b.period || "", false], [b.provider || "", false], [b.model || "", false], [num(b.calls), true], [num(b.total_tokens), true], [usd(b.cost_usd), true],
+]));
+</script>
+</body>
+</html>
+`))

--- a/internal/usage/export.go
+++ b/internal/usage/export.go
@@ -1,0 +1,174 @@
+package usage
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// ExportFormat selects the on-disk shape of an export.
+type ExportFormat string
+
+const (
+	ExportFormatCSV  ExportFormat = "csv"
+	ExportFormatJSON ExportFormat = "json"
+)
+
+// ExportOptions controls the date-range filter applied during export.
+// Out is the destination writer; Format selects encoding.
+type ExportOptions struct {
+	From   time.Time
+	To     time.Time
+	Format ExportFormat
+}
+
+// csvHeader is the column order for CSV exports — stable for downstream tooling.
+var csvHeader = []string{
+	"timestamp", "session_id", "provider", "model",
+	"tokens_in", "tokens_out", "total_tokens",
+	"ttft_ms", "total_ms", "tokens_per_sec",
+	"status", "error_type", "feature", "plugin",
+	"cost_usd", "cost_currency", "cost_estimated", "cost_source",
+}
+
+// Export streams entries from dir matching opts to out.
+func Export(dir string, opts ExportOptions, out io.Writer) error {
+	switch opts.Format {
+	case ExportFormatCSV:
+		return exportCSV(dir, opts, out)
+	case ExportFormatJSON:
+		return exportJSON(dir, opts, out)
+	default:
+		return fmt.Errorf("usage export: unknown format %q (want csv or json)", opts.Format)
+	}
+}
+
+func exportCSV(dir string, opts ExportOptions, out io.Writer) error {
+	w := csv.NewWriter(out)
+	if err := w.Write(csvHeader); err != nil {
+		return err
+	}
+	err := ScanAll(dir, func(e contracts.UsageEntry) bool {
+		if !inRange(e.Timestamp, opts) {
+			return true
+		}
+		_ = w.Write(csvRow(e))
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	w.Flush()
+	return w.Error()
+}
+
+func csvRow(e contracts.UsageEntry) []string {
+	return []string{
+		e.Timestamp.UTC().Format(time.RFC3339),
+		e.SessionID,
+		e.Provider,
+		e.Model,
+		strconv.Itoa(e.TokensIn),
+		strconv.Itoa(e.TokensOut),
+		strconv.Itoa(e.TotalTokens),
+		strconv.FormatInt(e.TTFMS, 10),
+		strconv.FormatInt(e.TotalMS, 10),
+		strconv.FormatFloat(e.TokensPerSecond, 'f', 3, 64),
+		e.Status,
+		e.ErrorType,
+		e.Feature,
+		e.Plugin,
+		strconv.FormatFloat(e.CostUSD, 'f', 6, 64),
+		e.CostCurrency,
+		strconv.FormatBool(e.CostEstimated),
+		e.CostSource,
+	}
+}
+
+func exportJSON(dir string, opts ExportOptions, out io.Writer) error {
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	if _, err := io.WriteString(out, "[\n"); err != nil {
+		return err
+	}
+	first := true
+	err := ScanAll(dir, func(e contracts.UsageEntry) bool {
+		if !inRange(e.Timestamp, opts) {
+			return true
+		}
+		if !first {
+			_, _ = io.WriteString(out, ",\n")
+		}
+		first = false
+		// Inline encode without trailing newline so commas land cleanly.
+		buf, mErr := json.MarshalIndent(e, "  ", "  ")
+		if mErr != nil {
+			return true
+		}
+		_, _ = io.WriteString(out, "  ")
+		_, _ = out.Write(buf)
+		return true
+	})
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(out, "\n]\n")
+	_ = enc // reserved for future streaming variants
+	return err
+}
+
+func inRange(ts time.Time, opts ExportOptions) bool {
+	if !opts.From.IsZero() && ts.Before(opts.From) {
+		return false
+	}
+	if !opts.To.IsZero() && !ts.Before(opts.To) {
+		return false
+	}
+	return true
+}
+
+func runExport(args []string, stdout, stderr io.Writer, dir string) error {
+	fs := flag.NewFlagSet("usage export", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	format := fs.String("format", "csv", "output format: csv or json")
+	from := fs.String("from", "", "include entries on/after this date (YYYY-MM-DD, UTC)")
+	to := fs.String("to", "", "include entries strictly before this date (YYYY-MM-DD, UTC)")
+	outPath := fs.String("out", "", "write to this file (default: stdout)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	opts := ExportOptions{Format: ExportFormat(*format)}
+	if *from != "" {
+		t, err := time.Parse("2006-01-02", *from)
+		if err != nil {
+			return fmt.Errorf("usage export: --from must be YYYY-MM-DD: %w", err)
+		}
+		opts.From = t.UTC()
+	}
+	if *to != "" {
+		t, err := time.Parse("2006-01-02", *to)
+		if err != nil {
+			return fmt.Errorf("usage export: --to must be YYYY-MM-DD: %w", err)
+		}
+		opts.To = t.UTC()
+	}
+
+	out := stdout
+	if *outPath != "" {
+		f, err := os.Create(*outPath)
+		if err != nil {
+			return fmt.Errorf("usage export: create output: %w", err)
+		}
+		defer f.Close()
+		out = f
+	}
+	return Export(dir, opts, out)
+}

--- a/internal/usage/purge.go
+++ b/internal/usage/purge.go
@@ -1,0 +1,143 @@
+package usage
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// PurgeOptions selects which usage entries to delete. At least one of Before
+// or Model must be set — unscoped purges are intentionally unsupported.
+type PurgeOptions struct {
+	Before time.Time // delete entries strictly before this UTC instant
+	Model  string    // case-insensitive exact match on entry.Model
+	DryRun bool      // count what would be removed but write nothing
+}
+
+// PurgeReport summarizes a purge across all log files.
+type PurgeReport struct {
+	Files   []RewriteResult
+	Kept    int
+	Dropped int
+}
+
+// Purge applies opts across every log file in dir. Returns the rollup report.
+func Purge(dir string, opts PurgeOptions) (PurgeReport, error) {
+	if opts.Before.IsZero() && opts.Model == "" {
+		return PurgeReport{}, fmt.Errorf("usage purge: --before or --model is required")
+	}
+
+	logs, err := ListLogs(dir)
+	if err != nil {
+		return PurgeReport{}, err
+	}
+
+	keep := matcher(opts)
+	var report PurgeReport
+	for _, log := range logs {
+		if opts.DryRun {
+			var kept, dropped int
+			if err := ScanLog(log, func(e contracts.UsageEntry) bool {
+				if keep(e) {
+					kept++
+				} else {
+					dropped++
+				}
+				return true
+			}); err != nil {
+				return report, err
+			}
+			report.Files = append(report.Files, RewriteResult{Path: log.Path, Kept: kept, Dropped: dropped})
+			report.Kept += kept
+			report.Dropped += dropped
+			continue
+		}
+
+		res, err := RewriteLog(log, keep)
+		if err != nil {
+			return report, err
+		}
+		report.Files = append(report.Files, res)
+		report.Kept += res.Kept
+		report.Dropped += res.Dropped
+	}
+	return report, nil
+}
+
+// matcher returns true for entries that should be kept (i.e. NOT purged).
+func matcher(opts PurgeOptions) func(contracts.UsageEntry) bool {
+	model := strings.ToLower(strings.TrimSpace(opts.Model))
+	return func(e contracts.UsageEntry) bool {
+		if !opts.Before.IsZero() && e.Timestamp.Before(opts.Before) {
+			return false
+		}
+		if model != "" && strings.EqualFold(e.Model, model) {
+			return false
+		}
+		return true
+	}
+}
+
+func runPurge(args []string, stdout, stderr io.Writer, dir string) error {
+	fs := flag.NewFlagSet("usage purge", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	beforeStr := fs.String("before", "", "delete entries before this date (YYYY-MM-DD, UTC)")
+	model := fs.String("model", "", "delete entries matching this model exactly")
+	dryRun := fs.Bool("dry-run", false, "report what would be deleted without changing files")
+	yes := fs.Bool("yes", false, "skip confirmation prompt (required for non-dry-run)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	opts := PurgeOptions{Model: *model, DryRun: *dryRun}
+	if *beforeStr != "" {
+		t, err := time.Parse("2006-01-02", *beforeStr)
+		if err != nil {
+			return fmt.Errorf("usage purge: --before must be YYYY-MM-DD: %w", err)
+		}
+		opts.Before = t.UTC()
+	}
+	if opts.Before.IsZero() && opts.Model == "" {
+		return fmt.Errorf("usage purge: at least one of --before or --model is required")
+	}
+	if !opts.DryRun && !*yes {
+		return fmt.Errorf("usage purge: refusing destructive purge without --yes (run with --dry-run to preview)")
+	}
+
+	report, err := Purge(dir, opts)
+	if err != nil {
+		return err
+	}
+	printPurgeReport(stdout, report, opts)
+	return nil
+}
+
+func printPurgeReport(w io.Writer, report PurgeReport, opts PurgeOptions) {
+	verb := "removed"
+	if opts.DryRun {
+		verb = "would remove"
+	}
+	fmt.Fprintf(w, "%s %d entr%s across %d file(s); kept %d.\n",
+		verb, report.Dropped, plural(report.Dropped), len(report.Files), report.Kept)
+	for _, f := range report.Files {
+		if f.Dropped == 0 && !f.Removed {
+			continue
+		}
+		marker := ""
+		if f.Removed {
+			marker = " (file deleted)"
+		}
+		fmt.Fprintf(w, "  %s: -%d / kept %d%s\n", f.Path, f.Dropped, f.Kept, marker)
+	}
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}

--- a/internal/usage/report.go
+++ b/internal/usage/report.go
@@ -1,0 +1,215 @@
+package usage
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// AggregateGroup selects how the report buckets entries. Each value is a
+// privacy-vs-utility trade-off — coarser groups leak less but are less useful.
+type AggregateGroup string
+
+const (
+	GroupDay      AggregateGroup = "day"      // (date, provider, model)
+	GroupMonth    AggregateGroup = "month"    // (year-month, provider, model)
+	GroupModel    AggregateGroup = "model"    // (provider, model) only
+	GroupProvider AggregateGroup = "provider" // (provider) only — coarsest
+)
+
+// AggregateOptions parameterises the aggregate report.
+type AggregateOptions struct {
+	From    time.Time
+	To      time.Time
+	GroupBy AggregateGroup
+}
+
+// Bucket is one row of the aggregate report. Bucket fields are intentionally
+// limited to what is needed for expense reporting — no session IDs, no
+// per-call latency, no feature/plugin attribution.
+type Bucket struct {
+	Period      string  `json:"period,omitempty"`   // YYYY-MM-DD or YYYY-MM, empty for non-time groups
+	Provider    string  `json:"provider,omitempty"` // empty when grouping above provider
+	Model       string  `json:"model,omitempty"`    // empty when grouping above model
+	Calls       int     `json:"calls"`
+	TotalTokens int     `json:"total_tokens"`
+	CostUSD     float64 `json:"cost_usd"`
+}
+
+// Aggregate scans dir and returns sorted buckets per opts.GroupBy.
+func Aggregate(dir string, opts AggregateOptions) ([]Bucket, error) {
+	if opts.GroupBy == "" {
+		opts.GroupBy = GroupDay
+	}
+	buckets := map[string]*Bucket{}
+	exportRange := ExportOptions{From: opts.From, To: opts.To}
+
+	err := ScanAll(dir, func(e contracts.UsageEntry) bool {
+		if !inRange(e.Timestamp, exportRange) {
+			return true
+		}
+		key, b := projectBucket(e, opts.GroupBy)
+		existing, ok := buckets[key]
+		if !ok {
+			buckets[key] = &b
+			existing = buckets[key]
+		}
+		existing.Calls++
+		existing.TotalTokens += e.TotalTokens
+		existing.CostUSD += e.CostUSD
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]Bucket, 0, len(buckets))
+	for _, b := range buckets {
+		out = append(out, *b)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Period != out[j].Period {
+			return out[i].Period < out[j].Period
+		}
+		if out[i].Provider != out[j].Provider {
+			return out[i].Provider < out[j].Provider
+		}
+		return out[i].Model < out[j].Model
+	})
+	return out, nil
+}
+
+// projectBucket maps one entry to the (key, fresh-bucket) pair for its group.
+//
+// PRIVACY NOTE: only fields explicitly carried forward end up in the report.
+// Feature, plugin, session_id, error_type and per-call latency are dropped
+// here on purpose — that is the "aggregate-only" guarantee for expense
+// reporting. Adjust grouping with care; finer keys leak more about usage
+// patterns. See README §usage for the rationale.
+func projectBucket(e contracts.UsageEntry, group AggregateGroup) (string, Bucket) {
+	day := e.Timestamp.UTC().Format("2006-01-02")
+	month := e.Timestamp.UTC().Format("2006-01")
+	switch group {
+	case GroupMonth:
+		return month + "|" + e.Provider + "|" + e.Model,
+			Bucket{Period: month, Provider: e.Provider, Model: e.Model}
+	case GroupModel:
+		return e.Provider + "|" + e.Model,
+			Bucket{Provider: e.Provider, Model: e.Model}
+	case GroupProvider:
+		return e.Provider,
+			Bucket{Provider: e.Provider}
+	default: // GroupDay
+		return day + "|" + e.Provider + "|" + e.Model,
+			Bucket{Period: day, Provider: e.Provider, Model: e.Model}
+	}
+}
+
+func runReport(args []string, stdout, stderr io.Writer, dir string) error {
+	fs := flag.NewFlagSet("usage report", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	group := fs.String("group", "day", "aggregation level: day, month, model, provider")
+	from := fs.String("from", "", "include entries on/after this date (YYYY-MM-DD, UTC)")
+	to := fs.String("to", "", "include entries strictly before this date (YYYY-MM-DD, UTC)")
+	asJSON := fs.Bool("json", false, "emit JSON instead of a text table")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	opts := AggregateOptions{GroupBy: AggregateGroup(strings.ToLower(*group))}
+	switch opts.GroupBy {
+	case GroupDay, GroupMonth, GroupModel, GroupProvider:
+	default:
+		return fmt.Errorf("usage report: --group must be one of day,month,model,provider")
+	}
+	if *from != "" {
+		t, err := time.Parse("2006-01-02", *from)
+		if err != nil {
+			return fmt.Errorf("usage report: --from must be YYYY-MM-DD: %w", err)
+		}
+		opts.From = t.UTC()
+	}
+	if *to != "" {
+		t, err := time.Parse("2006-01-02", *to)
+		if err != nil {
+			return fmt.Errorf("usage report: --to must be YYYY-MM-DD: %w", err)
+		}
+		opts.To = t.UTC()
+	}
+
+	buckets, err := Aggregate(dir, opts)
+	if err != nil {
+		return err
+	}
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(buckets)
+	}
+	return printAggregateTable(stdout, buckets, opts.GroupBy)
+}
+
+func printAggregateTable(w io.Writer, buckets []Bucket, group AggregateGroup) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	header := headerFor(group)
+	fmt.Fprintln(tw, strings.Join(header, "\t"))
+	var totalCalls, totalTokens int
+	var totalCost float64
+	for _, b := range buckets {
+		fmt.Fprintln(tw, strings.Join(rowFor(b, group), "\t"))
+		totalCalls += b.Calls
+		totalTokens += b.TotalTokens
+		totalCost += b.CostUSD
+	}
+	footer := append([]string{}, footerLabel(group)...)
+	footer = append(footer,
+		fmt.Sprintf("%d", totalCalls),
+		fmt.Sprintf("%d", totalTokens),
+		fmt.Sprintf("$%.4f", totalCost),
+	)
+	fmt.Fprintln(tw, strings.Join(footer, "\t"))
+	return tw.Flush()
+}
+
+func headerFor(group AggregateGroup) []string {
+	switch group {
+	case GroupModel:
+		return []string{"PROVIDER", "MODEL", "CALLS", "TOKENS", "COST_USD"}
+	case GroupProvider:
+		return []string{"PROVIDER", "CALLS", "TOKENS", "COST_USD"}
+	default: // day, month
+		return []string{"PERIOD", "PROVIDER", "MODEL", "CALLS", "TOKENS", "COST_USD"}
+	}
+}
+
+func footerLabel(group AggregateGroup) []string {
+	switch group {
+	case GroupModel:
+		return []string{"TOTAL", ""}
+	case GroupProvider:
+		return []string{"TOTAL"}
+	default:
+		return []string{"TOTAL", "", ""}
+	}
+}
+
+func rowFor(b Bucket, group AggregateGroup) []string {
+	cost := fmt.Sprintf("$%.4f", b.CostUSD)
+	calls := fmt.Sprintf("%d", b.Calls)
+	tokens := fmt.Sprintf("%d", b.TotalTokens)
+	switch group {
+	case GroupModel:
+		return []string{b.Provider, b.Model, calls, tokens, cost}
+	case GroupProvider:
+		return []string{b.Provider, calls, tokens, cost}
+	default:
+		return []string{b.Period, b.Provider, b.Model, calls, tokens, cost}
+	}
+}

--- a/internal/usage/store.go
+++ b/internal/usage/store.go
@@ -1,0 +1,241 @@
+package usage
+
+import (
+	"bufio"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// LogFile describes one daily usage log on disk.
+type LogFile struct {
+	Path       string
+	Compressed bool
+}
+
+// ListLogs returns daily usage logs (.jsonl and .jsonl.gz) under dir, sorted by name.
+// A missing directory is not an error and returns no files.
+func ListLogs(dir string) ([]LogFile, error) {
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("usage: read log dir: %w", err)
+	}
+	var logs []LogFile
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		switch {
+		case strings.HasSuffix(name, ".jsonl"):
+			logs = append(logs, LogFile{Path: filepath.Join(dir, name)})
+		case strings.HasSuffix(name, ".jsonl.gz"):
+			logs = append(logs, LogFile{Path: filepath.Join(dir, name), Compressed: true})
+		}
+	}
+	sort.Slice(logs, func(i, j int) bool { return logs[i].Path < logs[j].Path })
+	return logs, nil
+}
+
+// openReader returns a reader for a log file, transparently decompressing .gz.
+// Callers must close both the returned ReadCloser and the underlying file.
+func openReader(log LogFile) (io.ReadCloser, error) {
+	f, err := os.Open(log.Path)
+	if err != nil {
+		return nil, err
+	}
+	if !log.Compressed {
+		return f, nil
+	}
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		f.Close()
+		return nil, fmt.Errorf("usage: gzip reader %s: %w", log.Path, err)
+	}
+	return &gzipReadCloser{gz: gz, file: f}, nil
+}
+
+type gzipReadCloser struct {
+	gz   *gzip.Reader
+	file *os.File
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) { return g.gz.Read(p) }
+func (g *gzipReadCloser) Close() error {
+	gzErr := g.gz.Close()
+	fileErr := g.file.Close()
+	if gzErr != nil {
+		return gzErr
+	}
+	return fileErr
+}
+
+// ScanLog calls fn for each entry in log. Returning false from fn stops iteration.
+// Malformed lines are skipped silently; corruption shouldn't break user reports.
+func ScanLog(log LogFile, fn func(contracts.UsageEntry) bool) error {
+	r, err := openReader(log)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var entry contracts.UsageEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		if !fn(entry) {
+			return nil
+		}
+	}
+	return scanner.Err()
+}
+
+// ScanAll iterates every entry across every log file in dir.
+func ScanAll(dir string, fn func(contracts.UsageEntry) bool) error {
+	logs, err := ListLogs(dir)
+	if err != nil {
+		return err
+	}
+	for _, log := range logs {
+		stop := false
+		if err := ScanLog(log, func(e contracts.UsageEntry) bool {
+			if !fn(e) {
+				stop = true
+				return false
+			}
+			return true
+		}); err != nil {
+			return err
+		}
+		if stop {
+			return nil
+		}
+	}
+	return nil
+}
+
+// RewriteResult reports how many entries were kept and dropped from one file.
+type RewriteResult struct {
+	Path    string
+	Kept    int
+	Dropped int
+	Removed bool // true if the file was deleted because no entries remained
+}
+
+// RewriteLog atomically rewrites a log, keeping only entries for which keep returns true.
+// Files are written to a sibling .tmp and renamed; the format (.jsonl vs .gz) is preserved.
+// If every entry is dropped, the file is removed entirely.
+func RewriteLog(log LogFile, keep func(contracts.UsageEntry) bool) (RewriteResult, error) {
+	result := RewriteResult{Path: log.Path}
+
+	r, err := openReader(log)
+	if err != nil {
+		return result, err
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(log.Path), filepath.Base(log.Path)+".tmp-*")
+	if err != nil {
+		r.Close()
+		return result, fmt.Errorf("usage: create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	var writer io.Writer = tmp
+	var gzWriter *gzip.Writer
+	if log.Compressed {
+		gzWriter = gzip.NewWriter(tmp)
+		writer = gzWriter
+	}
+
+	cleanup := func() {
+		if gzWriter != nil {
+			_ = gzWriter.Close()
+		}
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		raw := scanner.Bytes()
+		if len(raw) == 0 {
+			continue
+		}
+		var entry contracts.UsageEntry
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			// Preserve malformed lines verbatim — never silently drop user data on parse error.
+			line := append([]byte{}, raw...)
+			line = append(line, '\n')
+			if _, err := writer.Write(line); err != nil {
+				cleanup()
+				r.Close()
+				return result, fmt.Errorf("usage: write malformed line: %w", err)
+			}
+			result.Kept++
+			continue
+		}
+		if !keep(entry) {
+			result.Dropped++
+			continue
+		}
+		line := append(raw, '\n')
+		if _, err := writer.Write(line); err != nil {
+			cleanup()
+			r.Close()
+			return result, fmt.Errorf("usage: write entry: %w", err)
+		}
+		result.Kept++
+	}
+	if err := scanner.Err(); err != nil {
+		cleanup()
+		r.Close()
+		return result, fmt.Errorf("usage: scan log: %w", err)
+	}
+	r.Close()
+
+	if gzWriter != nil {
+		if err := gzWriter.Close(); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+			return result, fmt.Errorf("usage: finalize gzip: %w", err)
+		}
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return result, fmt.Errorf("usage: close temp file: %w", err)
+	}
+
+	if result.Kept == 0 {
+		_ = os.Remove(tmpPath)
+		if err := os.Remove(log.Path); err != nil && !os.IsNotExist(err) {
+			return result, fmt.Errorf("usage: remove emptied log: %w", err)
+		}
+		result.Removed = true
+		return result, nil
+	}
+
+	if err := os.Rename(tmpPath, log.Path); err != nil {
+		_ = os.Remove(tmpPath)
+		return result, fmt.Errorf("usage: replace log: %w", err)
+	}
+	return result, nil
+}


### PR DESCRIPTION
## Summary
- `conduit usage purge --before <date> | --model <name>` with `--dry-run` and required `--yes` for destructive runs; preserves gzipped logs via atomic temp-file rewrite
- `conduit usage export --format csv|json --from --to --out` for raw analysis
- `conduit usage report --group day|month|model|provider [--json]` — aggregate-only buckets that structurally drop session ID, feature, plugin, and per-call latency
- `conduit usage dashboard --out report.html` — self-contained HTML (inline data, no CDN, no external assets) suitable for attaching to expense reports

All commands operate on `~/.conduit/logs/usage` and never touch the network.

Closes #120

## Test plan
- [x] `go test ./...` — full suite green
- [x] `go vet ./...` — clean
- [x] Smoke test: report + purge --dry-run against a temp HOME with sample JSONL
- [x] Purge handles `.jsonl.gz` files (round-trips through gzip on rewrite)
- [x] Dashboard contains no `<script src=` or `<link rel="stylesheet"`
- [x] `--yes` gate blocks destructive purges at the CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)