### PR TITLE
feat(computer-use): per-app approval system with persistent config (#39)

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/jabreeflor/conduit/internal/computeruse"
 	"github.com/jabreeflor/conduit/internal/endpoint"
 	evalpkg "github.com/jabreeflor/conduit/internal/eval"
 	"github.com/jabreeflor/conduit/internal/localmodel"
@@ -45,6 +46,12 @@ func main() {
 		case "usage":
 			if err := usage.RunCLI(context.Background(), os.Args[2:], os.Stdout, os.Stderr); err != nil {
 				fmt.Fprintf(os.Stderr, "conduit usage: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		case "computer-use":
+			if err := computeruse.RunCLI(context.Background(), os.Args[2:], os.Stdout, os.Stderr); err != nil {
+				fmt.Fprintf(os.Stderr, "conduit computer-use: %v\n", err)
 				os.Exit(1)
 			}
 			return

--- a/internal/computeruse/approval.go
+++ b/internal/computeruse/approval.go
@@ -1,0 +1,382 @@
+package computeruse
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultApprovalsPath is the on-disk location for the persistent approval
+// store. Mirrors the convention used by the usage tracker (#15) and credential
+// pool (#14): a per-user file under ~/.conduit/.
+const DefaultApprovalsPath = ".conduit/approved-apps.json"
+
+// Scope narrows what an approval grants. Values are intentionally
+// stringly-typed so users can hand-edit approved-apps.json without breaking
+// older Conduit binaries.
+type Scope string
+
+const (
+	// ScopeFull lets the agent perform any computer-use action against the app.
+	ScopeFull Scope = "full"
+	// ScopeReadOnly limits the agent to read-only inspection (screenshots,
+	// accessibility queries) without sending input events.
+	ScopeReadOnly Scope = "read_only"
+)
+
+// AppRef identifies a target macOS application. Either BundleID or Name must
+// be set; BundleID is preferred because it is stable across renames.
+type AppRef struct {
+	BundleID string `json:"bundle_id,omitempty"`
+	Name     string `json:"name,omitempty"`
+}
+
+// Key returns a stable lookup key for the app. Bundle IDs win when present;
+// otherwise we fall back to a normalised app name.
+func (a AppRef) Key() string {
+	if id := strings.TrimSpace(a.BundleID); id != "" {
+		return "bundle:" + strings.ToLower(id)
+	}
+	return "name:" + strings.ToLower(strings.TrimSpace(a.Name))
+}
+
+// IsZero reports whether the AppRef is empty (no bundle ID and no name).
+func (a AppRef) IsZero() bool {
+	return strings.TrimSpace(a.BundleID) == "" && strings.TrimSpace(a.Name) == ""
+}
+
+// ApprovalRecord is one row in the persistent approval store.
+//
+// Wire format (JSON):
+//
+//	{
+//	  "app":         { "bundle_id": "com.apple.Safari", "name": "Safari" },
+//	  "approved_at": "2026-05-02T12:00:00Z",
+//	  "scope":       "full",
+//	  "revoked_at":  null,
+//	  "note":        "approved during onboarding"
+//	}
+type ApprovalRecord struct {
+	App        AppRef     `json:"app"`
+	ApprovedAt time.Time  `json:"approved_at"`
+	Scope      Scope      `json:"scope"`
+	RevokedAt  *time.Time `json:"revoked_at,omitempty"`
+	Note       string     `json:"note,omitempty"`
+}
+
+// Active reports whether the record currently grants access. Revoked records
+// remain in the file so users keep an audit trail.
+func (r ApprovalRecord) Active() bool {
+	return r.RevokedAt == nil || r.RevokedAt.IsZero()
+}
+
+// Errors returned by the store. They are all sentinel values so callers can
+// match with errors.Is.
+var (
+	// ErrNotApproved means the requested app has no active approval. This is
+	// the error computer-use code paths must surface to the user.
+	ErrNotApproved = errors.New("computeruse: app is not approved")
+	// ErrUnknownApp is returned by Revoke when no record exists for the app.
+	ErrUnknownApp = errors.New("computeruse: no approval found for app")
+	// ErrEmptyApp guards against accidentally writing rows that match nothing.
+	ErrEmptyApp = errors.New("computeruse: app must have a bundle_id or name")
+)
+
+// fileSchema is the on-disk wrapper around the records slice. Wrapping in a
+// struct lets us add fields later without rewriting old files.
+type fileSchema struct {
+	Version  int              `json:"version"`
+	Records  []ApprovalRecord `json:"records"`
+	Modified time.Time        `json:"modified,omitempty"`
+}
+
+const currentSchemaVersion = 1
+
+// Store is the persistent per-app approval store.
+//
+// All public methods are safe for concurrent use. Writes go through a tmp
+// file + atomic rename so a crash mid-save can never leave a half-written
+// approvals file.
+type Store struct {
+	path    string
+	mu      sync.Mutex
+	records map[string]ApprovalRecord
+	now     func() time.Time
+}
+
+// Open loads (or initialises) the approval store at path. A missing file is
+// not an error — first-run code paths simply start with an empty store.
+func Open(path string) (*Store, error) {
+	if path == "" {
+		return nil, fmt.Errorf("computeruse: store path is required")
+	}
+	s := &Store{
+		path:    path,
+		records: make(map[string]ApprovalRecord),
+		now:     func() time.Time { return time.Now().UTC() },
+	}
+	if err := s.load(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// OpenDefault opens the store at ~/.conduit/approved-apps.json.
+func OpenDefault() (*Store, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("computeruse: resolve home dir: %w", err)
+	}
+	return Open(filepath.Join(home, DefaultApprovalsPath))
+}
+
+// Path returns the on-disk location of this store.
+func (s *Store) Path() string { return s.path }
+
+func (s *Store) load() error {
+	data, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("computeruse: read %s: %w", s.path, err)
+	}
+	if len(data) == 0 {
+		return nil
+	}
+
+	var file fileSchema
+	if err := json.Unmarshal(data, &file); err != nil {
+		return fmt.Errorf("computeruse: parse %s: %w", s.path, err)
+	}
+	for _, rec := range file.Records {
+		if rec.App.IsZero() {
+			continue
+		}
+		s.records[rec.App.Key()] = rec
+	}
+	return nil
+}
+
+func (s *Store) save() error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return fmt.Errorf("computeruse: create approvals dir: %w", err)
+	}
+
+	records := make([]ApprovalRecord, 0, len(s.records))
+	for _, rec := range s.records {
+		records = append(records, rec)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].App.Key() < records[j].App.Key()
+	})
+
+	file := fileSchema{
+		Version:  currentSchemaVersion,
+		Records:  records,
+		Modified: s.now(),
+	}
+	data, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		return fmt.Errorf("computeruse: encode approvals: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), filepath.Base(s.path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("computeruse: create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("computeruse: write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("computeruse: close temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("computeruse: replace %s: %w", s.path, err)
+	}
+	return nil
+}
+
+// IsApproved is the synchronous check computer-use call sites must call before
+// every action. Returns false for unknown, revoked, or zero AppRefs.
+//
+// This call is allocation-free in the common case so it is safe to call from
+// hot paths.
+func (s *Store) IsApproved(app AppRef) bool {
+	if app.IsZero() {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec, ok := s.records[app.Key()]
+	return ok && rec.Active()
+}
+
+// Lookup returns the stored record for app, if any. The boolean is false when
+// no record (active or revoked) exists.
+func (s *Store) Lookup(app AppRef) (ApprovalRecord, bool) {
+	if app.IsZero() {
+		return ApprovalRecord{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec, ok := s.records[app.Key()]
+	return rec, ok
+}
+
+// Approve grants scope to app and persists the record. If the app already has
+// an active or revoked record, the row is replaced with a fresh approval
+// (clearing any previous revocation timestamp).
+func (s *Store) Approve(app AppRef, scope Scope, note string) (ApprovalRecord, error) {
+	if app.IsZero() {
+		return ApprovalRecord{}, ErrEmptyApp
+	}
+	if scope == "" {
+		scope = ScopeFull
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rec := ApprovalRecord{
+		App:        app,
+		ApprovedAt: s.now(),
+		Scope:      scope,
+		Note:       note,
+	}
+	s.records[app.Key()] = rec
+	if err := s.save(); err != nil {
+		// Roll back the in-memory mutation so the store stays consistent
+		// with disk. This matters: a caller observing the error could still
+		// follow up with IsApproved and we don't want a phantom approval.
+		delete(s.records, app.Key())
+		return ApprovalRecord{}, err
+	}
+	return rec, nil
+}
+
+// Revoke marks the existing approval as revoked. The row is kept on disk so
+// users have an audit trail. Returns ErrUnknownApp if no record exists.
+func (s *Store) Revoke(app AppRef) (ApprovalRecord, error) {
+	if app.IsZero() {
+		return ApprovalRecord{}, ErrEmptyApp
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rec, ok := s.records[app.Key()]
+	if !ok {
+		return ApprovalRecord{}, ErrUnknownApp
+	}
+	if !rec.Active() {
+		return rec, nil
+	}
+	now := s.now()
+	rec.RevokedAt = &now
+	prev := s.records[app.Key()]
+	s.records[app.Key()] = rec
+	if err := s.save(); err != nil {
+		s.records[app.Key()] = prev
+		return ApprovalRecord{}, err
+	}
+	return rec, nil
+}
+
+// List returns every record (active and revoked), sorted by app key. The
+// returned slice is a copy and may be mutated by the caller.
+func (s *Store) List() []ApprovalRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ApprovalRecord, 0, len(s.records))
+	for _, rec := range s.records {
+		out = append(out, rec)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].App.Key() < out[j].App.Key()
+	})
+	return out
+}
+
+// ActiveApprovals returns only the records that currently grant access.
+func (s *Store) ActiveApprovals() []ApprovalRecord {
+	all := s.List()
+	out := all[:0]
+	for _, rec := range all {
+		if rec.Active() {
+			out = append(out, rec)
+		}
+	}
+	return out
+}
+
+// Confirm is a callback that prompts the user to approve an app. It returns
+// the granted scope, an optional note for the audit trail, and an error if
+// the user declines or cancels. CLI/TUI integrations supply their own
+// implementation; tests can pass a deterministic stub.
+type Confirm func(app AppRef) (scope Scope, note string, err error)
+
+// RequestApproval is the high-level helper a computer-use entry point can
+// call when an app is not yet approved. If the app already has an active
+// approval, the existing record is returned without prompting. Otherwise
+// confirm is invoked and (on success) the result is persisted.
+//
+// Pass a nil confirm to refuse approval automatically — useful in headless
+// runs where prompting is not possible.
+func (s *Store) RequestApproval(app AppRef, confirm Confirm) (ApprovalRecord, error) {
+	if app.IsZero() {
+		return ApprovalRecord{}, ErrEmptyApp
+	}
+	if rec, ok := s.Lookup(app); ok && rec.Active() {
+		return rec, nil
+	}
+	if confirm == nil {
+		return ApprovalRecord{}, ErrNotApproved
+	}
+	scope, note, err := confirm(app)
+	if err != nil {
+		return ApprovalRecord{}, err
+	}
+	return s.Approve(app, scope, note)
+}
+
+// EnsureApproved is the integration hook computer-use call sites must invoke
+// before every action against app. It performs a fast IsApproved check and,
+// if no approval exists, returns ErrNotApproved without prompting.
+//
+// TODO(#37,#40): wire from MCP request handler and capability adapters. The
+// MCP runtime (#37) should call EnsureApproved as the first step of
+// dispatching any computer-use tool call; capability adapters (#40) must
+// likewise gate every action behind this check. The function is intentionally
+// allocation-free and concurrency-safe for use on hot paths.
+func (s *Store) EnsureApproved(app AppRef) error {
+	if s.IsApproved(app) {
+		return nil
+	}
+	return fmt.Errorf("%w: %s", ErrNotApproved, displayName(app))
+}
+
+func displayName(app AppRef) string {
+	if app.Name != "" {
+		if app.BundleID != "" {
+			return fmt.Sprintf("%s (%s)", app.Name, app.BundleID)
+		}
+		return app.Name
+	}
+	if app.BundleID != "" {
+		return app.BundleID
+	}
+	return "<empty app>"
+}

--- a/internal/computeruse/approval_test.go
+++ b/internal/computeruse/approval_test.go
@@ -1,0 +1,375 @@
+package computeruse_test
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/computeruse"
+)
+
+func newStore(t *testing.T) (*computeruse.Store, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "approved-apps.json")
+	store, err := computeruse.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return store, path
+}
+
+func TestStore_ApproveThenIsApproved(t *testing.T) {
+	store, _ := newStore(t)
+	app := computeruse.AppRef{BundleID: "com.apple.Safari", Name: "Safari"}
+
+	if store.IsApproved(app) {
+		t.Fatal("IsApproved should be false before Approve")
+	}
+
+	rec, err := store.Approve(app, computeruse.ScopeFull, "onboarding")
+	if err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if rec.Scope != computeruse.ScopeFull {
+		t.Errorf("Scope = %q, want %q", rec.Scope, computeruse.ScopeFull)
+	}
+	if rec.ApprovedAt.IsZero() {
+		t.Error("ApprovedAt should be populated")
+	}
+	if !rec.Active() {
+		t.Error("freshly-approved record should be Active()")
+	}
+	if !store.IsApproved(app) {
+		t.Error("IsApproved should be true after Approve")
+	}
+}
+
+func TestStore_DefaultScopeIsFull(t *testing.T) {
+	store, _ := newStore(t)
+	rec, err := store.Approve(computeruse.AppRef{BundleID: "com.example"}, "", "")
+	if err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if rec.Scope != computeruse.ScopeFull {
+		t.Errorf("default Scope = %q, want %q", rec.Scope, computeruse.ScopeFull)
+	}
+}
+
+func TestStore_RejectsEmptyAppRef(t *testing.T) {
+	store, _ := newStore(t)
+	if _, err := store.Approve(computeruse.AppRef{}, computeruse.ScopeFull, ""); !errors.Is(err, computeruse.ErrEmptyApp) {
+		t.Errorf("Approve(empty) err = %v, want ErrEmptyApp", err)
+	}
+	if store.IsApproved(computeruse.AppRef{}) {
+		t.Error("IsApproved(empty) should be false")
+	}
+}
+
+func TestStore_RoundTripPersistsApprovals(t *testing.T) {
+	store, path := newStore(t)
+	app := computeruse.AppRef{BundleID: "com.apple.Mail", Name: "Mail"}
+	if _, err := store.Approve(app, computeruse.ScopeReadOnly, "audit"); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+
+	// Re-open from disk and verify the record is preserved verbatim.
+	reopened, err := computeruse.Open(path)
+	if err != nil {
+		t.Fatalf("Open after Approve: %v", err)
+	}
+	if !reopened.IsApproved(app) {
+		t.Error("approval should survive reopen")
+	}
+	rec, ok := reopened.Lookup(app)
+	if !ok {
+		t.Fatal("Lookup should find the persisted record")
+	}
+	if rec.Scope != computeruse.ScopeReadOnly {
+		t.Errorf("persisted Scope = %q, want %q", rec.Scope, computeruse.ScopeReadOnly)
+	}
+	if rec.Note != "audit" {
+		t.Errorf("persisted Note = %q, want %q", rec.Note, "audit")
+	}
+}
+
+func TestStore_Revoke(t *testing.T) {
+	store, path := newStore(t)
+	app := computeruse.AppRef{BundleID: "com.apple.Terminal"}
+	if _, err := store.Approve(app, computeruse.ScopeFull, ""); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+
+	rec, err := store.Revoke(app)
+	if err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if rec.RevokedAt == nil || rec.RevokedAt.IsZero() {
+		t.Error("RevokedAt should be populated after Revoke")
+	}
+	if rec.Active() {
+		t.Error("revoked record should not be Active()")
+	}
+	if store.IsApproved(app) {
+		t.Error("IsApproved should be false after Revoke")
+	}
+
+	// Revocation persists across reopen and is preserved (audit trail).
+	reopened, err := computeruse.Open(path)
+	if err != nil {
+		t.Fatalf("Open after Revoke: %v", err)
+	}
+	if reopened.IsApproved(app) {
+		t.Error("revoked status should survive reopen")
+	}
+	if got, ok := reopened.Lookup(app); !ok || got.Active() {
+		t.Errorf("Lookup after reopen: rec=%+v ok=%v want revoked record", got, ok)
+	}
+}
+
+func TestStore_RevokeUnknownReturnsSentinel(t *testing.T) {
+	store, _ := newStore(t)
+	if _, err := store.Revoke(computeruse.AppRef{BundleID: "com.unknown"}); !errors.Is(err, computeruse.ErrUnknownApp) {
+		t.Errorf("Revoke(unknown) err = %v, want ErrUnknownApp", err)
+	}
+}
+
+func TestStore_ApproveAfterRevokeReinstates(t *testing.T) {
+	store, _ := newStore(t)
+	app := computeruse.AppRef{BundleID: "com.apple.Safari"}
+
+	if _, err := store.Approve(app, computeruse.ScopeFull, ""); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if _, err := store.Revoke(app); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if _, err := store.Approve(app, computeruse.ScopeFull, "re-approved"); err != nil {
+		t.Fatalf("re-Approve: %v", err)
+	}
+	if !store.IsApproved(app) {
+		t.Error("re-approved app should be approved again")
+	}
+	rec, _ := store.Lookup(app)
+	if !rec.Active() {
+		t.Error("re-approved record should be Active()")
+	}
+	if rec.RevokedAt != nil {
+		t.Error("re-approval should clear RevokedAt")
+	}
+}
+
+func TestStore_List(t *testing.T) {
+	store, _ := newStore(t)
+	apps := []computeruse.AppRef{
+		{BundleID: "com.apple.Safari"},
+		{BundleID: "com.apple.Mail"},
+		{Name: "OldUtility"},
+	}
+	for _, a := range apps {
+		if _, err := store.Approve(a, computeruse.ScopeFull, ""); err != nil {
+			t.Fatalf("Approve %v: %v", a, err)
+		}
+	}
+	if _, err := store.Revoke(apps[2]); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+
+	if got := store.List(); len(got) != 3 {
+		t.Errorf("List len = %d, want 3 (revoked rows kept for audit)", len(got))
+	}
+	if got := store.ActiveApprovals(); len(got) != 2 {
+		t.Errorf("ActiveApprovals len = %d, want 2", len(got))
+	}
+}
+
+func TestStore_RequestApprovalUsesConfirm(t *testing.T) {
+	store, _ := newStore(t)
+	app := computeruse.AppRef{BundleID: "com.example.app"}
+
+	called := 0
+	confirm := func(a computeruse.AppRef) (computeruse.Scope, string, error) {
+		called++
+		if a.BundleID != app.BundleID {
+			t.Errorf("confirm got app %v, want %v", a, app)
+		}
+		return computeruse.ScopeReadOnly, "user said ok", nil
+	}
+
+	rec, err := store.RequestApproval(app, confirm)
+	if err != nil {
+		t.Fatalf("RequestApproval: %v", err)
+	}
+	if rec.Scope != computeruse.ScopeReadOnly {
+		t.Errorf("Scope = %q, want %q", rec.Scope, computeruse.ScopeReadOnly)
+	}
+	if !store.IsApproved(app) {
+		t.Error("IsApproved should be true after RequestApproval")
+	}
+
+	// A second RequestApproval for the same active app must NOT prompt again.
+	if _, err := store.RequestApproval(app, confirm); err != nil {
+		t.Fatalf("RequestApproval (already approved): %v", err)
+	}
+	if called != 1 {
+		t.Errorf("confirm called %d times, want 1 (cached)", called)
+	}
+}
+
+func TestStore_RequestApprovalNilConfirmDeniesByDefault(t *testing.T) {
+	store, _ := newStore(t)
+	app := computeruse.AppRef{BundleID: "com.example"}
+	if _, err := store.RequestApproval(app, nil); !errors.Is(err, computeruse.ErrNotApproved) {
+		t.Errorf("RequestApproval(nil) err = %v, want ErrNotApproved", err)
+	}
+	if store.IsApproved(app) {
+		t.Error("denied request should not produce an approval")
+	}
+}
+
+func TestStore_EnsureApprovedReturnsSentinel(t *testing.T) {
+	store, _ := newStore(t)
+	app := computeruse.AppRef{BundleID: "com.example"}
+
+	err := store.EnsureApproved(app)
+	if !errors.Is(err, computeruse.ErrNotApproved) {
+		t.Fatalf("EnsureApproved err = %v, want ErrNotApproved", err)
+	}
+	if !strings.Contains(err.Error(), "com.example") {
+		t.Errorf("EnsureApproved error %q should mention the app id", err)
+	}
+
+	if _, err := store.Approve(app, computeruse.ScopeFull, ""); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if err := store.EnsureApproved(app); err != nil {
+		t.Errorf("EnsureApproved after Approve: %v", err)
+	}
+}
+
+func TestStore_KeyMatchesByBundleIDFirst(t *testing.T) {
+	store, _ := newStore(t)
+	a := computeruse.AppRef{BundleID: "com.apple.Safari", Name: "Safari"}
+	b := computeruse.AppRef{BundleID: "com.apple.Safari", Name: "AnotherSafariFork"}
+
+	if _, err := store.Approve(a, computeruse.ScopeFull, ""); err != nil {
+		t.Fatalf("Approve a: %v", err)
+	}
+	// Same bundle id with a different name must hit the same record.
+	if !store.IsApproved(b) {
+		t.Error("IsApproved should match by BundleID when names differ")
+	}
+}
+
+func TestStore_KeyFallsBackToNameWhenBundleIDMissing(t *testing.T) {
+	store, _ := newStore(t)
+	a := computeruse.AppRef{Name: "MyTool"}
+	b := computeruse.AppRef{Name: "  mytool  "} // case + whitespace
+
+	if _, err := store.Approve(a, computeruse.ScopeFull, ""); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if !store.IsApproved(b) {
+		t.Error("IsApproved should normalise name (case + whitespace)")
+	}
+}
+
+func TestStore_OpenMissingFileIsNotAnError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nope", "approved-apps.json")
+	store, err := computeruse.Open(path)
+	if err != nil {
+		t.Fatalf("Open(missing): %v", err)
+	}
+	if got := store.List(); len(got) != 0 {
+		t.Errorf("fresh store List() len = %d, want 0", len(got))
+	}
+}
+
+func TestStore_OpenRejectsCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "approved-apps.json")
+	if err := os.WriteFile(path, []byte("{ this is not json"), 0o644); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+	if _, err := computeruse.Open(path); err == nil {
+		t.Error("Open should fail on corrupt JSON")
+	}
+}
+
+func TestStore_FileFormatIsHumanReadable(t *testing.T) {
+	store, path := newStore(t)
+	app := computeruse.AppRef{BundleID: "com.apple.Safari", Name: "Safari"}
+	if _, err := store.Approve(app, computeruse.ScopeFull, "onboarding"); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	// Indented JSON keeps the file user-editable, matching the convention
+	// established by the credentials/usage stores.
+	if !strings.Contains(string(data), "  ") {
+		t.Error("expected indented JSON output for human readability")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("file is not valid JSON: %v", err)
+	}
+	if _, ok := parsed["records"]; !ok {
+		t.Error("file should contain a records array")
+	}
+	if v, ok := parsed["version"].(float64); !ok || int(v) != 1 {
+		t.Errorf("file version = %v, want 1", parsed["version"])
+	}
+}
+
+func TestStore_AtomicSavePreservesPreviousFileOnError(t *testing.T) {
+	// Verifies that a save() going through tmp+rename never leaves a
+	// partially-written file. We can't easily inject a write failure, but we
+	// can at least confirm that no .tmp-* siblings are left around after a
+	// successful Approve cycle.
+	store, path := newStore(t)
+	for i := range [5]struct{}{} {
+		app := computeruse.AppRef{BundleID: "com.example.app" + string(rune('A'+i))}
+		if _, err := store.Approve(app, computeruse.ScopeFull, ""); err != nil {
+			t.Fatalf("Approve %d: %v", i, err)
+		}
+	}
+	dir := filepath.Dir(path)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestStore_ModifiedTimestampUpdatedOnSave(t *testing.T) {
+	store, path := newStore(t)
+	app := computeruse.AppRef{BundleID: "com.example"}
+	if _, err := store.Approve(app, computeruse.ScopeFull, ""); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed struct {
+		Modified time.Time `json:"modified"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if parsed.Modified.IsZero() {
+		t.Error("modified timestamp should be set after save")
+	}
+}

--- a/internal/computeruse/cli.go
+++ b/internal/computeruse/cli.go
@@ -1,0 +1,259 @@
+package computeruse
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// RunCLI is the entry point for `conduit computer-use`. It manages the
+// persistent per-app approval store: list, approve, revoke, and check.
+func RunCLI(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
+		return printUsage(stdout)
+	}
+
+	switch args[0] {
+	case "list":
+		return runList(args[1:], stdout, stderr)
+	case "approve":
+		return runApprove(ctx, args[1:], stdout, stderr)
+	case "revoke":
+		return runRevoke(args[1:], stdout, stderr)
+	case "check":
+		return runCheck(args[1:], stdout, stderr)
+	default:
+		return fmt.Errorf("unknown computer-use subcommand %q; try: list, approve, revoke, check", args[0])
+	}
+}
+
+func printUsage(w io.Writer) error {
+	_, err := fmt.Fprint(w, `usage: conduit computer-use <command>
+
+Commands:
+  list                       show every approval (active + revoked) and its scope
+  approve --bundle <id>      grant computer-use permission for an app
+          [--name <name>]
+          [--scope full|read_only]
+          [--note <text>]
+          [--yes]            skip the interactive y/N prompt
+  revoke  --bundle <id>      revoke a previously granted approval
+          [--name <name>]
+  check   --bundle <id>      exit 0 if the app is approved, 1 otherwise
+          [--name <name>]
+
+Approvals persist to ~/.conduit/approved-apps.json and survive across runs.
+`)
+	return err
+}
+
+func openStore(stderr io.Writer) (*Store, error) {
+	store, err := OpenDefault()
+	if err != nil {
+		fmt.Fprintf(stderr, "computer-use: open store: %v\n", err)
+		return nil, err
+	}
+	return store, nil
+}
+
+func runList(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("computer-use list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	activeOnly := fs.Bool("active", false, "show only currently-granting approvals")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	store, err := openStore(stderr)
+	if err != nil {
+		return err
+	}
+
+	var records []ApprovalRecord
+	if *activeOnly {
+		records = store.ActiveApprovals()
+	} else {
+		records = store.List()
+	}
+	if len(records) == 0 {
+		fmt.Fprintln(stdout, "no approvals on file.")
+		return nil
+	}
+
+	fmt.Fprintf(stdout, "%s\n", store.Path())
+	for _, rec := range records {
+		state := "active "
+		when := rec.ApprovedAt.Format("2006-01-02")
+		if !rec.Active() {
+			state = "revoked"
+			if rec.RevokedAt != nil {
+				when = rec.RevokedAt.Format("2006-01-02")
+			}
+		}
+		note := ""
+		if rec.Note != "" {
+			note = "  -- " + rec.Note
+		}
+		fmt.Fprintf(stdout, "  [%s] %s  scope=%s  %s%s\n",
+			state, displayName(rec.App), rec.Scope, when, note)
+	}
+	return nil
+}
+
+func runApprove(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("computer-use approve", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	bundle := fs.String("bundle", "", "macOS bundle ID (preferred)")
+	name := fs.String("name", "", "fallback app display name")
+	scope := fs.String("scope", string(ScopeFull), "approval scope: full | read_only")
+	note := fs.String("note", "", "optional note recorded in the audit trail")
+	yes := fs.Bool("yes", false, "skip the interactive confirmation prompt")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	app := AppRef{BundleID: *bundle, Name: *name}
+	if app.IsZero() {
+		return fmt.Errorf("computer-use approve: --bundle or --name is required")
+	}
+	parsed, err := parseScope(*scope)
+	if err != nil {
+		return err
+	}
+
+	store, err := openStore(stderr)
+	if err != nil {
+		return err
+	}
+
+	if !*yes {
+		ok, err := confirmInteractive(ctx, stdout, app, parsed)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Fprintln(stdout, "approval declined.")
+			return nil
+		}
+	}
+
+	rec, err := store.Approve(app, parsed, *note)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "approved %s with scope=%s (saved to %s).\n",
+		displayName(rec.App), rec.Scope, store.Path())
+	return nil
+}
+
+func runRevoke(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("computer-use revoke", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	bundle := fs.String("bundle", "", "macOS bundle ID")
+	name := fs.String("name", "", "fallback app display name")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	app := AppRef{BundleID: *bundle, Name: *name}
+	if app.IsZero() {
+		return fmt.Errorf("computer-use revoke: --bundle or --name is required")
+	}
+
+	store, err := openStore(stderr)
+	if err != nil {
+		return err
+	}
+	rec, err := store.Revoke(app)
+	if err != nil {
+		if errors.Is(err, ErrUnknownApp) {
+			fmt.Fprintf(stderr, "no approval on file for %s.\n", displayName(app))
+		}
+		return err
+	}
+	fmt.Fprintf(stdout, "revoked %s (was scope=%s).\n", displayName(rec.App), rec.Scope)
+	return nil
+}
+
+func runCheck(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("computer-use check", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	bundle := fs.String("bundle", "", "macOS bundle ID")
+	name := fs.String("name", "", "fallback app display name")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	app := AppRef{BundleID: *bundle, Name: *name}
+	if app.IsZero() {
+		return fmt.Errorf("computer-use check: --bundle or --name is required")
+	}
+
+	store, err := openStore(stderr)
+	if err != nil {
+		return err
+	}
+	if store.IsApproved(app) {
+		fmt.Fprintf(stdout, "approved: %s\n", displayName(app))
+		return nil
+	}
+	fmt.Fprintf(stdout, "not approved: %s\n", displayName(app))
+	// Mirrors `git diff --exit-code`: non-zero exit is the actionable signal
+	// for shell scripts. The CLI caller maps this error to os.Exit(1).
+	return ErrNotApproved
+}
+
+func parseScope(raw string) (Scope, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "full":
+		return ScopeFull, nil
+	case "read_only", "readonly", "ro":
+		return ScopeReadOnly, nil
+	default:
+		return "", fmt.Errorf("computer-use: unknown scope %q (want full | read_only)", raw)
+	}
+}
+
+func confirmInteractive(ctx context.Context, w io.Writer, app AppRef, scope Scope) (bool, error) {
+	if !isTerminal(os.Stdin) {
+		return false, fmt.Errorf("computer-use approve: stdin is not a terminal; pass --yes to confirm non-interactively")
+	}
+	fmt.Fprintf(w, "Grant Conduit %s access to %s? [y/N] ", scope, displayName(app))
+
+	type result struct {
+		answer string
+		err    error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		reader := bufio.NewReader(os.Stdin)
+		line, err := reader.ReadString('\n')
+		ch <- result{answer: strings.TrimSpace(line), err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	case r := <-ch:
+		if r.err != nil && !errors.Is(r.err, io.EOF) {
+			return false, r.err
+		}
+		ans := strings.ToLower(r.answer)
+		return ans == "y" || ans == "yes", nil
+	}
+}
+
+// isTerminal reports whether f looks like an interactive TTY. We avoid pulling
+// in an extra dep (golang.org/x/term) by sniffing the file mode — good enough
+// for the CLI prompt path. Tests bypass this branch via --yes.
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}

--- a/internal/computeruse/cli_test.go
+++ b/internal/computeruse/cli_test.go
@@ -1,0 +1,152 @@
+package computeruse
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withFakeHome redirects HOME so CLI calls that touch ~/.conduit land in a
+// scratch directory rather than the developer's real home.
+func withFakeHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	return dir
+}
+
+func TestRunCLI_HelpExits(t *testing.T) {
+	withFakeHome(t)
+	var out, errBuf bytes.Buffer
+	if err := RunCLI(context.Background(), nil, &out, &errBuf); err != nil {
+		t.Fatalf("RunCLI(nil): %v", err)
+	}
+	if !strings.Contains(out.String(), "computer-use") {
+		t.Errorf("help output missing program name: %q", out.String())
+	}
+}
+
+func TestRunCLI_ApproveListRevokeRoundTrip(t *testing.T) {
+	home := withFakeHome(t)
+	var out, errBuf bytes.Buffer
+
+	args := []string{"approve", "--bundle", "com.apple.Safari", "--name", "Safari", "--scope", "full", "--note", "test", "--yes"}
+	if err := RunCLI(context.Background(), args, &out, &errBuf); err != nil {
+		t.Fatalf("approve: %v (stderr=%s)", err, errBuf.String())
+	}
+	if !strings.Contains(out.String(), "approved") {
+		t.Errorf("expected approve output, got %q", out.String())
+	}
+
+	// File should now exist at $HOME/.conduit/approved-apps.json.
+	path := filepath.Join(home, DefaultApprovalsPath)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("approvals file not created: %v", err)
+	}
+
+	// list should surface the entry.
+	out.Reset()
+	errBuf.Reset()
+	if err := RunCLI(context.Background(), []string{"list"}, &out, &errBuf); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out.String(), "com.apple.Safari") {
+		t.Errorf("list missing app: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "active") {
+		t.Errorf("list should mark entry active: %q", out.String())
+	}
+
+	// check should succeed (exit 0).
+	out.Reset()
+	errBuf.Reset()
+	if err := RunCLI(context.Background(), []string{"check", "--bundle", "com.apple.Safari"}, &out, &errBuf); err != nil {
+		t.Fatalf("check approved: %v", err)
+	}
+	if !strings.Contains(out.String(), "approved") {
+		t.Errorf("check output unexpected: %q", out.String())
+	}
+
+	// revoke flips state.
+	out.Reset()
+	errBuf.Reset()
+	if err := RunCLI(context.Background(), []string{"revoke", "--bundle", "com.apple.Safari"}, &out, &errBuf); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if !strings.Contains(out.String(), "revoked") {
+		t.Errorf("revoke output unexpected: %q", out.String())
+	}
+
+	// check after revoke must return ErrNotApproved.
+	out.Reset()
+	errBuf.Reset()
+	err := RunCLI(context.Background(), []string{"check", "--bundle", "com.apple.Safari"}, &out, &errBuf)
+	if !errors.Is(err, ErrNotApproved) {
+		t.Errorf("check after revoke err = %v, want ErrNotApproved", err)
+	}
+
+	// list --active should now be empty.
+	out.Reset()
+	errBuf.Reset()
+	if err := RunCLI(context.Background(), []string{"list", "--active"}, &out, &errBuf); err != nil {
+		t.Fatalf("list --active: %v", err)
+	}
+	if !strings.Contains(out.String(), "no approvals") {
+		t.Errorf("list --active should be empty: %q", out.String())
+	}
+}
+
+func TestRunCLI_ApproveRequiresAppRef(t *testing.T) {
+	withFakeHome(t)
+	var out, errBuf bytes.Buffer
+	err := RunCLI(context.Background(), []string{"approve", "--yes"}, &out, &errBuf)
+	if err == nil || !strings.Contains(err.Error(), "required") {
+		t.Errorf("expected error about missing --bundle/--name, got %v", err)
+	}
+}
+
+func TestRunCLI_RevokeUnknownApp(t *testing.T) {
+	withFakeHome(t)
+	var out, errBuf bytes.Buffer
+	err := RunCLI(context.Background(), []string{"revoke", "--bundle", "com.unknown"}, &out, &errBuf)
+	if !errors.Is(err, ErrUnknownApp) {
+		t.Errorf("revoke unknown err = %v, want ErrUnknownApp", err)
+	}
+}
+
+func TestRunCLI_UnknownSubcommand(t *testing.T) {
+	withFakeHome(t)
+	var out, errBuf bytes.Buffer
+	err := RunCLI(context.Background(), []string{"bogus"}, &out, &errBuf)
+	if err == nil || !strings.Contains(err.Error(), "unknown computer-use subcommand") {
+		t.Errorf("expected unknown subcommand error, got %v", err)
+	}
+}
+
+func TestParseScope(t *testing.T) {
+	cases := map[string]Scope{
+		"":          ScopeFull,
+		"full":      ScopeFull,
+		"FULL":      ScopeFull,
+		"read_only": ScopeReadOnly,
+		"readonly":  ScopeReadOnly,
+		"ro":        ScopeReadOnly,
+	}
+	for in, want := range cases {
+		got, err := parseScope(in)
+		if err != nil {
+			t.Errorf("parseScope(%q) err = %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("parseScope(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if _, err := parseScope("nuke"); err == nil {
+		t.Error("parseScope(nuke) should error")
+	}
+}

--- a/internal/computeruse/doc.go
+++ b/internal/computeruse/doc.go
@@ -1,0 +1,12 @@
+// Package computeruse holds the runtime hooks that gate Conduit's macOS
+// computer-use capability (PRD §6.8).
+//
+// The package is self-contained: callers depend only on the exported types
+// and functions here. Sibling computer-use modules (MCP runtime in #37,
+// capability adapters in #40) integrate via the EnsureApproved hook below.
+//
+// Approvals are persisted to ~/.conduit/approved-apps.json so that revocations
+// and grants survive across processes. The on-disk format is documented on
+// ApprovalRecord and is intentionally human-readable: users may audit or
+// hand-edit it just like the credentials/usage files.
+package computeruse


### PR DESCRIPTION
## Summary

Introduces `internal/computeruse`, the durable per-app approval store that PRD §6.8 requires before Conduit can drive any macOS app. Self-contained module ready for the in-flight MCP runtime (#37) and capability adapters (#40) to integrate with.

- **Persistent approval store** — `ApprovalRecord` (bundle id / app name, scope, `approved_at`, `revoked_at`, optional note) saved atomically as indented JSON to `~/.conduit/approved-apps.json`, matching the convention from #14 (credentials) and #15 (usage tracker).
- **Store API** — `IsApproved` (hot-path check), `Lookup`, `Approve`, `Revoke` (revoked rows kept on disk for audit trail), `List`, `ActiveApprovals`, `RequestApproval` (with `Confirm` callback), and `EnsureApproved` as the integration hook for the MCP runtime / capability adapters. Carries a `// TODO(#37,#40): wire from MCP request handler` marker. All methods are concurrency-safe; saves go through `tmp + rename` so a crash mid-save can never leave a half-written file.
- **CLI** — new `conduit computer-use {list,approve,revoke,check}` subcommand wired into `cmd/conduit/main.go` so users can manage approvals directly (`--scope full|read_only`, optional `--note`, `--yes` to skip the y/N prompt).
- **Tests** — 23 new tests cover load/save round-trip, revoke + reinstate, audit-trail retention, bundle-id-vs-name keying, atomic save (no leftover `.tmp-*`), corrupt-file rejection, CLI subcommands, and the `EnsureApproved` sentinel error.

## Test plan

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes (`internal/computeruse` 23/23, no regressions in other packages)
- [x] `make build` succeeds
- [x] Manual smoketest: `conduit computer-use approve --bundle com.apple.Safari --name Safari --note "smoketest" --yes` → `conduit computer-use list` → `conduit computer-use revoke --bundle com.apple.Safari` round-trips through `~/.conduit/approved-apps.json` correctly

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)