### PR TITLE
feat(computer-use): safety guardrails for destructive actions (#42)

### DIFF
--- a/internal/computeruse/guardrails/action.go
+++ b/internal/computeruse/guardrails/action.go
@@ -1,0 +1,109 @@
+// Package guardrails enforces safety rules on macOS computer-use actions
+// before they reach the OS. PRD §6.8 mandates a checkpoint before any
+// destructive action and explicit confirmation before sending email,
+// posting publicly, or executing a financial transaction.
+//
+// The MCP step dispatcher (issue #37) MUST call (*Engine).Evaluate on every
+// proposed action before executing it. The capability adapters (issue #40)
+// supply the per-action metadata — bundle ID, URL, action verb, target
+// element — that the classifier consumes.
+package guardrails
+
+import "time"
+
+// Category labels the kind of risk an action carries. Multiple categories
+// can apply to a single action (e.g. clicking a "Confirm purchase" button in
+// a browser is both Communication-shaped and Financial — Financial wins).
+type Category string
+
+const (
+	// CategoryUnknown is the absence of any matched rule.
+	CategoryUnknown Category = ""
+	// CategoryCommunication covers send-email, post-publicly, send-DM.
+	CategoryCommunication Category = "communication"
+	// CategoryFinancial covers banking, payments, checkout, confirm-purchase.
+	CategoryFinancial Category = "financial"
+	// CategoryFilesystem covers rm/delete/empty-trash/format/uninstall.
+	CategoryFilesystem Category = "filesystem"
+	// CategorySystem covers shutdown/restart/sudo/login-window logout.
+	CategorySystem Category = "system"
+)
+
+// Verdict is the policy decision for one Action.
+type Verdict string
+
+const (
+	// VerdictAllow means the dispatcher may execute the action without prompting.
+	VerdictAllow Verdict = "allow"
+	// VerdictRequireConfirmation means the dispatcher must obtain user consent
+	// (via Engine.RequestConfirmation) before executing.
+	VerdictRequireConfirmation Verdict = "require_confirmation"
+	// VerdictDeny means the dispatcher must NOT execute the action. Used for
+	// hard-blocked targets (financial by default on ambiguity) and for
+	// confirmation timeouts.
+	VerdictDeny Verdict = "deny"
+)
+
+// Action is the structured description of a single computer-use step that
+// the capability adapter (#40) hands to the dispatcher (#37).
+//
+// Fields are intentionally permissive — a v1 classifier matches on whichever
+// signals are present. None are required; an empty Action evaluates to
+// CategoryUnknown / VerdictAllow.
+type Action struct {
+	// Verb is the high-level intent: "click", "type", "send", "delete",
+	// "shutdown", "open", "screenshot", etc.
+	Verb string
+	// BundleID is the macOS application bundle identifier, e.g.
+	// "com.apple.mail" or "com.tinyspeck.slackmacgap".
+	BundleID string
+	// AppName is a human-readable fallback when BundleID is unavailable.
+	AppName string
+	// URL is set for browser actions; the classifier matches the host.
+	URL string
+	// Target is the accessibility-tree label of the element being acted on,
+	// e.g. "Send", "Confirm Purchase", "Empty Trash".
+	Target string
+	// Path is the filesystem path for file actions.
+	Path string
+	// Text is the typed/sent payload (used to spot keywords like "rm -rf").
+	Text string
+	// Description is a freeform sentence the model emitted for the step,
+	// used as a final keyword fallback.
+	Description string
+}
+
+// Decision is the result of evaluating one Action.
+type Decision struct {
+	Verdict    Verdict
+	Categories []Category
+	// MatchedRule names the policy entry that produced the verdict; empty
+	// when nothing matched (default-allow path).
+	MatchedRule string
+	Reason      string
+	// Confirmed reports whether a require_confirmation decision was actually
+	// approved by the user. Audit consumers use this to distinguish a
+	// "would-have-prompted" decision from an "approved" one.
+	Confirmed bool
+}
+
+// AuditEntry is the JSONL record written to the session log for every
+// guardrail decision. The shape matches the per-session JSONL convention
+// established by the cost tracker (PR #15) — flat fields, RFC3339 timestamp.
+type AuditEntry struct {
+	Timestamp   time.Time `json:"timestamp"`
+	SessionID   string    `json:"session_id"`
+	Verdict     Verdict   `json:"verdict"`
+	Confirmed   bool      `json:"confirmed,omitempty"`
+	Categories  []string  `json:"categories,omitempty"`
+	MatchedRule string    `json:"matched_rule,omitempty"`
+	Reason      string    `json:"reason,omitempty"`
+	Verb        string    `json:"verb,omitempty"`
+	BundleID    string    `json:"bundle_id,omitempty"`
+	AppName     string    `json:"app_name,omitempty"`
+	URLHost     string    `json:"url_host,omitempty"`
+	Target      string    `json:"target,omitempty"`
+	Path        string    `json:"path,omitempty"`
+	// Note: Text is intentionally NOT logged — it can contain secrets.
+	Description string `json:"description,omitempty"`
+}

--- a/internal/computeruse/guardrails/audit.go
+++ b/internal/computeruse/guardrails/audit.go
@@ -1,0 +1,111 @@
+package guardrails
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// AuditSink consumes one guardrail decision per call. The default file-based
+// implementation appends one JSONL record per call (matching the per-session
+// JSONL convention from PR #15). Tests use the slice-backed MemoryAuditSink.
+type AuditSink interface {
+	Write(entry AuditEntry) error
+}
+
+// FileAuditSink writes one JSON record per Write call to the configured
+// path, separated by newlines. Safe for concurrent use.
+type FileAuditSink struct {
+	mu   sync.Mutex
+	path string
+}
+
+// NewFileAuditSink returns a sink that appends to path. Parent directories
+// are created on demand.
+func NewFileAuditSink(path string) (*FileAuditSink, error) {
+	if path == "" {
+		return nil, fmt.Errorf("guardrails: audit path is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("guardrails: create audit dir: %w", err)
+	}
+	return &FileAuditSink{path: path}, nil
+}
+
+// Write appends one JSONL entry to the audit file.
+func (s *FileAuditSink) Write(entry AuditEntry) error {
+	line, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("guardrails: marshal audit entry: %w", err)
+	}
+	line = append(line, '\n')
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	f, err := os.OpenFile(s.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("guardrails: open audit log: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(line); err != nil {
+		return fmt.Errorf("guardrails: write audit entry: %w", err)
+	}
+	return nil
+}
+
+// WriterAuditSink wraps an arbitrary io.Writer (e.g. a buffer in tests).
+type WriterAuditSink struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// NewWriterAuditSink returns a sink that JSONL-encodes to w.
+func NewWriterAuditSink(w io.Writer) *WriterAuditSink {
+	return &WriterAuditSink{w: w}
+}
+
+// Write JSONL-encodes one entry to the underlying writer.
+func (s *WriterAuditSink) Write(entry AuditEntry) error {
+	line, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("guardrails: marshal audit entry: %w", err)
+	}
+	line = append(line, '\n')
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, err := s.w.Write(line); err != nil {
+		return fmt.Errorf("guardrails: write audit entry: %w", err)
+	}
+	return nil
+}
+
+// MemoryAuditSink keeps every entry in-memory; useful in tests.
+type MemoryAuditSink struct {
+	mu      sync.Mutex
+	entries []AuditEntry
+}
+
+// Write appends entry to the in-memory slice.
+func (s *MemoryAuditSink) Write(entry AuditEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = append(s.entries, entry)
+	return nil
+}
+
+// Entries returns a copy of every recorded entry, in arrival order.
+func (s *MemoryAuditSink) Entries() []AuditEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]AuditEntry(nil), s.entries...)
+}
+
+// nopAuditSink is the default when no sink is configured.
+type nopAuditSink struct{}
+
+func (nopAuditSink) Write(_ AuditEntry) error { return nil }

--- a/internal/computeruse/guardrails/classifier.go
+++ b/internal/computeruse/guardrails/classifier.go
@@ -1,0 +1,368 @@
+package guardrails
+
+import (
+	"net/url"
+	"strings"
+)
+
+// Classifier holds the bundle-ID, URL, and keyword indices used to label an
+// Action with one or more risk Categories. The lists are intentionally
+// pragmatic for v1 — extend Config to add custom entries.
+type Classifier struct {
+	// Bundle ID prefixes / exact matches keyed by category. Matched
+	// case-insensitively against Action.BundleID.
+	bundleIDs map[Category][]string
+	// Host suffixes keyed by category. Matched case-insensitively against
+	// the host parsed from Action.URL (e.g. "chase.com" matches
+	// "secure.chase.com").
+	hostSuffixes map[Category][]string
+	// Verb / target / text keyword fragments keyed by category. Matched
+	// case-insensitively as a substring against the joined action text.
+	keywords map[Category][]string
+}
+
+// Config customizes the classifier. Each field is OPTIONAL — missing
+// categories fall back to DefaultClassifier's curated list.
+type Config struct {
+	BundleIDs    map[Category][]string
+	HostSuffixes map[Category][]string
+	Keywords     map[Category][]string
+	// FinancialDefaultDeny, when true (the package default), causes the
+	// policy layer to prefer VerdictDeny over VerdictRequireConfirmation
+	// when a financial signal is present but ambiguous (e.g. unknown
+	// bundle ID for a checkout-shaped target).
+	FinancialDefaultDeny bool
+}
+
+// DefaultClassifier returns a curated v1 classifier for macOS.
+func DefaultClassifier() *Classifier {
+	return NewClassifier(Config{FinancialDefaultDeny: true})
+}
+
+// NewClassifier merges cfg with the curated defaults and returns a ready
+// classifier. Custom entries APPEND to defaults — they don't replace them,
+// so callers cannot accidentally weaken the safety floor.
+func NewClassifier(cfg Config) *Classifier {
+	c := &Classifier{
+		bundleIDs:    cloneMap(defaultBundleIDs),
+		hostSuffixes: cloneMap(defaultHostSuffixes),
+		keywords:     cloneMap(defaultKeywords),
+	}
+	for cat, ids := range cfg.BundleIDs {
+		c.bundleIDs[cat] = append(c.bundleIDs[cat], ids...)
+	}
+	for cat, hosts := range cfg.HostSuffixes {
+		c.hostSuffixes[cat] = append(c.hostSuffixes[cat], hosts...)
+	}
+	for cat, kws := range cfg.Keywords {
+		c.keywords[cat] = append(c.keywords[cat], kws...)
+	}
+	return c
+}
+
+// Classify returns every category triggered by the action. The slice is
+// stable in priority order: Financial, System, Filesystem, Communication —
+// so the first element is the dominant risk for default-deny logic.
+func (c *Classifier) Classify(a Action) []Category {
+	bundle := strings.ToLower(strings.TrimSpace(a.BundleID))
+	app := strings.ToLower(strings.TrimSpace(a.AppName))
+	host := hostFromURL(a.URL)
+	combined := strings.ToLower(strings.Join([]string{
+		a.Verb, a.Target, a.Path, a.Text, a.Description,
+	}, " "))
+
+	hits := make(map[Category]bool, 4)
+	check := func(cat Category) {
+		if matchPrefix(bundle, c.bundleIDs[cat]) ||
+			matchContainsAny(app, c.bundleIDs[cat]) ||
+			matchHostSuffix(host, c.hostSuffixes[cat]) ||
+			matchSubstring(combined, c.keywords[cat]) {
+			hits[cat] = true
+		}
+	}
+	for _, cat := range categoryPriority {
+		check(cat)
+	}
+
+	out := make([]Category, 0, len(hits))
+	for _, cat := range categoryPriority {
+		if hits[cat] {
+			out = append(out, cat)
+		}
+	}
+	return out
+}
+
+// categoryPriority orders categories from most-severe to least-severe for
+// default-deny tie-breaking. Financial first by PRD direction.
+var categoryPriority = []Category{
+	CategoryFinancial,
+	CategorySystem,
+	CategoryFilesystem,
+	CategoryCommunication,
+}
+
+// --- curated v1 lists ---------------------------------------------------
+
+// defaultBundleIDs maps macOS app bundle IDs (and human app-name fragments)
+// to risk categories. Match is prefix-on-bundle, contains-on-app-name.
+var defaultBundleIDs = map[Category][]string{
+	CategoryCommunication: {
+		"com.apple.mail",       // Apple Mail
+		"com.apple.mobilemail", // Mail (macOS Catalina+ id variant)
+		"com.apple.messages",   // Messages
+		"com.apple.ichat",      // legacy Messages bundle id
+		"com.tinyspeck.slack",  // Slack (covers slackmacgap suffix)
+		"com.microsoft.teams",
+		"com.microsoft.outlook",
+		"us.zoom.xos",
+		"com.hnc.discord",
+		"com.tdesktop.telegram",
+		"net.whatsapp.whatsapp",
+		"com.readdle.smartemail-mac", // Spark
+		"mail",                       // app-name fragment fallback
+		"slack",
+		"messages",
+		"outlook",
+		"discord",
+	},
+	CategoryFinancial: {
+		// Apple Wallet / Pay
+		"com.apple.passbook",
+		// Common consumer banking / brokerage / payments app prefixes
+		"com.chase.sig.chase",
+		"com.bankofamerica.bofa",
+		"com.wellsfargo.wellsfargomobile",
+		"com.citi.citimobile",
+		"com.paypal.ppclient",
+		"com.venmo",
+		"com.squareup.cash",
+		"com.robinhood",
+		"com.coinbase",
+		"com.intuit.quickbooks",
+		"com.intuit.turbotax",
+		"com.mint",
+		// app-name fragment fallbacks
+		"chase",
+		"paypal",
+		"venmo",
+		"robinhood",
+		"coinbase",
+		"wallet",
+	},
+	CategoryFilesystem: {
+		"com.apple.finder",
+	},
+	CategorySystem: {
+		"com.apple.systempreferences",
+		"com.apple.systemsettings",
+		"com.apple.terminal",
+		"com.googlecode.iterm2",
+	},
+}
+
+// defaultHostSuffixes maps URL host suffixes (matched right-to-left) to
+// risk categories. Used for browser computer-use actions.
+var defaultHostSuffixes = map[Category][]string{
+	CategoryCommunication: {
+		"mail.google.com",
+		"outlook.live.com",
+		"outlook.office.com",
+		"outlook.office365.com",
+		"twitter.com",
+		"x.com",
+		"facebook.com",
+		"instagram.com",
+		"linkedin.com",
+		"reddit.com",
+		"tiktok.com",
+		"threads.net",
+		"bsky.app",
+		"mastodon.social",
+		"slack.com",
+		"discord.com",
+		"web.whatsapp.com",
+		"messages.google.com",
+	},
+	CategoryFinancial: {
+		"chase.com",
+		"bankofamerica.com",
+		"wellsfargo.com",
+		"citi.com",
+		"capitalone.com",
+		"americanexpress.com",
+		"discover.com",
+		"usbank.com",
+		"schwab.com",
+		"fidelity.com",
+		"vanguard.com",
+		"robinhood.com",
+		"coinbase.com",
+		"binance.com",
+		"kraken.com",
+		"paypal.com",
+		"venmo.com",
+		"cash.app",
+		"stripe.com",
+		"checkout.stripe.com",
+		"checkout.shopify.com",
+		"checkout.amazon.com",
+		"pay.amazon.com",
+		"buy.itunes.apple.com",
+		"finance.apple.com",
+		"plaid.com",
+	},
+}
+
+// defaultKeywords maps verb/target/description substrings to categories.
+// Lower-cased; matched as substring against the joined action text.
+var defaultKeywords = map[Category][]string{
+	CategoryCommunication: {
+		"send email",
+		"send message",
+		"send dm",
+		"send tweet",
+		"send post",
+		"reply all",
+		"compose mail",
+		"publish post",
+		"post publicly",
+		"share publicly",
+		"tweet",
+		"send to ",
+	},
+	CategoryFinancial: {
+		"confirm purchase",
+		"complete purchase",
+		"place order",
+		"submit order",
+		"checkout",
+		"check out",
+		"pay now",
+		"send money",
+		"transfer funds",
+		"wire transfer",
+		"buy now",
+		"add card",
+		"authorize payment",
+	},
+	CategoryFilesystem: {
+		"rm -rf",
+		"sudo rm",
+		"empty trash",
+		"empty bin",
+		"move to trash",
+		"delete file",
+		"delete folder",
+		"format disk",
+		"erase disk",
+		"uninstall ",
+		"diskutil erase",
+	},
+	CategorySystem: {
+		"shutdown",
+		"restart computer",
+		"reboot",
+		"log out",
+		"sign out",
+		"sudo ",
+		"sudo\t",
+		"system preferences",
+		"disable firewall",
+		"disable gatekeeper",
+		"sudo -s",
+	},
+}
+
+// --- helpers -------------------------------------------------------------
+
+func cloneMap(in map[Category][]string) map[Category][]string {
+	out := make(map[Category][]string, len(in))
+	for k, v := range in {
+		out[k] = append([]string(nil), v...)
+	}
+	return out
+}
+
+func hostFromURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		// Try a relaxed parse for bare hosts ("chase.com/login").
+		// Strip scheme-less leading slashes and a trailing path.
+		host := strings.TrimPrefix(strings.TrimPrefix(raw, "https://"), "http://")
+		if i := strings.IndexAny(host, "/?#"); i >= 0 {
+			host = host[:i]
+		}
+		return strings.ToLower(host)
+	}
+	return strings.ToLower(u.Host)
+}
+
+func matchPrefix(s string, prefixes []string) bool {
+	if s == "" {
+		return false
+	}
+	for _, p := range prefixes {
+		if p == "" {
+			continue
+		}
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchContainsAny(s string, fragments []string) bool {
+	if s == "" {
+		return false
+	}
+	for _, f := range fragments {
+		if f == "" {
+			continue
+		}
+		// App-name fallbacks are short fragments — only match those that
+		// don't look like reverse-DNS bundle IDs to avoid false positives
+		// from app names like "Chase" matching "com.chase.sig.chase".
+		if strings.Contains(f, ".") {
+			continue
+		}
+		if strings.Contains(s, f) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchHostSuffix(host string, suffixes []string) bool {
+	if host == "" {
+		return false
+	}
+	for _, suf := range suffixes {
+		if suf == "" {
+			continue
+		}
+		if host == suf || strings.HasSuffix(host, "."+suf) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchSubstring(s string, fragments []string) bool {
+	if s == "" {
+		return false
+	}
+	for _, f := range fragments {
+		if f == "" {
+			continue
+		}
+		if strings.Contains(s, f) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/computeruse/guardrails/classifier_test.go
+++ b/internal/computeruse/guardrails/classifier_test.go
@@ -1,0 +1,208 @@
+package guardrails
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestClassifier_Communication(t *testing.T) {
+	c := DefaultClassifier()
+
+	cases := []struct {
+		name   string
+		action Action
+	}{
+		{
+			name:   "apple mail bundle id",
+			action: Action{Verb: "click", BundleID: "com.apple.mail", Target: "Send"},
+		},
+		{
+			name:   "slack bundle id",
+			action: Action{Verb: "click", BundleID: "com.tinyspeck.slackmacgap", Target: "Send"},
+		},
+		{
+			name:   "gmail browser host",
+			action: Action{Verb: "click", URL: "https://mail.google.com/mail/u/0/#inbox", Target: "Send"},
+		},
+		{
+			name:   "twitter post browser host",
+			action: Action{Verb: "click", URL: "https://x.com/home", Target: "Post"},
+		},
+		{
+			name:   "send email by description",
+			action: Action{Verb: "click", Description: "send email to investors with quarterly numbers"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cats := c.Classify(tc.action)
+			if !slices.Contains(cats, CategoryCommunication) {
+				t.Fatalf("expected CategoryCommunication; got %v", cats)
+			}
+		})
+	}
+}
+
+func TestClassifier_Financial(t *testing.T) {
+	c := DefaultClassifier()
+	cases := []struct {
+		name   string
+		action Action
+	}{
+		{
+			name:   "chase mobile app",
+			action: Action{Verb: "click", BundleID: "com.chase.sig.chase", Target: "Send Money"},
+		},
+		{
+			name:   "venmo app",
+			action: Action{Verb: "tap", BundleID: "com.venmo.iphone"},
+		},
+		{
+			name:   "stripe checkout url",
+			action: Action{Verb: "click", URL: "https://checkout.stripe.com/c/pay/abc", Target: "Pay"},
+		},
+		{
+			name:   "amazon checkout button",
+			action: Action{Verb: "click", URL: "https://www.amazon.com/cart", Target: "Place order"},
+		},
+		{
+			name:   "confirm purchase keyword",
+			action: Action{Verb: "click", Description: "confirm purchase of $4500 chair"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cats := c.Classify(tc.action)
+			if !slices.Contains(cats, CategoryFinancial) {
+				t.Fatalf("expected CategoryFinancial; got %v", cats)
+			}
+			if cats[0] != CategoryFinancial {
+				t.Fatalf("Financial should be highest priority; got order %v", cats)
+			}
+		})
+	}
+}
+
+func TestClassifier_Filesystem(t *testing.T) {
+	c := DefaultClassifier()
+	cases := []struct {
+		name   string
+		action Action
+	}{
+		{
+			name:   "rm -rf in shell",
+			action: Action{Verb: "type", Text: "sudo rm -rf /Users/me/work"},
+		},
+		{
+			name:   "empty trash button in finder",
+			action: Action{Verb: "click", BundleID: "com.apple.finder", Target: "Empty Trash"},
+		},
+		{
+			name:   "uninstall keyword",
+			action: Action{Verb: "click", Description: "uninstall application Acme"},
+		},
+		{
+			name:   "diskutil erase",
+			action: Action{Verb: "type", Text: "diskutil eraseDisk APFS NewName disk2"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cats := c.Classify(tc.action)
+			if !slices.Contains(cats, CategoryFilesystem) {
+				t.Fatalf("expected CategoryFilesystem; got %v", cats)
+			}
+		})
+	}
+}
+
+func TestClassifier_System(t *testing.T) {
+	c := DefaultClassifier()
+	cases := []struct {
+		name   string
+		action Action
+	}{
+		{
+			name:   "shutdown verb",
+			action: Action{Verb: "click", Description: "shutdown the computer"},
+		},
+		{
+			name:   "sudo in terminal",
+			action: Action{Verb: "type", BundleID: "com.apple.terminal", Text: "sudo shutdown -h now"},
+		},
+		{
+			name:   "reboot keyword",
+			action: Action{Verb: "click", Target: "Restart computer"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cats := c.Classify(tc.action)
+			if !slices.Contains(cats, CategorySystem) {
+				t.Fatalf("expected CategorySystem; got %v", cats)
+			}
+		})
+	}
+}
+
+func TestClassifier_BenignAction(t *testing.T) {
+	c := DefaultClassifier()
+	benign := []Action{
+		{Verb: "screenshot"},
+		{Verb: "click", BundleID: "com.apple.safari", URL: "https://news.ycombinator.com/", Target: "Read more"},
+		{Verb: "type", Text: "hello world"},
+		{Verb: "scroll", Description: "scroll down"},
+	}
+	for _, a := range benign {
+		cats := c.Classify(a)
+		if len(cats) != 0 {
+			t.Fatalf("expected no categories for %v; got %v", a, cats)
+		}
+	}
+}
+
+func TestClassifier_CustomConfigExtends(t *testing.T) {
+	c := NewClassifier(Config{
+		BundleIDs: map[Category][]string{
+			CategoryFinancial: {"com.example.brokerage"},
+		},
+		HostSuffixes: map[Category][]string{
+			CategoryCommunication: {"my-internal-forum.example.com"},
+		},
+		Keywords: map[Category][]string{
+			CategoryFilesystem: {"shred file"},
+		},
+	})
+
+	if got := c.Classify(Action{BundleID: "com.example.brokerage.app"}); !slices.Contains(got, CategoryFinancial) {
+		t.Errorf("custom bundle did not match: %v", got)
+	}
+	if got := c.Classify(Action{URL: "https://my-internal-forum.example.com/post"}); !slices.Contains(got, CategoryCommunication) {
+		t.Errorf("custom host did not match: %v", got)
+	}
+	if got := c.Classify(Action{Description: "shred file ~/foo"}); !slices.Contains(got, CategoryFilesystem) {
+		t.Errorf("custom keyword did not match: %v", got)
+	}
+
+	// Defaults still apply.
+	if got := c.Classify(Action{BundleID: "com.apple.mail"}); !slices.Contains(got, CategoryCommunication) {
+		t.Errorf("default bundle disappeared after custom extension: %v", got)
+	}
+}
+
+func TestHostFromURL(t *testing.T) {
+	cases := map[string]string{
+		"https://Mail.Google.com/inbox": "mail.google.com",
+		"http://chase.com/login":        "chase.com",
+		"checkout.stripe.com/c/pay/abc": "checkout.stripe.com",
+		"https://example.com:8080/path": "example.com:8080",
+		"":                              "",
+		"notaurl":                       "notaurl",
+	}
+	for in, want := range cases {
+		if got := hostFromURL(in); got != want {
+			t.Errorf("hostFromURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/computeruse/guardrails/engine.go
+++ b/internal/computeruse/guardrails/engine.go
@@ -1,0 +1,235 @@
+package guardrails
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// DefaultConfirmationTimeout bounds how long the engine waits for the host
+// to deliver a confirmation answer. On timeout the engine returns
+// VerdictDeny so we never silently execute a destructive action because the
+// user wandered away from the terminal.
+const DefaultConfirmationTimeout = 60 * time.Second
+
+// Engine is the safety guardrail layer. The MCP step dispatcher (issue #37)
+// MUST call (*Engine).Evaluate on every proposed action before executing it.
+//
+// TODO(issue #37, issue #40): wire Engine.Evaluate into the MCP dispatcher
+// pre-step hook. The dispatcher should treat (Decision.Verdict ==
+// VerdictAllow) as the only green-light state — every other verdict means
+// "do not call the OS for this step".
+type Engine struct {
+	classifier *Classifier
+	policy     Policy
+	confirmer  Confirmer
+	audit      AuditSink
+	sessionID  string
+	timeout    time.Duration
+	now        func() time.Time
+}
+
+// Option configures an Engine.
+type Option func(*Engine)
+
+// WithClassifier sets a custom classifier. If unset, DefaultClassifier()
+// is used.
+func WithClassifier(c *Classifier) Option {
+	return func(e *Engine) {
+		if c != nil {
+			e.classifier = c
+		}
+	}
+}
+
+// WithPolicy overrides the default policy.
+func WithPolicy(p Policy) Option {
+	return func(e *Engine) {
+		if p.Categories == nil {
+			p.Categories = map[Category]Verdict{}
+		}
+		if p.Default == "" {
+			p.Default = VerdictAllow
+		}
+		e.policy = p
+	}
+}
+
+// WithConfirmer registers the host-side confirmation hook.
+func WithConfirmer(c Confirmer) Option {
+	return func(e *Engine) {
+		if c != nil {
+			e.confirmer = c
+		}
+	}
+}
+
+// WithAuditSink registers a JSONL audit writer.
+func WithAuditSink(s AuditSink) Option {
+	return func(e *Engine) {
+		if s != nil {
+			e.audit = s
+		}
+	}
+}
+
+// WithSessionID stamps every audit entry with the given session id (matches
+// the per-session JSONL convention from PR #15).
+func WithSessionID(id string) Option {
+	return func(e *Engine) {
+		e.sessionID = id
+	}
+}
+
+// WithConfirmationTimeout bounds the host-side confirmation wait.
+func WithConfirmationTimeout(d time.Duration) Option {
+	return func(e *Engine) {
+		if d > 0 {
+			e.timeout = d
+		}
+	}
+}
+
+// WithClock injects a clock for tests.
+func WithClock(now func() time.Time) Option {
+	return func(e *Engine) {
+		if now != nil {
+			e.now = now
+		}
+	}
+}
+
+// New constructs an Engine with the supplied options. Sensible defaults are
+// applied for any omitted option, INCLUDING fail-closed behaviour: if no
+// confirmer is supplied, the engine treats every "require_confirmation"
+// outcome as a denial.
+func New(opts ...Option) *Engine {
+	e := &Engine{
+		classifier: DefaultClassifier(),
+		policy:     DefaultPolicy(),
+		confirmer:  denyConfirmer{},
+		audit:      nopAuditSink{},
+		timeout:    DefaultConfirmationTimeout,
+		now:        func() time.Time { return time.Now().UTC() },
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// Evaluate is the synchronous decision API. It runs in three phases:
+//
+//  1. Classify the action (no I/O).
+//  2. Resolve the policy verdict for the dominant category.
+//  3. If require_confirmation, call the host Confirmer with a bounded
+//     timeout. Any error or timeout is treated as a denial.
+//
+// The final decision is written to the audit sink before return.
+//
+// The MCP dispatcher MUST treat anything other than VerdictAllow as
+// "do not execute the underlying OS action".
+func (e *Engine) Evaluate(ctx context.Context, action Action) (Decision, error) {
+	cats := e.classifier.Classify(action)
+	verdict, dominant := e.policy.verdictFor(cats)
+	reason := reasonFor(verdict, dominant, action)
+
+	dec := Decision{
+		Verdict:    verdict,
+		Categories: cats,
+		Reason:     reason,
+	}
+
+	if verdict == VerdictRequireConfirmation {
+		confirmed, confirmErr := e.runConfirmation(ctx, action, reason)
+		dec.MatchedRule = "policy:require_confirmation"
+		dec.Confirmed = confirmed
+		if !confirmed {
+			dec.Verdict = VerdictDeny
+			if confirmErr != nil && !errors.Is(confirmErr, context.Canceled) &&
+				!errors.Is(confirmErr, context.DeadlineExceeded) {
+				dec.Reason = reason + " confirmation_error=" + confirmErr.Error()
+			} else if confirmErr != nil {
+				dec.Reason = reason + " confirmation=timeout_or_canceled"
+			} else {
+				dec.Reason = reason + " confirmation=denied"
+			}
+		} else {
+			dec.Verdict = VerdictAllow
+			dec.Reason = reason + " confirmation=granted"
+		}
+		e.writeAudit(action, dec)
+		return dec, nil
+	}
+
+	if verdict == VerdictDeny {
+		dec.MatchedRule = "policy:deny"
+	} else if dominant != CategoryUnknown {
+		dec.MatchedRule = "policy:allow:" + string(dominant)
+	}
+	e.writeAudit(action, dec)
+	return dec, nil
+}
+
+// RequestConfirmation is the public confirmation hook documented in the
+// PRD §6.8 brief. It exposes the engine's bounded-timeout machinery to
+// callers that already know they need consent (e.g. checkpoint flows that
+// don't run through Evaluate). Default-deny on timeout.
+func (e *Engine) RequestConfirmation(ctx context.Context, action Action, reason string) (bool, error) {
+	return e.runConfirmation(ctx, action, reason)
+}
+
+func (e *Engine) runConfirmation(ctx context.Context, action Action, reason string) (bool, error) {
+	if e.confirmer == nil {
+		return false, nil
+	}
+	if e.timeout <= 0 {
+		return e.confirmer.Confirm(ctx, action, reason)
+	}
+	cctx, cancel := context.WithTimeout(ctx, e.timeout)
+	defer cancel()
+
+	type result struct {
+		ok  bool
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		ok, err := e.confirmer.Confirm(cctx, action, reason)
+		ch <- result{ok: ok, err: err}
+	}()
+
+	select {
+	case r := <-ch:
+		return r.ok, r.err
+	case <-cctx.Done():
+		return false, cctx.Err()
+	}
+}
+
+func (e *Engine) writeAudit(a Action, d Decision) {
+	if e.audit == nil {
+		return
+	}
+	cats := make([]string, len(d.Categories))
+	for i, c := range d.Categories {
+		cats[i] = string(c)
+	}
+	entry := AuditEntry{
+		Timestamp:   e.now(),
+		SessionID:   e.sessionID,
+		Verdict:     d.Verdict,
+		Confirmed:   d.Confirmed,
+		Categories:  cats,
+		MatchedRule: d.MatchedRule,
+		Reason:      d.Reason,
+		Verb:        a.Verb,
+		BundleID:    a.BundleID,
+		AppName:     a.AppName,
+		URLHost:     hostFromURL(a.URL),
+		Target:      a.Target,
+		Path:        a.Path,
+		Description: a.Description,
+	}
+	_ = e.audit.Write(entry)
+}

--- a/internal/computeruse/guardrails/engine_test.go
+++ b/internal/computeruse/guardrails/engine_test.go
@@ -1,0 +1,278 @@
+package guardrails
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEngine_BenignAllow(t *testing.T) {
+	sink := &MemoryAuditSink{}
+	e := New(WithAuditSink(sink), WithSessionID("sess-1"))
+
+	dec, err := e.Evaluate(context.Background(), Action{Verb: "screenshot"})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if dec.Verdict != VerdictAllow {
+		t.Fatalf("expected allow, got %s", dec.Verdict)
+	}
+
+	entries := sink.Entries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", len(entries))
+	}
+	if entries[0].Verdict != VerdictAllow {
+		t.Fatalf("audit verdict = %s, want allow", entries[0].Verdict)
+	}
+	if entries[0].SessionID != "sess-1" {
+		t.Fatalf("audit session id = %q, want sess-1", entries[0].SessionID)
+	}
+}
+
+func TestEngine_FinancialDeniedByDefault(t *testing.T) {
+	sink := &MemoryAuditSink{}
+	// No confirmer supplied; engine should deny financial regardless.
+	e := New(WithAuditSink(sink))
+
+	dec, err := e.Evaluate(context.Background(), Action{
+		Verb:   "click",
+		URL:    "https://checkout.stripe.com/c/pay/abc",
+		Target: "Pay $4500",
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if dec.Verdict != VerdictDeny {
+		t.Fatalf("expected deny on financial; got %s (reason=%s)", dec.Verdict, dec.Reason)
+	}
+	if len(dec.Categories) == 0 || dec.Categories[0] != CategoryFinancial {
+		t.Fatalf("expected dominant Financial; got %v", dec.Categories)
+	}
+}
+
+func TestEngine_CommunicationRequiresConfirmation_Granted(t *testing.T) {
+	called := 0
+	confirmer := ConfirmerFunc(func(ctx context.Context, a Action, reason string) (bool, error) {
+		called++
+		if !strings.Contains(reason, "communication") {
+			t.Errorf("reason should include category; got %q", reason)
+		}
+		return true, nil
+	})
+	sink := &MemoryAuditSink{}
+	e := New(WithAuditSink(sink), WithConfirmer(confirmer))
+
+	dec, err := e.Evaluate(context.Background(), Action{
+		Verb:     "click",
+		BundleID: "com.apple.mail",
+		Target:   "Send",
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if dec.Verdict != VerdictAllow {
+		t.Fatalf("verdict = %s, want allow after confirmation", dec.Verdict)
+	}
+	if !dec.Confirmed {
+		t.Fatalf("expected Confirmed=true")
+	}
+	if called != 1 {
+		t.Fatalf("confirmer called %d times, want 1", called)
+	}
+	if got := sink.Entries(); len(got) != 1 || !got[0].Confirmed {
+		t.Fatalf("audit entries = %+v", got)
+	}
+}
+
+func TestEngine_CommunicationRequiresConfirmation_Denied(t *testing.T) {
+	confirmer := ConfirmerFunc(func(ctx context.Context, a Action, reason string) (bool, error) {
+		return false, nil
+	})
+	sink := &MemoryAuditSink{}
+	e := New(WithAuditSink(sink), WithConfirmer(confirmer))
+
+	dec, err := e.Evaluate(context.Background(), Action{
+		Verb:     "click",
+		BundleID: "com.apple.mail",
+		Target:   "Send",
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if dec.Verdict != VerdictDeny {
+		t.Fatalf("verdict = %s, want deny", dec.Verdict)
+	}
+	if dec.Confirmed {
+		t.Fatalf("expected Confirmed=false")
+	}
+}
+
+func TestEngine_DefaultDenyWithoutConfirmer(t *testing.T) {
+	sink := &MemoryAuditSink{}
+	e := New(WithAuditSink(sink)) // no confirmer
+
+	dec, err := e.Evaluate(context.Background(), Action{
+		Verb:     "click",
+		BundleID: "com.apple.mail",
+		Target:   "Send",
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if dec.Verdict != VerdictDeny {
+		t.Fatalf("verdict = %s, want deny when no confirmer registered", dec.Verdict)
+	}
+}
+
+func TestEngine_ConfirmationTimeoutDenies(t *testing.T) {
+	// Confirmer hangs forever — timeout must close the gap.
+	confirmer := ConfirmerFunc(func(ctx context.Context, a Action, reason string) (bool, error) {
+		<-ctx.Done()
+		return false, ctx.Err()
+	})
+	sink := &MemoryAuditSink{}
+	e := New(
+		WithAuditSink(sink),
+		WithConfirmer(confirmer),
+		WithConfirmationTimeout(20*time.Millisecond),
+	)
+
+	dec, err := e.Evaluate(context.Background(), Action{
+		Verb:     "click",
+		BundleID: "com.apple.mail",
+		Target:   "Send",
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if dec.Verdict != VerdictDeny {
+		t.Fatalf("verdict = %s, want deny on timeout", dec.Verdict)
+	}
+	if !strings.Contains(dec.Reason, "timeout") && !strings.Contains(dec.Reason, "canceled") {
+		t.Fatalf("reason = %q, want timeout/canceled", dec.Reason)
+	}
+}
+
+func TestEngine_ConfirmerError_Denies(t *testing.T) {
+	wantErr := errors.New("confirmer broke")
+	confirmer := ConfirmerFunc(func(ctx context.Context, a Action, reason string) (bool, error) {
+		return false, wantErr
+	})
+	sink := &MemoryAuditSink{}
+	e := New(WithAuditSink(sink), WithConfirmer(confirmer))
+
+	dec, err := e.Evaluate(context.Background(), Action{
+		Verb:     "click",
+		BundleID: "com.apple.mail",
+		Target:   "Send",
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if dec.Verdict != VerdictDeny {
+		t.Fatalf("verdict = %s, want deny on confirmer error", dec.Verdict)
+	}
+	if !strings.Contains(dec.Reason, "confirmer broke") {
+		t.Fatalf("reason = %q, want confirmer error message", dec.Reason)
+	}
+}
+
+func TestEngine_AuditFileJSONLPerSession(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "guardrails.jsonl")
+	sink, err := NewFileAuditSink(path)
+	if err != nil {
+		t.Fatalf("sink: %v", err)
+	}
+	e := New(
+		WithAuditSink(sink),
+		WithSessionID("sess-42"),
+		WithClock(func() time.Time { return time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC) }),
+	)
+
+	if _, err := e.Evaluate(context.Background(), Action{Verb: "screenshot"}); err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if _, err := e.Evaluate(context.Background(), Action{
+		Verb:   "click",
+		URL:    "https://chase.com/transfer",
+		Target: "Send Money",
+	}); err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read jsonl: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2: %q", len(lines), data)
+	}
+	for i, line := range lines {
+		var entry AuditEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("line %d invalid JSON: %v", i, err)
+		}
+		if entry.SessionID != "sess-42" {
+			t.Errorf("line %d session id = %q", i, entry.SessionID)
+		}
+		if entry.Timestamp.IsZero() {
+			t.Errorf("line %d missing timestamp", i)
+		}
+	}
+}
+
+func TestEngine_RequestConfirmation_ContextCancel(t *testing.T) {
+	hung := make(chan struct{})
+	confirmer := ConfirmerFunc(func(ctx context.Context, a Action, reason string) (bool, error) {
+		<-ctx.Done()
+		close(hung)
+		return false, ctx.Err()
+	})
+	e := New(
+		WithConfirmer(confirmer),
+		WithConfirmationTimeout(time.Second),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ok, err := e.RequestConfirmation(ctx, Action{Verb: "send"}, "test")
+	if ok {
+		t.Fatalf("expected denial on cancelled ctx")
+	}
+	if err == nil {
+		t.Fatalf("expected error on cancelled ctx")
+	}
+	select {
+	case <-hung:
+		// goroutine cleaned up
+	case <-time.After(time.Second):
+		t.Fatalf("confirmer goroutine leaked")
+	}
+}
+
+func TestPolicy_FinancialOverridesAllowDefault(t *testing.T) {
+	p := DefaultPolicy()
+	// Even if a misconfigured policy says allow for Financial, the
+	// FinancialDefaultDeny safety floor stays disabled (intentionally:
+	// explicit allow is explicit).
+	p.Categories[CategoryFinancial] = VerdictAllow
+	v, _ := p.verdictFor([]Category{CategoryFinancial})
+	if v != VerdictAllow {
+		t.Fatalf("explicit allow should not be upgraded; got %s", v)
+	}
+
+	// But require_confirmation upgrades to deny under the safety floor.
+	p2 := DefaultPolicy()
+	p2.Categories[CategoryFinancial] = VerdictRequireConfirmation
+	v2, _ := p2.verdictFor([]Category{CategoryFinancial})
+	if v2 != VerdictDeny {
+		t.Fatalf("financial require_confirmation should upgrade to deny; got %s", v2)
+	}
+}

--- a/internal/computeruse/guardrails/policy.go
+++ b/internal/computeruse/guardrails/policy.go
@@ -1,0 +1,108 @@
+package guardrails
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Policy maps each Category to a default Verdict. Callers can override
+// individual entries via Engine options. Defaults follow the PRD §6.8 rule
+// of thumb: financial actions are deny-by-default on ambiguity, every
+// other destructive category requires explicit confirmation.
+type Policy struct {
+	// Default is the verdict for actions that match no category.
+	Default Verdict
+	// Per-category verdicts. Missing categories fall through to Default.
+	Categories map[Category]Verdict
+	// FinancialDefaultDeny preserves the safety floor: when true, an action
+	// with CategoryFinancial that would otherwise be RequireConfirmation
+	// upgrades to Deny. The MCP dispatcher must surface a clear error to
+	// the user — better to interrupt than to send a wrong wire.
+	FinancialDefaultDeny bool
+}
+
+// DefaultPolicy returns the PRD §6.8 default policy.
+func DefaultPolicy() Policy {
+	return Policy{
+		Default: VerdictAllow,
+		Categories: map[Category]Verdict{
+			CategoryCommunication: VerdictRequireConfirmation,
+			CategoryFinancial:     VerdictRequireConfirmation,
+			CategoryFilesystem:    VerdictRequireConfirmation,
+			CategorySystem:        VerdictRequireConfirmation,
+		},
+		FinancialDefaultDeny: true,
+	}
+}
+
+// verdictFor returns the verdict for the highest-priority category in cats.
+// When no category matches, it returns p.Default. The Financial-default-deny
+// upgrade is applied last so it always wins.
+func (p Policy) verdictFor(cats []Category) (Verdict, Category) {
+	if len(cats) == 0 {
+		return p.Default, CategoryUnknown
+	}
+	dominant := cats[0]
+	v, ok := p.Categories[dominant]
+	if !ok {
+		v = p.Default
+	}
+	if dominant == CategoryFinancial && p.FinancialDefaultDeny &&
+		v != VerdictAllow {
+		v = VerdictDeny
+	}
+	return v, dominant
+}
+
+// reasonFor renders a short, user-readable reason string.
+func reasonFor(verdict Verdict, dominant Category, a Action) string {
+	parts := []string{string(verdict)}
+	if dominant != CategoryUnknown {
+		parts = append(parts, "category="+string(dominant))
+	}
+	if a.Verb != "" {
+		parts = append(parts, "verb="+a.Verb)
+	}
+	if a.BundleID != "" {
+		parts = append(parts, "bundle="+a.BundleID)
+	} else if a.AppName != "" {
+		parts = append(parts, "app="+a.AppName)
+	}
+	if a.URL != "" {
+		if h := hostFromURL(a.URL); h != "" {
+			parts = append(parts, "host="+h)
+		}
+	}
+	if a.Target != "" {
+		parts = append(parts, fmt.Sprintf("target=%q", a.Target))
+	}
+	return strings.Join(parts, " ")
+}
+
+// Confirmer is the host-side hook that the TUI / CLI / GUI implements.
+// It MUST block until the user makes a decision OR the supplied context is
+// cancelled. On context cancellation it MUST return (false, ctx.Err()) so
+// the engine can fail closed.
+//
+// Implementations are expected to render `reason` verbatim so the user
+// sees exactly what is being asked.
+type Confirmer interface {
+	Confirm(ctx context.Context, action Action, reason string) (bool, error)
+}
+
+// ConfirmerFunc adapts a plain function to the Confirmer interface.
+type ConfirmerFunc func(ctx context.Context, action Action, reason string) (bool, error)
+
+// Confirm implements Confirmer.
+func (f ConfirmerFunc) Confirm(ctx context.Context, action Action, reason string) (bool, error) {
+	return f(ctx, action, reason)
+}
+
+// denyConfirmer is the safe-by-default confirmer used when the host did not
+// supply one. It always denies, ensuring the engine fails closed.
+type denyConfirmer struct{}
+
+func (denyConfirmer) Confirm(_ context.Context, _ Action, _ string) (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
## Summary

Adds `internal/computeruse/guardrails`, a self-contained policy module that the MCP step dispatcher (#37) and capability adapters (#40) consult **before** executing any computer-use action.

- **Classifier** labels actions with one or more risk categories — Communication (Mail / Messages / Slack / mail.google.com / x.com / etc.), Financial (Chase / Stripe / Coinbase / checkout buttons), Filesystem (rm -rf / Empty Trash / diskutil erase), System (shutdown / sudo / Restart). Bundle IDs, URL hosts, and keyword fragments are curated for v1 and extensible via `Config`.
- **Decision API** `Engine.Evaluate(ctx, action) -> Decision{Verdict, Categories, Reason, Confirmed}`. Verdicts are `allow`, `require_confirmation`, `deny`. Per-PRD §6.8: financial deny-by-default on ambiguity, every other destructive category requires explicit confirmation.
- **Confirmation hook** `Engine.RequestConfirmation` / `Confirmer` interface that the host UI (TUI / CLI / GUI) implements. Bounded timeout (default 60 s); timeouts, ctx cancel, errors, and a missing confirmer **all fail closed** to deny.
- **Audit** every decision is appended as JSONL (matches the per-session JSONL convention from #15). The `Text` payload is intentionally never logged. `FileAuditSink`, `WriterAuditSink`, and `MemoryAuditSink` are provided.
- **Wire-points** TODO comments reference #37 and #40 — no tight coupling, since those PRs are still in flight in the parallel batch.

## Hard rule alignment

- Default verdict on ambiguity: `deny` for financial, `require_confirmation` for everything else.
- No silent allow path: missing confirmer => deny; timeout => deny.
- Audit always written, including for `allow` decisions.

## Test plan

- [x] `go test ./internal/computeruse/guardrails/...` — classifier per category + benign actions + custom-config extension; engine allow/deny/timeout/cancel paths; JSONL file format.
- [x] `go test ./...` — full suite green.
- [x] `make lint` — gofmt + go vet clean.
- [ ] Wired into MCP dispatcher (deferred to #37 / #40 — TODO markers in `engine.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)