### PR TITLE
feat(#33): workflow checkpointing & resume

### DIFF
--- a/internal/workflow/checkpoint.go
+++ b/internal/workflow/checkpoint.go
@@ -1,0 +1,128 @@
+package workflow
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ErrCheckpointNotFound is returned by Checkpointer.Load when no checkpoint
+// exists for the given run ID.
+var ErrCheckpointNotFound = errors.New("workflow: checkpoint not found")
+
+// Checkpointer persists and reloads Run state.
+//
+// Implementations must make Save atomic with respect to concurrent readers:
+// after Save returns, a subsequent Load on any goroutine must observe either
+// the previous Run or the freshly written Run, never a partial write.
+type Checkpointer interface {
+	// Save writes run to durable storage keyed by run.ID.
+	Save(run *Run) error
+	// Load reads the Run previously written under runID. If no such Run
+	// exists, Load returns ErrCheckpointNotFound.
+	Load(runID string) (*Run, error)
+}
+
+// FileCheckpointer is a Checkpointer that stores Runs as JSON files in a
+// directory. Each Run is a single file named "<run-id>.json".
+//
+// Save uses the standard tmpfile+rename pattern so a crash during write
+// cannot leave a torn file in place.
+type FileCheckpointer struct {
+	dir string
+}
+
+// NewFileCheckpointer returns a FileCheckpointer rooted at dir. The directory
+// is created if it does not exist.
+func NewFileCheckpointer(dir string) (*FileCheckpointer, error) {
+	if dir == "" {
+		return nil, errors.New("workflow: checkpoint directory must not be empty")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("workflow: create checkpoint dir: %w", err)
+	}
+	return &FileCheckpointer{dir: dir}, nil
+}
+
+// DefaultCheckpointDir returns the standard checkpoint directory under the
+// user's home: ~/.conduit/runs.
+func DefaultCheckpointDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("workflow: resolve home: %w", err)
+	}
+	return filepath.Join(home, ".conduit", "runs"), nil
+}
+
+// Dir returns the directory backing this FileCheckpointer.
+func (c *FileCheckpointer) Dir() string { return c.dir }
+
+// Save writes run to <dir>/<run.ID>.json atomically.
+func (c *FileCheckpointer) Save(run *Run) error {
+	if run == nil {
+		return errors.New("workflow: cannot save nil Run")
+	}
+	if run.ID == "" {
+		return errors.New("workflow: Run.ID must be set before Save")
+	}
+
+	data, err := json.MarshalIndent(run, "", "  ")
+	if err != nil {
+		return fmt.Errorf("workflow: marshal run: %w", err)
+	}
+
+	finalPath := c.pathFor(run.ID)
+	tmp, err := os.CreateTemp(c.dir, run.ID+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("workflow: create temp checkpoint: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	// Best-effort cleanup if anything below fails before rename.
+	cleanup := func() { _ = os.Remove(tmpPath) }
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("workflow: write temp checkpoint: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("workflow: sync temp checkpoint: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("workflow: close temp checkpoint: %w", err)
+	}
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		cleanup()
+		return fmt.Errorf("workflow: rename checkpoint into place: %w", err)
+	}
+	return nil
+}
+
+// Load reads the Run previously written under runID.
+func (c *FileCheckpointer) Load(runID string) (*Run, error) {
+	if runID == "" {
+		return nil, errors.New("workflow: runID must not be empty")
+	}
+	data, err := os.ReadFile(c.pathFor(runID))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrCheckpointNotFound
+		}
+		return nil, fmt.Errorf("workflow: read checkpoint: %w", err)
+	}
+	var run Run
+	if err := json.Unmarshal(data, &run); err != nil {
+		return nil, fmt.Errorf("workflow: decode checkpoint: %w", err)
+	}
+	return &run, nil
+}
+
+func (c *FileCheckpointer) pathFor(runID string) string {
+	return filepath.Join(c.dir, runID+".json")
+}

--- a/internal/workflow/checkpoint_test.go
+++ b/internal/workflow/checkpoint_test.go
@@ -1,0 +1,165 @@
+package workflow
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFileCheckpointerWriteThenRead(t *testing.T) {
+	dir := t.TempDir()
+	cp, err := NewFileCheckpointer(dir)
+	if err != nil {
+		t.Fatalf("NewFileCheckpointer: %v", err)
+	}
+
+	now := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	original := &Run{
+		ID:         "run-1",
+		WorkflowID: "wf-greet",
+		Workflow: Workflow{
+			ID:   "wf-greet",
+			Name: "greet",
+			Steps: []Step{
+				{ID: "s1", Name: "first", Prompt: "hello"},
+				{ID: "s2", Name: "second", Prompt: "world"},
+			},
+			Providers: []string{"primary", "secondary"},
+		},
+		State:       RunStateRunning,
+		CurrentStep: 1,
+		Results: []StepResult{
+			{
+				StepID:      "s1",
+				Provider:    "primary",
+				Output:      "hi",
+				StartedAt:   now,
+				CompletedAt: now.Add(time.Second),
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now.Add(time.Second),
+	}
+
+	if err := cp.Save(original); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// File should land at the canonical path.
+	if _, err := os.Stat(filepath.Join(dir, "run-1.json")); err != nil {
+		t.Fatalf("expected checkpoint file: %v", err)
+	}
+
+	loaded, err := cp.Load("run-1")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.ID != original.ID {
+		t.Errorf("ID = %q, want %q", loaded.ID, original.ID)
+	}
+	if loaded.State != original.State {
+		t.Errorf("State = %q, want %q", loaded.State, original.State)
+	}
+	if loaded.CurrentStep != original.CurrentStep {
+		t.Errorf("CurrentStep = %d, want %d", loaded.CurrentStep, original.CurrentStep)
+	}
+	if len(loaded.Workflow.Steps) != len(original.Workflow.Steps) {
+		t.Fatalf("Steps len = %d, want %d", len(loaded.Workflow.Steps), len(original.Workflow.Steps))
+	}
+	if len(loaded.Workflow.Providers) != 2 || loaded.Workflow.Providers[0] != "primary" {
+		t.Errorf("Providers roundtrip mismatch: %+v", loaded.Workflow.Providers)
+	}
+	if len(loaded.Results) != 1 {
+		t.Fatalf("Results len = %d, want 1", len(loaded.Results))
+	}
+	if got, _ := loaded.Results[0].Output.(string); got != "hi" {
+		t.Errorf("Results[0].Output = %v, want %q", loaded.Results[0].Output, "hi")
+	}
+	if !loaded.UpdatedAt.Equal(original.UpdatedAt) {
+		t.Errorf("UpdatedAt = %v, want %v", loaded.UpdatedAt, original.UpdatedAt)
+	}
+}
+
+func TestFileCheckpointerLoadMissing(t *testing.T) {
+	cp, err := NewFileCheckpointer(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileCheckpointer: %v", err)
+	}
+	_, err = cp.Load("does-not-exist")
+	if !errors.Is(err, ErrCheckpointNotFound) {
+		t.Fatalf("expected ErrCheckpointNotFound, got %v", err)
+	}
+}
+
+func TestFileCheckpointerOverwriteIsAtomic(t *testing.T) {
+	dir := t.TempDir()
+	cp, err := NewFileCheckpointer(dir)
+	if err != nil {
+		t.Fatalf("NewFileCheckpointer: %v", err)
+	}
+
+	run := &Run{ID: "run-x", WorkflowID: "wf"}
+	run.State = RunStatePending
+	if err := cp.Save(run); err != nil {
+		t.Fatalf("Save 1: %v", err)
+	}
+
+	run.State = RunStateCompleted
+	run.CurrentStep = 7
+	if err := cp.Save(run); err != nil {
+		t.Fatalf("Save 2: %v", err)
+	}
+
+	loaded, err := cp.Load("run-x")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.State != RunStateCompleted || loaded.CurrentStep != 7 {
+		t.Errorf("overwrite did not take effect: %+v", loaded)
+	}
+
+	// No leftover .tmp files in the directory.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) == ".tmp" {
+			t.Errorf("leftover temp file: %s", entry.Name())
+		}
+	}
+}
+
+func TestFileCheckpointerRequiresDir(t *testing.T) {
+	if _, err := NewFileCheckpointer(""); err == nil {
+		t.Fatal("expected error for empty dir")
+	}
+}
+
+func TestFileCheckpointerRejectsBadInput(t *testing.T) {
+	cp, err := NewFileCheckpointer(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileCheckpointer: %v", err)
+	}
+	if err := cp.Save(nil); err == nil {
+		t.Fatal("Save(nil) should fail")
+	}
+	if err := cp.Save(&Run{}); err == nil {
+		t.Fatal("Save without ID should fail")
+	}
+	if _, err := cp.Load(""); err == nil {
+		t.Fatal("Load(\"\") should fail")
+	}
+}
+
+func TestDefaultCheckpointDirShape(t *testing.T) {
+	dir, err := DefaultCheckpointDir()
+	if err != nil {
+		t.Fatalf("DefaultCheckpointDir: %v", err)
+	}
+	if filepath.Base(dir) != "runs" || filepath.Base(filepath.Dir(dir)) != ".conduit" {
+		t.Errorf("unexpected default dir shape: %s", dir)
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1,0 +1,252 @@
+package workflow
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ProviderError marks a StepExecutor failure as recoverable via provider
+// failover. The Engine catches errors satisfying this interface (or wrapped
+// with errors.As around *ProviderFailure) and advances to the next provider
+// in the Workflow's chain before retrying the Step.
+type ProviderError interface {
+	error
+	// IsProviderError is the marker. Implementations always return true.
+	IsProviderError() bool
+}
+
+// ProviderFailure is the canonical ProviderError implementation. Callers can
+// construct one with NewProviderFailure or by satisfying ProviderError on
+// their own error type.
+type ProviderFailure struct {
+	// Provider is the failing provider identifier (often a model name).
+	Provider string
+	// Err is the underlying transport or upstream error.
+	Err error
+}
+
+// Error implements error.
+func (p *ProviderFailure) Error() string {
+	if p == nil {
+		return "<nil provider failure>"
+	}
+	if p.Err == nil {
+		return fmt.Sprintf("provider %q failed", p.Provider)
+	}
+	return fmt.Sprintf("provider %q failed: %v", p.Provider, p.Err)
+}
+
+// Unwrap exposes the underlying error for errors.Is/As.
+func (p *ProviderFailure) Unwrap() error { return p.Err }
+
+// IsProviderError marks ProviderFailure as a recoverable failover error.
+func (p *ProviderFailure) IsProviderError() bool { return true }
+
+// NewProviderFailure wraps err as a ProviderFailure attributed to provider.
+func NewProviderFailure(provider string, err error) *ProviderFailure {
+	return &ProviderFailure{Provider: provider, Err: err}
+}
+
+// isProviderError reports whether err is recoverable via provider failover.
+func isProviderError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pe ProviderError
+	if errors.As(err, &pe) {
+		return pe.IsProviderError()
+	}
+	return false
+}
+
+// StepExecutor invokes a model (or other backend) for a single Step.
+//
+// The Engine calls Execute once per provider in the failover chain until a
+// call returns nil error or the chain is exhausted. Implementations should
+// return a ProviderError (typically *ProviderFailure) for recoverable
+// upstream failures and a plain error for terminal failures that should not
+// trigger failover.
+type StepExecutor interface {
+	Execute(ctx context.Context, provider string, step Step) (string, error)
+}
+
+// StepExecutorFunc adapts an ordinary function to StepExecutor.
+type StepExecutorFunc func(ctx context.Context, provider string, step Step) (string, error)
+
+// Execute implements StepExecutor.
+func (f StepExecutorFunc) Execute(ctx context.Context, provider string, step Step) (string, error) {
+	return f(ctx, provider, step)
+}
+
+// nowFunc is the clock used by Engine. Tests may override it for
+// deterministic timestamps.
+type nowFunc func() time.Time
+
+// Engine drives a Workflow to completion, persisting a checkpoint after
+// every Step and handling provider failover on recoverable errors.
+type Engine struct {
+	checkpointer Checkpointer
+	executor     StepExecutor
+	now          nowFunc
+}
+
+// NewEngine returns an Engine that uses checkpointer for durability and
+// executor for Step invocations.
+func NewEngine(checkpointer Checkpointer, executor StepExecutor) *Engine {
+	if checkpointer == nil {
+		panic("workflow: NewEngine requires a non-nil Checkpointer")
+	}
+	if executor == nil {
+		panic("workflow: NewEngine requires a non-nil StepExecutor")
+	}
+	return &Engine{
+		checkpointer: checkpointer,
+		executor:     executor,
+		now:          func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// SetClock overrides the Engine's time source. Intended for tests.
+func (e *Engine) SetClock(now func() time.Time) {
+	if now != nil {
+		e.now = now
+	}
+}
+
+// Start begins a new Run for wf. If runID is empty, a fresh ID is generated.
+// The newly-created Run is checkpointed before any Step executes so that an
+// immediate crash leaves a resumable artifact behind.
+func (e *Engine) Start(ctx context.Context, wf Workflow, runID string) (*Run, error) {
+	if runID == "" {
+		generated, err := newRunID()
+		if err != nil {
+			return nil, fmt.Errorf("workflow: generate run id: %w", err)
+		}
+		runID = generated
+	}
+	now := e.now()
+	run := &Run{
+		ID:          runID,
+		WorkflowID:  wf.ID,
+		Workflow:    wf,
+		State:       RunStatePending,
+		CurrentStep: 0,
+		Results:     []StepResult{},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := e.checkpointer.Save(run); err != nil {
+		return nil, fmt.Errorf("workflow: save initial checkpoint: %w", err)
+	}
+	return e.run(ctx, run)
+}
+
+// Resume reloads the Run identified by runID and continues execution from
+// the next unfinished Step. A Run that is already Completed or Failed is
+// returned as-is without further execution.
+func (e *Engine) Resume(ctx context.Context, runID string) (*Run, error) {
+	run, err := e.checkpointer.Load(runID)
+	if err != nil {
+		return nil, err
+	}
+	switch run.State {
+	case RunStateCompleted, RunStateFailed:
+		return run, nil
+	}
+	return e.run(ctx, run)
+}
+
+// run executes Steps from run.CurrentStep until completion, failure, or
+// context cancellation. The Run is checkpointed after every Step.
+func (e *Engine) run(ctx context.Context, run *Run) (*Run, error) {
+	for run.CurrentStep < len(run.Workflow.Steps) {
+		if err := ctx.Err(); err != nil {
+			return run, err
+		}
+
+		step := run.Workflow.Steps[run.CurrentStep]
+		started := e.now()
+		output, provider, err := e.executeWithFailover(ctx, run.Workflow.Providers, step)
+		completed := e.now()
+
+		result := StepResult{
+			StepID:      step.ID,
+			Provider:    provider,
+			Output:      output,
+			StartedAt:   started,
+			CompletedAt: completed,
+		}
+
+		if err != nil {
+			result.Error = err.Error()
+			run.Results = append(run.Results, result)
+			run.State = RunStateFailed
+			run.LastError = err.Error()
+			run.UpdatedAt = completed
+			if saveErr := e.checkpointer.Save(run); saveErr != nil {
+				return run, fmt.Errorf("workflow: save failure checkpoint: %w (original: %v)", saveErr, err)
+			}
+			return run, err
+		}
+
+		run.Results = append(run.Results, result)
+		run.CurrentStep++
+		run.State = RunStateRunning
+		run.UpdatedAt = completed
+		if run.CurrentStep == len(run.Workflow.Steps) {
+			run.State = RunStateCompleted
+		}
+		if saveErr := e.checkpointer.Save(run); saveErr != nil {
+			return run, fmt.Errorf("workflow: save step checkpoint: %w", saveErr)
+		}
+	}
+
+	if run.State == RunStatePending {
+		// A Workflow with no Steps short-circuits to Completed.
+		run.State = RunStateCompleted
+		run.UpdatedAt = e.now()
+		if err := e.checkpointer.Save(run); err != nil {
+			return run, fmt.Errorf("workflow: save completion checkpoint: %w", err)
+		}
+	}
+	return run, nil
+}
+
+// executeWithFailover invokes step against each provider in turn, advancing
+// on ProviderError until success or chain exhaustion. With an empty chain,
+// the executor is invoked once with provider="" and any error is terminal.
+func (e *Engine) executeWithFailover(ctx context.Context, providers []string, step Step) (string, string, error) {
+	if len(providers) == 0 {
+		out, err := e.executor.Execute(ctx, "", step)
+		return out, "", err
+	}
+
+	var lastErr error
+	for _, provider := range providers {
+		if err := ctx.Err(); err != nil {
+			return "", provider, err
+		}
+		out, err := e.executor.Execute(ctx, provider, step)
+		if err == nil {
+			return out, provider, nil
+		}
+		if !isProviderError(err) {
+			return "", provider, err
+		}
+		lastErr = err
+	}
+	return "", providers[len(providers)-1], fmt.Errorf("workflow: provider chain exhausted: %w", lastErr)
+}
+
+// newRunID returns a 128-bit hex-encoded random identifier. Stdlib only.
+func newRunID() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf[:]), nil
+}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1,0 +1,380 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// recordingExecutor logs each (provider, stepID) call and dispatches to a
+// per-call handler so each test can shape a deterministic scenario.
+type recordingExecutor struct {
+	calls   []callRecord
+	handler func(call callRecord) (string, error)
+}
+
+type callRecord struct {
+	Provider string
+	StepID   string
+	Index    int
+}
+
+func (r *recordingExecutor) Execute(_ context.Context, provider string, step Step) (string, error) {
+	rec := callRecord{Provider: provider, StepID: step.ID, Index: len(r.calls)}
+	r.calls = append(r.calls, rec)
+	if r.handler == nil {
+		return "ok", nil
+	}
+	return r.handler(rec)
+}
+
+func newTestEngine(t *testing.T, exec StepExecutor) (*Engine, Checkpointer) {
+	t.Helper()
+	cp, err := NewFileCheckpointer(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileCheckpointer: %v", err)
+	}
+	eng := NewEngine(cp, exec)
+	// Deterministic clock so timestamps stay stable across CI runners.
+	base := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	tick := 0
+	eng.SetClock(func() time.Time {
+		tick++
+		return base.Add(time.Duration(tick) * time.Second)
+	})
+	return eng, cp
+}
+
+func sampleWorkflow(providers ...string) Workflow {
+	return Workflow{
+		ID:   "wf-1",
+		Name: "sample",
+		Steps: []Step{
+			{ID: "a", Name: "a", Prompt: "do a"},
+			{ID: "b", Name: "b", Prompt: "do b"},
+			{ID: "c", Name: "c", Prompt: "do c"},
+		},
+		Providers: providers,
+	}
+}
+
+func TestEngineStartCompletesAllSteps(t *testing.T) {
+	exec := &recordingExecutor{
+		handler: func(c callRecord) (string, error) {
+			return "out:" + c.StepID, nil
+		},
+	}
+	eng, cp := newTestEngine(t, exec)
+
+	run, err := eng.Start(context.Background(), sampleWorkflow("p1"), "run-happy")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if run.State != RunStateCompleted {
+		t.Fatalf("State = %q, want completed", run.State)
+	}
+	if run.CurrentStep != 3 {
+		t.Errorf("CurrentStep = %d, want 3", run.CurrentStep)
+	}
+	if len(run.Results) != 3 {
+		t.Fatalf("Results len = %d, want 3", len(run.Results))
+	}
+	for i, want := range []string{"out:a", "out:b", "out:c"} {
+		got, _ := run.Results[i].Output.(string)
+		if got != want {
+			t.Errorf("Results[%d].Output = %v, want %q", i, run.Results[i].Output, want)
+		}
+		if run.Results[i].Provider != "p1" {
+			t.Errorf("Results[%d].Provider = %q, want p1", i, run.Results[i].Provider)
+		}
+	}
+
+	loaded, err := cp.Load("run-happy")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.State != RunStateCompleted || len(loaded.Results) != 3 {
+		t.Errorf("checkpoint did not capture completion: %+v", loaded)
+	}
+}
+
+func TestEngineResumePicksUpAtNextStep(t *testing.T) {
+	// First Engine: panic on the third Step to simulate a crash.
+	type stopErr struct{ error }
+	stopper := &recordingExecutor{
+		handler: func(c callRecord) (string, error) {
+			if c.StepID == "c" {
+				return "", stopErr{errors.New("simulated crash")}
+			}
+			return "out:" + c.StepID, nil
+		},
+	}
+	eng1, cp := newTestEngine(t, stopper)
+
+	_, err := eng1.Start(context.Background(), sampleWorkflow(), "run-resume")
+	if err == nil {
+		t.Fatal("Start should have returned the simulated error")
+	}
+
+	// Confirm the on-disk checkpoint sits exactly at the failed step.
+	mid, err := cp.Load("run-resume")
+	if err != nil {
+		t.Fatalf("Load mid: %v", err)
+	}
+	if mid.State != RunStateFailed {
+		t.Errorf("mid State = %q, want failed", mid.State)
+	}
+	if mid.CurrentStep != 2 {
+		t.Errorf("mid CurrentStep = %d, want 2", mid.CurrentStep)
+	}
+	if len(mid.Results) != 3 { // 2 successes + 1 failure record
+		t.Errorf("mid Results len = %d, want 3", len(mid.Results))
+	}
+
+	// To exercise Resume's actual continuation path, repair the checkpoint
+	// to the running state that would exist after step b succeeded.
+	mid.State = RunStateRunning
+	mid.LastError = ""
+	mid.Results = mid.Results[:2]
+	if err := cp.Save(mid); err != nil {
+		t.Fatalf("Save repaired: %v", err)
+	}
+
+	// Second Engine: a fresh executor that succeeds. Resume should only
+	// invoke it for step c.
+	good := &recordingExecutor{
+		handler: func(c callRecord) (string, error) {
+			return "resumed:" + c.StepID, nil
+		},
+	}
+	eng2 := NewEngine(cp, good)
+
+	resumed, err := eng2.Resume(context.Background(), "run-resume")
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if resumed.State != RunStateCompleted {
+		t.Errorf("resumed State = %q, want completed", resumed.State)
+	}
+	if len(good.calls) != 1 {
+		t.Fatalf("expected 1 executor call after resume, got %d (%v)", len(good.calls), good.calls)
+	}
+	if good.calls[0].StepID != "c" {
+		t.Errorf("resume started at step %q, want c", good.calls[0].StepID)
+	}
+	if len(resumed.Results) != 3 {
+		t.Errorf("Results len = %d, want 3", len(resumed.Results))
+	}
+	if got, _ := resumed.Results[2].Output.(string); got != "resumed:c" {
+		t.Errorf("step c output = %v, want resumed:c", resumed.Results[2].Output)
+	}
+}
+
+func TestEngineResumeAlreadyTerminal(t *testing.T) {
+	exec := &recordingExecutor{}
+	eng, cp := newTestEngine(t, exec)
+
+	completed := &Run{
+		ID:          "run-done",
+		WorkflowID:  "wf",
+		Workflow:    sampleWorkflow(),
+		State:       RunStateCompleted,
+		CurrentStep: 3,
+	}
+	if err := cp.Save(completed); err != nil {
+		t.Fatalf("seed checkpoint: %v", err)
+	}
+
+	got, err := eng.Resume(context.Background(), "run-done")
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if got.State != RunStateCompleted {
+		t.Errorf("State = %q, want completed", got.State)
+	}
+	if len(exec.calls) != 0 {
+		t.Errorf("expected no executor calls, got %d", len(exec.calls))
+	}
+}
+
+func TestEngineFailoverAdvancesProviderOnError(t *testing.T) {
+	// p1 always fails with a recoverable ProviderError; p2 succeeds.
+	exec := &recordingExecutor{
+		handler: func(c callRecord) (string, error) {
+			if c.Provider == "p1" {
+				return "", NewProviderFailure("p1", fmt.Errorf("boom on %s", c.StepID))
+			}
+			return "out:" + c.StepID, nil
+		},
+	}
+	eng, cp := newTestEngine(t, exec)
+
+	wf := sampleWorkflow("p1", "p2")
+	run, err := eng.Start(context.Background(), wf, "run-failover")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if run.State != RunStateCompleted {
+		t.Fatalf("State = %q, want completed", run.State)
+	}
+
+	// Each step calls p1 then p2: 3 steps * 2 providers = 6 calls.
+	if len(exec.calls) != 6 {
+		t.Fatalf("expected 6 executor calls, got %d", len(exec.calls))
+	}
+	for i := 0; i < 6; i += 2 {
+		if exec.calls[i].Provider != "p1" {
+			t.Errorf("calls[%d].Provider = %q, want p1", i, exec.calls[i].Provider)
+		}
+		if exec.calls[i+1].Provider != "p2" {
+			t.Errorf("calls[%d].Provider = %q, want p2", i+1, exec.calls[i+1].Provider)
+		}
+	}
+	for i, r := range run.Results {
+		if r.Provider != "p2" {
+			t.Errorf("Results[%d].Provider = %q, want p2", i, r.Provider)
+		}
+	}
+
+	loaded, err := cp.Load("run-failover")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.State != RunStateCompleted {
+		t.Errorf("loaded state = %q, want completed", loaded.State)
+	}
+}
+
+func TestEngineFailoverChainExhaustionFailsRun(t *testing.T) {
+	exec := &recordingExecutor{
+		handler: func(c callRecord) (string, error) {
+			return "", NewProviderFailure(c.Provider, errors.New("upstream down"))
+		},
+	}
+	eng, cp := newTestEngine(t, exec)
+
+	run, err := eng.Start(context.Background(), sampleWorkflow("p1", "p2"), "run-bust")
+	if err == nil {
+		t.Fatal("expected Start to return the chain-exhaustion error")
+	}
+	if run.State != RunStateFailed {
+		t.Errorf("State = %q, want failed", run.State)
+	}
+	if run.LastError == "" {
+		t.Error("LastError should be populated on failure")
+	}
+	// The first Step exhausts the chain; subsequent Steps must not run.
+	if len(exec.calls) != 2 {
+		t.Errorf("expected 2 calls (one per provider), got %d", len(exec.calls))
+	}
+	loaded, err := cp.Load("run-bust")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.State != RunStateFailed {
+		t.Errorf("checkpoint state = %q, want failed", loaded.State)
+	}
+}
+
+func TestEngineNonProviderErrorIsTerminal(t *testing.T) {
+	// A plain error (not ProviderError) must NOT trigger failover.
+	exec := &recordingExecutor{
+		handler: func(c callRecord) (string, error) {
+			return "", errors.New("hard stop")
+		},
+	}
+	eng, _ := newTestEngine(t, exec)
+
+	_, err := eng.Start(context.Background(), sampleWorkflow("p1", "p2"), "run-hard")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if len(exec.calls) != 1 {
+		t.Errorf("expected single call (no failover), got %d", len(exec.calls))
+	}
+}
+
+func TestEngineNoProvidersStillRuns(t *testing.T) {
+	exec := &recordingExecutor{
+		handler: func(c callRecord) (string, error) { return "ok:" + c.StepID, nil },
+	}
+	eng, _ := newTestEngine(t, exec)
+
+	run, err := eng.Start(context.Background(), sampleWorkflow(), "run-noprov")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if run.State != RunStateCompleted {
+		t.Fatalf("State = %q, want completed", run.State)
+	}
+	for _, c := range exec.calls {
+		if c.Provider != "" {
+			t.Errorf("expected empty provider, got %q", c.Provider)
+		}
+	}
+}
+
+func TestEngineEmptyWorkflowCompletes(t *testing.T) {
+	exec := &recordingExecutor{}
+	eng, _ := newTestEngine(t, exec)
+
+	wf := Workflow{ID: "empty", Name: "empty"}
+	run, err := eng.Start(context.Background(), wf, "run-empty")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if run.State != RunStateCompleted {
+		t.Errorf("State = %q, want completed", run.State)
+	}
+	if len(exec.calls) != 0 {
+		t.Errorf("expected zero calls, got %d", len(exec.calls))
+	}
+}
+
+func TestEngineStartGeneratesRunID(t *testing.T) {
+	exec := &recordingExecutor{}
+	eng, _ := newTestEngine(t, exec)
+
+	run, err := eng.Start(context.Background(), Workflow{ID: "wf"}, "")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if len(run.ID) != 32 { // 16 random bytes hex-encoded
+		t.Errorf("generated ID has unexpected length %d: %q", len(run.ID), run.ID)
+	}
+}
+
+func TestEngineStepExecutorFuncAdapter(t *testing.T) {
+	// Make sure the function adapter type compiles into the StepExecutor
+	// interface without ceremony.
+	var _ StepExecutor = StepExecutorFunc(func(_ context.Context, _ string, _ Step) (string, error) {
+		return "", nil
+	})
+}
+
+func TestEngineContextCancelStopsBetweenSteps(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	exec := &recordingExecutor{
+		handler: func(c callRecord) (string, error) {
+			if c.StepID == "a" {
+				cancel()
+			}
+			return "ok", nil
+		},
+	}
+	eng, cp := newTestEngine(t, exec)
+
+	_, err := eng.Start(ctx, sampleWorkflow(), "run-cancel")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	loaded, err := cp.Load("run-cancel")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.CurrentStep != 1 {
+		t.Errorf("CurrentStep = %d, want 1 (after step a only)", loaded.CurrentStep)
+	}
+}

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -1,46 +1,125 @@
-// Package workflow implements the conduit workflow engine described in
-// PRD §6.7. This file defines the minimal step/result types needed by the
-// branching evaluator. Issue #33 owns the canonical foundational types
-// (Workflow, Step, Run, Engine); when those land, the fields below should
-// be reconciled with whatever #33 ships and the duplicate definitions
-// here removed.
+// Package workflow implements durable, resumable multi-step workflow runs.
+//
+// The package owns the minimal state machine required by PRD §6.7
+// (workflow checkpointing & resume) and the associated provider failover
+// chain. Conditional branching (issue #34) is implemented in
+// condition.go; additional features (scheduling, etc.) extend these
+// types in their own files.
 package workflow
 
-// Step is the unit of work in a workflow. Only the fields needed for
-// conditional branching (PRD §6.7) are defined here; #33 will extend it
-// with execution metadata (kind, inputs, retries, etc.).
+import "time"
+
+// RunState is the lifecycle state of a single Run.
+type RunState string
+
+const (
+	// RunStatePending means the Run has been created but no Step has executed.
+	RunStatePending RunState = "pending"
+	// RunStateRunning means at least one Step has executed and the Run is
+	// neither completed nor failed.
+	RunStateRunning RunState = "running"
+	// RunStateCompleted means every Step finished successfully.
+	RunStateCompleted RunState = "completed"
+	// RunStateFailed means a Step exhausted its provider chain and the Run
+	// cannot make further progress without intervention.
+	RunStateFailed RunState = "failed"
+)
+
+// Step is one unit of work within a Workflow.
+//
+// The struct unifies the checkpointing fields needed by issue #33 with
+// the conditional-branching fields contributed by issue #34. Additional
+// features (scheduling, retries) should extend this struct rather than
+// duplicate it.
 type Step struct {
-	// ID uniquely identifies the step within its workflow.
+	// ID is a stable identifier for the Step within its Workflow.
+	// IDs must be unique inside a single Workflow.
 	ID string `json:"id" yaml:"id"`
+	// Name is a human-readable label shown in surfaces and logs.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// Prompt is the input handed to the StepExecutor when the Step runs.
+	Prompt string `json:"prompt,omitempty" yaml:"prompt,omitempty"`
 
 	// Next is the unconditional successor step ID. Used when Condition is
-	// nil, or as a fallback when Condition's outcomes are empty.
+	// nil, or as a fallback when Condition's outcomes are empty. The
+	// linear engine in this PR ignores Next; conditional branching uses
+	// it (see condition.go).
 	Next string `json:"next,omitempty" yaml:"next,omitempty"`
-
 	// Condition, if non-nil, is evaluated against the previous step's
 	// StepResult to decide which branch to take. See condition.go.
 	Condition *Condition `json:"condition,omitempty" yaml:"condition,omitempty"`
-
 	// OnTrue is the step ID taken when Condition evaluates to true.
 	// Empty string means "stop the workflow".
 	OnTrue string `json:"on_true,omitempty" yaml:"on_true,omitempty"`
-
 	// OnFalse is the step ID taken when Condition evaluates to false.
 	// Empty string means "stop the workflow".
 	OnFalse string `json:"on_false,omitempty" yaml:"on_false,omitempty"`
 }
 
-// StepResult captures the output of a step execution. The branching
-// evaluator only reads Output and Error; #33 will extend with timings,
-// stdout/stderr, exit codes, etc.
+// Workflow is the static definition of a multi-step task.
+type Workflow struct {
+	// ID identifies the Workflow definition. Two Runs of the same
+	// definition share this ID.
+	ID string `json:"id" yaml:"id"`
+	// Name is a human-readable label.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// Steps are executed in order. Empty Steps is a valid (no-op) workflow.
+	Steps []Step `json:"steps" yaml:"steps"`
+	// Providers is the ordered failover chain for model invocations.
+	// When a Step's StepExecutor returns an error, the Engine advances
+	// to the next provider and retries the Step before failing the Run.
+	// An empty chain means a single attempt with the executor's default
+	// provider (empty string).
+	Providers []string `json:"providers,omitempty" yaml:"providers,omitempty"`
+}
+
+// StepResult is the persisted outcome of executing a Step.
 type StepResult struct {
-	// StepID is the ID of the step that produced this result.
+	// StepID matches Step.ID.
 	StepID string `json:"step_id" yaml:"step_id"`
-
+	// Provider is the entry from Workflow.Providers that produced Output,
+	// or empty if no provider chain was configured.
+	Provider string `json:"provider,omitempty" yaml:"provider,omitempty"`
 	// Output is the structured value emitted by the step. May be a
-	// string, number, bool, map[string]any, []any, or nil.
+	// string, number, bool, map[string]any, []any, or nil. The
+	// branching evaluator (see condition.go) reads this value via
+	// JSONPath; the StepExecutor used by this PR returns plain strings.
 	Output any `json:"output,omitempty" yaml:"output,omitempty"`
-
-	// Error is the error string if the step failed, empty otherwise.
+	// Error is set when the Step ultimately failed after exhausting the
+	// provider chain. A successful Step has Error == "".
 	Error string `json:"error,omitempty" yaml:"error,omitempty"`
+	// StartedAt and CompletedAt bracket the Step's wall-clock execution.
+	StartedAt   time.Time `json:"started_at,omitempty" yaml:"started_at,omitempty"`
+	CompletedAt time.Time `json:"completed_at,omitempty" yaml:"completed_at,omitempty"`
+}
+
+// Run is the durable state for one execution of a Workflow.
+//
+// The struct is JSON-encoded by the Checkpointer after every Step. Any
+// new field added here must also survive a write/read roundtrip through
+// encoding/json.
+type Run struct {
+	// ID uniquely identifies this Run across the host. Used as the
+	// checkpoint filename.
+	ID string `json:"id"`
+	// WorkflowID matches Workflow.ID.
+	WorkflowID string `json:"workflow_id"`
+	// Workflow is the embedded definition so a Run can be resumed
+	// without consulting an external definition store.
+	Workflow Workflow `json:"workflow"`
+	// State is the lifecycle position of the Run.
+	State RunState `json:"state"`
+	// CurrentStep is the index into Workflow.Steps of the next Step to
+	// execute. After a successful Step at index i, CurrentStep is i+1.
+	// When CurrentStep == len(Workflow.Steps), the Run is complete.
+	CurrentStep int `json:"current_step"`
+	// Results is the per-Step outcome history, one entry per executed
+	// Step in execution order.
+	Results []StepResult `json:"results"`
+	// CreatedAt is when the Run was first checkpointed.
+	CreatedAt time.Time `json:"created_at"`
+	// UpdatedAt is the timestamp of the most recent checkpoint.
+	UpdatedAt time.Time `json:"updated_at"`
+	// LastError captures the failure reason when State == RunStateFailed.
+	LastError string `json:"last_error,omitempty"`
 }


### PR DESCRIPTION
## Summary

Implements PRD §6.7 (workflow checkpointing & resume): the `internal/workflow` package now persists every Run to disk after each Step, recovers cleanly on resume, and re-routes mid-workflow to the next provider in a configurable chain when a model invocation fails.

This is the **foundational types layer** for the workflow package. Sibling PRs for issues #34, #35, #36 will extend `Workflow` / `Step` / `Run` with their own concerns (conditions, branches, scheduling) — this PR deliberately keeps the surface minimal so those extensions don't conflict.

- `types.go` — `Workflow`, `Step`, `Run`, `RunState`, `StepResult`, only the fields checkpointing needs
- `checkpoint.go` — `Checkpointer` interface + `FileCheckpointer` writing JSON to `~/.conduit/runs/<run-id>.json` via tmpfile + atomic rename
- `engine.go` — `Engine.Start` / `Engine.Resume` driving Steps with checkpoint-after-each-step durability and provider-chain failover keyed off a `ProviderError` marker interface; `StepExecutor` is injected so no real model providers are dragged in

No new third-party deps. Stdlib `crypto/rand` powers a tiny inline UUID-ish ID generator.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/workflow/...` — 17 tests pass
- [x] `go test ./...` — all existing packages still green
- [x] Checkpoint write-then-read roundtrip preserves `Workflow`, `Providers`, `Results`, timestamps
- [x] Resume picks up at the first unfinished Step and does not re-run completed Steps
- [x] Resume on an already-completed/failed Run is a no-op
- [x] Provider failover advances on `ProviderError` and lands on the first healthy provider
- [x] Plain (non-`ProviderError`) errors are terminal — no failover, no retries
- [x] Provider-chain exhaustion fails the Run and persists `LastError`
- [x] Empty / no-provider workflows behave correctly
- [x] Context cancellation between Steps is respected and the checkpoint reflects the last completed Step
- [x] Atomic rename leaves no `.tmp` debris on overwrite