### PR TITLE
feat(#36): TUI workflow status display

### DIFF
--- a/internal/tui/workflow_status.go
+++ b/internal/tui/workflow_status.go
@@ -1,0 +1,193 @@
+// Package tui — workflow status view.
+//
+// This file renders a numbered list of workflow steps with their status,
+// per-step cost, and per-step duration. It is intentionally decoupled from
+// the (in-progress) `internal/workflow` package: the view consumes a small
+// local interface (StepView / WorkflowStatus) so it can compile and be tested
+// before the foundational workflow types land. After those types ship, an
+// adapter in the workflow package can satisfy these interfaces.
+//
+// Issue: #36 — PRD §19 Phase 3.
+package tui
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// StepStatus values are declared in context_panel.go: StepPending,
+// StepRunning, StepDone, StepFailed. We reuse them here so the workflow
+// surface is consistent across the context panel and the dedicated status
+// view, and so this file does not duplicate those declarations.
+
+// StepView is the minimal contract the status renderer needs from a step.
+// Defined locally so this package does not depend on the unfinished
+// internal/workflow package (issue #33).
+type StepView interface {
+	Name() string
+	Status() StepStatus
+	// CostUSD returns the cost in USD spent on this step. Zero means "no cost
+	// yet" and is omitted from the rendered line.
+	CostUSD() float64
+	// Duration returns the elapsed time for this step. Zero means "not yet
+	// timed" and is omitted from the rendered line.
+	Duration() time.Duration
+}
+
+// WorkflowStatus is the minimal contract for a workflow's view state.
+type WorkflowStatus interface {
+	Steps() []StepView
+	// CurrentStep is the 0-based index of the active step, or -1 if no step
+	// is currently running (e.g. the workflow has not started or is done).
+	CurrentStep() int
+}
+
+// ANSI escape codes. Kept local so we don't pull in a TUI library — matches
+// the hand-rolled ANSI style of the rest of internal/tui.
+const (
+	ansiReset = "\x1b[0m"
+	ansiBold  = "\x1b[1m"
+	ansiRed   = "\x1b[31m"
+	ansiGreen = "\x1b[32m"
+	ansiCyan  = "\x1b[36m"
+	ansiDim   = "\x1b[2m"
+)
+
+// statusGlyph returns the icon + ANSI styling envelope for a given status.
+// The current/highlighted step is rendered bold cyan when running.
+func statusGlyph(s StepStatus) string {
+	switch s {
+	case StepRunning:
+		return ansiBold + ansiCyan + "▶" + ansiReset // ▶
+	case StepDone:
+		return ansiGreen + "●" + ansiReset // ●
+	case StepFailed:
+		return ansiRed + "✕" + ansiReset // ✕
+	case StepPending:
+		fallthrough
+	default:
+		return ansiDim + "○" + ansiReset // ○
+	}
+}
+
+// formatDuration renders a duration as a compact human-readable string.
+//
+//	1.5ns   -> "0ms"
+//	450ms   -> "450ms"
+//	1.25s   -> "1.2s"
+//	75s     -> "1m15s"
+//	3725s   -> "1h2m"
+//
+// Anything zero or negative renders as the empty string so the caller can
+// elide the field entirely.
+func formatDuration(d time.Duration) string {
+	if d <= 0 {
+		return ""
+	}
+	if d < time.Second {
+		ms := d / time.Millisecond
+		return fmt.Sprintf("%dms", ms)
+	}
+	if d < time.Minute {
+		// e.g. 1.2s
+		secs := float64(d) / float64(time.Second)
+		return fmt.Sprintf("%.1fs", secs)
+	}
+	if d < time.Hour {
+		m := int(d / time.Minute)
+		s := int((d % time.Minute) / time.Second)
+		return fmt.Sprintf("%dm%ds", m, s)
+	}
+	h := int(d / time.Hour)
+	m := int((d % time.Hour) / time.Minute)
+	return fmt.Sprintf("%dh%dm", h, m)
+}
+
+// formatCost renders a cost as "$0.0123". Matches the style used by
+// formatStatusBar in app.go (4 decimal places). Zero costs return "" so the
+// caller can omit the field.
+func formatCost(usd float64) string {
+	if usd <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("$%.4f", usd)
+}
+
+// WorkflowStatusView renders a WorkflowStatus to a writer.
+//
+// Output format (one line per step):
+//
+//  1. step name [icon] $0.0123 1.2s
+//
+// The current step is highlighted bold-cyan via the icon and name.
+// Empty cost and empty duration are omitted (no trailing whitespace).
+type WorkflowStatusView struct {
+	// NoColor disables ANSI escape codes. Useful for plain logs / CI / tests.
+	NoColor bool
+}
+
+// Render writes the status block for w to out.
+func (v WorkflowStatusView) Render(out io.Writer, w WorkflowStatus) error {
+	if w == nil {
+		return nil
+	}
+	steps := w.Steps()
+	current := w.CurrentStep()
+
+	var b strings.Builder
+	for i, s := range steps {
+		isCurrent := i == current && s.Status() == StepRunning
+		icon := statusGlyph(s.Status())
+		name := s.Name()
+		if isCurrent {
+			name = ansiBold + ansiCyan + name + ansiReset
+		}
+
+		line := fmt.Sprintf("%d. %s %s", i+1, icon, name)
+
+		if c := formatCost(s.CostUSD()); c != "" {
+			line += " " + c
+		}
+		if d := formatDuration(s.Duration()); d != "" {
+			line += " " + d
+		}
+
+		if v.NoColor {
+			line = stripANSI(line)
+		}
+
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+
+	_, err := io.WriteString(out, b.String())
+	return err
+}
+
+// stripANSI removes CSI escape sequences (ESC [ ... letter) from s.
+// Conservative: handles the small set of escapes statusGlyph emits.
+func stripANSI(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			// Skip until we find a letter (final byte of CSI sequence).
+			j := i + 2
+			for j < len(s) {
+				c := s[j]
+				if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+					j++
+					break
+				}
+				j++
+			}
+			i = j
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}

--- a/internal/tui/workflow_status_test.go
+++ b/internal/tui/workflow_status_test.go
@@ -1,0 +1,212 @@
+package tui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeStep is a test double for the StepView interface.
+type fakeStep struct {
+	name     string
+	status   StepStatus
+	costUSD  float64
+	duration time.Duration
+}
+
+func (s fakeStep) Name() string            { return s.name }
+func (s fakeStep) Status() StepStatus      { return s.status }
+func (s fakeStep) CostUSD() float64        { return s.costUSD }
+func (s fakeStep) Duration() time.Duration { return s.duration }
+
+// fakeWorkflow is a test double for the WorkflowStatus interface.
+type fakeWorkflow struct {
+	steps   []StepView
+	current int
+}
+
+func (w fakeWorkflow) Steps() []StepView { return w.steps }
+func (w fakeWorkflow) CurrentStep() int  { return w.current }
+
+func TestFormatDuration(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{0, ""},
+		{-1, ""},
+		{45 * time.Millisecond, "45ms"},
+		{999 * time.Millisecond, "999ms"},
+		{1200 * time.Millisecond, "1.2s"},
+		{59 * time.Second, "59.0s"},
+		{75 * time.Second, "1m15s"},
+		{2*time.Minute + 13*time.Second, "2m13s"},
+		{time.Hour + 2*time.Minute, "1h2m"},
+	}
+	for _, tc := range cases {
+		got := formatDuration(tc.in)
+		if got != tc.want {
+			t.Errorf("formatDuration(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFormatCost(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{0, ""},
+		{-0.5, ""},
+		{0.0123, "$0.0123"},
+		{1.5, "$1.5000"},
+	}
+	for _, tc := range cases {
+		got := formatCost(tc.in)
+		if got != tc.want {
+			t.Errorf("formatCost(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// renderPlain returns the rendered output with ANSI codes stripped, so tests
+// are stable across terminal capabilities.
+func renderPlain(t *testing.T, w WorkflowStatus) string {
+	t.Helper()
+	var buf bytes.Buffer
+	view := WorkflowStatusView{NoColor: true}
+	if err := view.Render(&buf, w); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	return buf.String()
+}
+
+func TestRender_AllStatusKinds(t *testing.T) {
+	wf := fakeWorkflow{
+		current: 2,
+		steps: []StepView{
+			fakeStep{name: "fetch source", status: StepDone, costUSD: 0.0123, duration: 1200 * time.Millisecond},
+			fakeStep{name: "lint", status: StepDone, costUSD: 0.0050, duration: 450 * time.Millisecond},
+			fakeStep{name: "run tests", status: StepRunning, costUSD: 0, duration: 0},
+			fakeStep{name: "deploy", status: StepPending},
+			fakeStep{name: "smoke", status: StepFailed, costUSD: 0.0001, duration: 2*time.Minute + 13*time.Second},
+		},
+	}
+
+	got := renderPlain(t, wf)
+	want := "" +
+		"1. ● fetch source $0.0123 1.2s\n" +
+		"2. ● lint $0.0050 450ms\n" +
+		"3. ▶ run tests\n" +
+		"4. ○ deploy\n" +
+		"5. ✕ smoke $0.0001 2m13s\n"
+
+	if got != want {
+		t.Fatalf("Render mismatch.\n got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestRender_PendingOnly(t *testing.T) {
+	wf := fakeWorkflow{
+		current: -1,
+		steps: []StepView{
+			fakeStep{name: "step a", status: StepPending},
+			fakeStep{name: "step b", status: StepPending},
+		},
+	}
+	got := renderPlain(t, wf)
+	want := "1. ○ step a\n2. ○ step b\n"
+	if got != want {
+		t.Fatalf("Render mismatch.\n got:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestRender_NilWorkflowIsNoop(t *testing.T) {
+	var buf bytes.Buffer
+	view := WorkflowStatusView{}
+	if err := view.Render(&buf, nil); err != nil {
+		t.Fatalf("Render(nil): %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output for nil workflow, got %q", buf.String())
+	}
+}
+
+func TestRender_EmptySteps(t *testing.T) {
+	wf := fakeWorkflow{current: -1, steps: nil}
+	got := renderPlain(t, wf)
+	if got != "" {
+		t.Fatalf("expected empty output for no steps, got %q", got)
+	}
+}
+
+func TestRender_ColoredOutputContainsANSI(t *testing.T) {
+	// When NoColor is false (the default), ANSI escapes must appear.
+	wf := fakeWorkflow{
+		current: 0,
+		steps: []StepView{
+			fakeStep{name: "build", status: StepRunning},
+		},
+	}
+	var buf bytes.Buffer
+	view := WorkflowStatusView{}
+	if err := view.Render(&buf, wf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "\x1b[") {
+		t.Fatalf("expected ANSI escape codes in colored output, got %q", out)
+	}
+	// The current running step name should be wrapped in bold+cyan.
+	if !strings.Contains(out, ansiBold+ansiCyan+"build"+ansiReset) {
+		t.Fatalf("expected current step name to be bold-cyan highlighted, got %q", out)
+	}
+	// And the running glyph should be present (highlighted).
+	if !strings.Contains(out, "▶") {
+		t.Fatalf("expected running glyph in output, got %q", out)
+	}
+}
+
+func TestRender_FailedStepIsRed(t *testing.T) {
+	wf := fakeWorkflow{
+		current: -1,
+		steps: []StepView{
+			fakeStep{name: "broken", status: StepFailed, costUSD: 0.01, duration: 30 * time.Millisecond},
+		},
+	}
+	var buf bytes.Buffer
+	if err := (WorkflowStatusView{}).Render(&buf, wf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, ansiRed+"✕"+ansiReset) {
+		t.Fatalf("expected failed glyph wrapped in red ANSI, got %q", out)
+	}
+}
+
+func TestRender_CompletedStepIsGreen(t *testing.T) {
+	wf := fakeWorkflow{
+		current: -1,
+		steps: []StepView{
+			fakeStep{name: "ok", status: StepDone, costUSD: 0.005, duration: time.Second},
+		},
+	}
+	var buf bytes.Buffer
+	if err := (WorkflowStatusView{}).Render(&buf, wf); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, ansiGreen+"●"+ansiReset) {
+		t.Fatalf("expected completed glyph wrapped in green ANSI, got %q", out)
+	}
+}
+
+func TestStripANSI(t *testing.T) {
+	in := ansiBold + ansiCyan + "hello" + ansiReset + " " + ansiRed + "world" + ansiReset
+	got := stripANSI(in)
+	want := "hello world"
+	if got != want {
+		t.Fatalf("stripANSI = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/tui/workflow_status.go` with a `WorkflowStatusView` that renders a numbered step list with status icons, per-step cost, and per-step duration.
- Defines a minimal local `StepView` / `WorkflowStatus` interface so the TUI can compile and ship without depending on the in-flight `internal/workflow` package (issue #33). Adapter from real workflow types to these interfaces is a follow-up after #33 lands.
- Stdlib-only, hand-rolled ANSI matching the existing `internal/tui/` style (no new dependencies).

Closes #36 — PRD §19 Phase 3.

## Sample render

```
1. ● fetch source $0.0123 1.2s
2. ● lint $0.0050 450ms
3. ▶ run tests
4. ○ deploy
5. ✕ smoke $0.0001 2m13s
```

Status icons: pending `○` (dim), running `▶` (bold cyan, current step also bold-cyan), completed `●` (green), failed `✕` (red). Cost uses `$%.4f` to match `formatStatusBar` in `app.go`. Duration uses a compact format: `45ms`, `1.2s`, `2m13s`, `1h2m`. Empty cost / duration fields are omitted.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./internal/tui/...` (11 tests pass; golden-string tests render with `NoColor: true` for stable assertions, plus separate tests assert ANSI escapes are present in colored output)
- [x] `go test ./...` (full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)