### PR TITLE
feat(computer-use): integrate open-codex-computer-use MCP server (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,39 @@ make test       # unit tests
 make release    # darwin arm64/amd64 release binaries in dist/
 ```
 
+## MCP Servers
+
+Conduit speaks the Model Context Protocol both ways: it exposes its built-in tools as an MCP server (`conduit mcp serve`) and connects to external MCP servers configured in `~/.conduit/mcp.yaml` (or per-project `.conduit/mcp.yaml`).
+
+```sh
+conduit mcp list                       # show configured servers + tool counts
+conduit mcp serve [addr]                # expose Conduit tools over MCP/HTTP
+conduit mcp call <server> <tool> k=v…   # one-shot tool invocation
+```
+
+### Computer use (PRD §6.8)
+
+Conduit ships a built-in integration with [`open-codex-computer-use`](https://github.com/iFurySt/open-codex-computer-use) for macOS Accessibility + Screen Recording. It is **off by default**. Enable it in your root config:
+
+```yaml
+# ~/.conduit/config.yaml
+computer_use:
+  enabled: true
+  # command: open-computer-use   # optional override
+  # args: [mcp]                  # optional override
+  # allowlist: [list_apps, get_app_state, press_key]
+```
+
+Then install the upstream binary and grant macOS permissions on first run:
+
+```sh
+npm i -g open-computer-use
+open-computer-use            # one-time: grant Accessibility + Screen Recording
+conduit mcp list             # should show "open-computer-use" with ok status
+```
+
+The integration is gated on `runtime.GOOS == "darwin"` so non-macOS dev environments stay untouched even if the flag is enabled. User-supplied entries with the same name in `mcp.yaml` always win, so you can pin a custom binary path or transport without losing the rest of your MCP config.
+
 ## Roadmap
 
 Conduit is shipped in phases. See [docs/PRD.md § 19](./docs/PRD.md) for the full roadmap.

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/jabreeflor/conduit/internal/computeruse"
+	"github.com/jabreeflor/conduit/internal/config"
 	"github.com/jabreeflor/conduit/internal/endpoint"
 	evalpkg "github.com/jabreeflor/conduit/internal/eval"
 	"github.com/jabreeflor/conduit/internal/localmodel"
@@ -18,7 +20,25 @@ import (
 
 var version = "dev"
 
+// registerBuiltinMCPServers wires Conduit subsystems that ship their own
+// MCP servers (PRD §6.8 computer use today; more later) into the MCP
+// runtime. User-supplied mcp.yaml entries always override these.
+func registerBuiltinMCPServers() {
+	cfg, err := config.Load()
+	if err != nil {
+		// Config errors are surfaced when callers actually need a
+		// section — don't fail startup on a bad config here.
+		return
+	}
+	cu := computeruse.FromRootConfig(cfg)
+	if entry, ok := cu.ServerEntry(); ok {
+		mcp.RegisterBuiltinServer(entry)
+	}
+}
+
 func main() {
+	registerBuiltinMCPServers()
+
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "--version", "version":

--- a/internal/computeruse/doc.go
+++ b/internal/computeruse/doc.go
@@ -1,0 +1,15 @@
+// Package computeruse wires the open-codex-computer-use MCP server
+// (https://github.com/iFurySt/open-codex-computer-use) into Conduit's MCP
+// runtime so the agent can drive macOS via the Accessibility API and
+// Screen Recording.
+//
+// This package owns the small surface that PRD §6.8 needs at the runtime
+// level: the canonical server name, the default stdio launch command,
+// platform gating (macOS-only by default), and a translator from a config
+// flag into an mcp.ServerEntry.
+//
+// Sibling work — issues #38 (permissions onboarding), #39 (per-app
+// approval), #40 (capability adapters), #41 (pre/post screenshots), and
+// #42 (safety guardrails) — extends this package rather than reaching
+// into mcp internals. Keep additions here narrow and clearly named.
+package computeruse

--- a/internal/computeruse/integration.go
+++ b/internal/computeruse/integration.go
@@ -1,0 +1,46 @@
+package computeruse
+
+import (
+	"github.com/jabreeflor/conduit/internal/config"
+	"github.com/jabreeflor/conduit/internal/mcp"
+)
+
+// FromRootConfig translates the root Conduit config's computer_use block
+// into the package-local Config. The two structs are kept separate so
+// ForceNonDarwin and other runtime knobs can grow here without bloating
+// the root YAML schema.
+func FromRootConfig(cfg config.Config) Config {
+	c := cfg.ComputerUse
+	return Config{
+		Enabled:        c.Enabled,
+		Command:        c.Command,
+		Args:           append([]string(nil), c.Args...),
+		Env:            append([]string(nil), c.Env...),
+		Allowlist:      append([]string(nil), c.Allowlist...),
+		ForceNonDarwin: c.ForceNonDarwin,
+	}
+}
+
+// MergeInto returns mcpCfg with the open-computer-use server entry
+// appended (or replacing an existing same-named entry) when the
+// integration is active. When inactive, mcpCfg is returned unchanged.
+//
+// User-supplied entries with the same name in mcpCfg take precedence —
+// this lets advanced users pin a specific binary path or transport
+// without losing the rest of their MCP config.
+func MergeInto(mcpCfg mcp.Config, c Config) mcp.Config {
+	entry, ok := c.ServerEntry()
+	if !ok {
+		return mcpCfg
+	}
+
+	for _, existing := range mcpCfg.Servers {
+		if existing.Name == ServerName {
+			// User-defined entry wins.
+			return mcpCfg
+		}
+	}
+
+	mcpCfg.Servers = append(mcpCfg.Servers, entry)
+	return mcpCfg
+}

--- a/internal/computeruse/integration_test.go
+++ b/internal/computeruse/integration_test.go
@@ -1,0 +1,82 @@
+package computeruse_test
+
+import (
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/computeruse"
+	"github.com/jabreeflor/conduit/internal/config"
+	"github.com/jabreeflor/conduit/internal/mcp"
+)
+
+func TestFromRootConfig(t *testing.T) {
+	root := config.Config{
+		ComputerUse: config.ComputerUseConfig{
+			Enabled:        true,
+			Command:        "open-computer-use",
+			Args:           []string{"mcp"},
+			Env:            []string{"X=1"},
+			Allowlist:      []string{"list_apps"},
+			ForceNonDarwin: true,
+		},
+	}
+	got := computeruse.FromRootConfig(root)
+	if !got.Enabled || !got.ForceNonDarwin {
+		t.Fatalf("flags not propagated: %+v", got)
+	}
+	if got.Command != "open-computer-use" {
+		t.Errorf("Command = %q", got.Command)
+	}
+	if len(got.Args) != 1 || got.Args[0] != "mcp" {
+		t.Errorf("Args = %v", got.Args)
+	}
+	if len(got.Env) != 1 || got.Env[0] != "X=1" {
+		t.Errorf("Env = %v", got.Env)
+	}
+	if len(got.Allowlist) != 1 || got.Allowlist[0] != "list_apps" {
+		t.Errorf("Allowlist = %v", got.Allowlist)
+	}
+}
+
+func TestMergeIntoInactive(t *testing.T) {
+	in := mcp.Config{Servers: []mcp.ServerEntry{{Name: "other"}}}
+	out := computeruse.MergeInto(in, computeruse.Config{Enabled: false})
+	if len(out.Servers) != 1 || out.Servers[0].Name != "other" {
+		t.Fatalf("inactive merge changed config: %+v", out.Servers)
+	}
+}
+
+func TestMergeIntoActiveAppends(t *testing.T) {
+	in := mcp.Config{Servers: []mcp.ServerEntry{{Name: "other"}}}
+	out := computeruse.MergeInto(in, computeruse.Config{
+		Enabled:        true,
+		ForceNonDarwin: true,
+	})
+	if len(out.Servers) != 2 {
+		t.Fatalf("expected 2 servers, got %d", len(out.Servers))
+	}
+	if out.Servers[1].Name != computeruse.ServerName {
+		t.Errorf("appended server name = %q", out.Servers[1].Name)
+	}
+}
+
+func TestMergeIntoUserOverrideWins(t *testing.T) {
+	// If a user has explicitly configured the server (e.g. with a custom
+	// binary path), the integration must not stomp it.
+	custom := mcp.ServerEntry{
+		Name:      computeruse.ServerName,
+		Transport: mcp.TransportStdio,
+		Command:   "/custom/path",
+		Args:      []string{"mcp", "--debug"},
+	}
+	in := mcp.Config{Servers: []mcp.ServerEntry{custom}}
+	out := computeruse.MergeInto(in, computeruse.Config{
+		Enabled:        true,
+		ForceNonDarwin: true,
+	})
+	if len(out.Servers) != 1 {
+		t.Fatalf("expected 1 server (user override), got %d", len(out.Servers))
+	}
+	if out.Servers[0].Command != "/custom/path" {
+		t.Errorf("user override lost: %+v", out.Servers[0])
+	}
+}

--- a/internal/computeruse/server.go
+++ b/internal/computeruse/server.go
@@ -1,0 +1,101 @@
+package computeruse
+
+import (
+	"runtime"
+
+	"github.com/jabreeflor/conduit/internal/mcp"
+)
+
+// ServerName is the canonical MCP server name Conduit uses for the
+// open-codex-computer-use integration. The wider codebase (allowlists,
+// approval gates, telemetry) keys off this string, so do not change it
+// without a migration.
+const ServerName = "open-computer-use"
+
+// DefaultCommand is the binary published by the upstream npm package
+// `open-computer-use`. Users install it once with `npm i -g
+// open-computer-use` and grant Accessibility + Screen Recording on macOS
+// the first time it runs.
+const DefaultCommand = "open-computer-use"
+
+// DefaultArgs invokes the server's stdio MCP transport, matching the
+// snippet documented in the upstream README's "mcpServers" example.
+var DefaultArgs = []string{"mcp"}
+
+// Config controls whether and how Conduit launches the open-computer-use
+// MCP server. Zero value is "off"; Enabled must be set explicitly.
+//
+// Sibling issues #38–#42 layer on top of this struct (per-app approval,
+// safety rails) — extend rather than rename.
+type Config struct {
+	// Enabled gates the entire integration. Defaults to false. The
+	// effective gate also requires runtime.GOOS == "darwin" unless the
+	// caller passes ForceNonDarwin (intended for tests / Linux preview).
+	Enabled bool `yaml:"enabled"`
+
+	// Command overrides the binary path. Empty means DefaultCommand.
+	Command string `yaml:"command,omitempty"`
+
+	// Args overrides the launch args. Nil means DefaultArgs.
+	Args []string `yaml:"args,omitempty"`
+
+	// Env is forwarded to the subprocess. Use the "KEY=value" form mcp
+	// already accepts.
+	Env []string `yaml:"env,omitempty"`
+
+	// Allowlist optionally restricts which tools the server may expose.
+	// Empty means all upstream tools are allowed; refer to the
+	// open-computer-use README for the current tool set.
+	Allowlist []string `yaml:"allowlist,omitempty"`
+
+	// ForceNonDarwin allows enabling the integration on non-macOS hosts.
+	// Off by default because Accessibility + Screen Recording are
+	// macOS-specific; upstream does support Linux/Windows but Conduit's
+	// permission flow (#38) is macOS-first in v1.
+	ForceNonDarwin bool `yaml:"force_non_darwin,omitempty"`
+}
+
+// IsActive reports whether ServerEntry should be registered for this
+// host given the config and current GOOS.
+func (c Config) IsActive() bool {
+	if !c.Enabled {
+		return false
+	}
+	if runtime.GOOS == "darwin" {
+		return true
+	}
+	return c.ForceNonDarwin
+}
+
+// ServerEntry returns the mcp.ServerEntry that boots open-computer-use
+// over stdio. The second return value is false when the integration is
+// inactive on the current host (caller should skip registration).
+//
+// Defaults are filled in here so callers can pass a bare Config{Enabled: true}
+// and get a working entry.
+func (c Config) ServerEntry() (mcp.ServerEntry, bool) {
+	if !c.IsActive() {
+		return mcp.ServerEntry{}, false
+	}
+
+	cmd := c.Command
+	if cmd == "" {
+		cmd = DefaultCommand
+	}
+
+	args := c.Args
+	if args == nil {
+		args = DefaultArgs
+	}
+
+	enabled := true
+	return mcp.ServerEntry{
+		Name:      ServerName,
+		Transport: mcp.TransportStdio,
+		Command:   cmd,
+		Args:      append([]string(nil), args...),
+		Env:       append([]string(nil), c.Env...),
+		Enabled:   &enabled,
+		Allowlist: append([]string(nil), c.Allowlist...),
+	}, true
+}

--- a/internal/computeruse/server_test.go
+++ b/internal/computeruse/server_test.go
@@ -1,0 +1,114 @@
+package computeruse_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/computeruse"
+	"github.com/jabreeflor/conduit/internal/mcp"
+)
+
+func TestConfigDisabledByDefault(t *testing.T) {
+	var c computeruse.Config
+	if c.IsActive() {
+		t.Fatal("zero-value Config must be inactive")
+	}
+	if _, ok := c.ServerEntry(); ok {
+		t.Fatal("zero-value Config must not produce a ServerEntry")
+	}
+}
+
+func TestConfigGatedByGOOS(t *testing.T) {
+	c := computeruse.Config{Enabled: true}
+	got := c.IsActive()
+	want := runtime.GOOS == "darwin"
+	if got != want {
+		t.Fatalf("IsActive on %s: got %v, want %v", runtime.GOOS, got, want)
+	}
+}
+
+func TestConfigForceNonDarwin(t *testing.T) {
+	c := computeruse.Config{Enabled: true, ForceNonDarwin: true}
+	if !c.IsActive() {
+		t.Fatal("ForceNonDarwin should activate on any GOOS when Enabled")
+	}
+	entry, ok := c.ServerEntry()
+	if !ok {
+		t.Fatal("expected ServerEntry when ForceNonDarwin is set")
+	}
+	if entry.Name != computeruse.ServerName {
+		t.Errorf("entry.Name = %q, want %q", entry.Name, computeruse.ServerName)
+	}
+	if entry.Transport != mcp.TransportStdio {
+		t.Errorf("entry.Transport = %q, want %q", entry.Transport, mcp.TransportStdio)
+	}
+	if entry.Command != computeruse.DefaultCommand {
+		t.Errorf("entry.Command = %q, want %q", entry.Command, computeruse.DefaultCommand)
+	}
+	if len(entry.Args) != 1 || entry.Args[0] != "mcp" {
+		t.Errorf("entry.Args = %v, want [mcp]", entry.Args)
+	}
+	if !entry.IsEnabled() {
+		t.Error("entry should be marked enabled")
+	}
+}
+
+func TestConfigOverridesCommandAndArgs(t *testing.T) {
+	c := computeruse.Config{
+		Enabled:        true,
+		ForceNonDarwin: true,
+		Command:        "/opt/cu/bin/open-computer-use",
+		Args:           []string{"mcp", "--verbose"},
+		Env:            []string{"FOO=bar"},
+		Allowlist:      []string{"list_apps", "get_app_state"},
+	}
+	entry, ok := c.ServerEntry()
+	if !ok {
+		t.Fatal("expected ServerEntry")
+	}
+	if entry.Command != c.Command {
+		t.Errorf("Command override lost: got %q, want %q", entry.Command, c.Command)
+	}
+	if len(entry.Args) != 2 || entry.Args[1] != "--verbose" {
+		t.Errorf("Args override lost: %v", entry.Args)
+	}
+	if len(entry.Env) != 1 || entry.Env[0] != "FOO=bar" {
+		t.Errorf("Env not propagated: %v", entry.Env)
+	}
+	if len(entry.Allowlist) != 2 {
+		t.Errorf("Allowlist not propagated: %v", entry.Allowlist)
+	}
+}
+
+func TestServerEntryIsolatesSlices(t *testing.T) {
+	// Mutating the returned entry must not affect the source Config.
+	c := computeruse.Config{
+		Enabled:        true,
+		ForceNonDarwin: true,
+		Args:           []string{"mcp"},
+		Allowlist:      []string{"list_apps"},
+		Env:            []string{"X=1"},
+	}
+	entry, _ := c.ServerEntry()
+	entry.Args[0] = "tampered"
+	entry.Allowlist[0] = "tampered"
+	entry.Env[0] = "tampered"
+
+	if c.Args[0] != "mcp" {
+		t.Errorf("Args aliased: %v", c.Args)
+	}
+	if c.Allowlist[0] != "list_apps" {
+		t.Errorf("Allowlist aliased: %v", c.Allowlist)
+	}
+	if c.Env[0] != "X=1" {
+		t.Errorf("Env aliased: %v", c.Env)
+	}
+}
+
+func TestServerNameIsStable(t *testing.T) {
+	// Allowlists, telemetry, and per-app approval (#39) key off this
+	// string. Changing it is a breaking change.
+	if computeruse.ServerName != "open-computer-use" {
+		t.Errorf("ServerName = %q; do not rename without a migration", computeruse.ServerName)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,35 @@ type Config struct {
 	Budgets     BudgetsConfig                  `yaml:"budgets"`
 	Costs       CostConfig                     `yaml:"costs"`
 	Credentials map[string]ProviderCredentials `yaml:"credentials"`
+	ComputerUse ComputerUseConfig              `yaml:"computer_use"`
+}
+
+// ComputerUseConfig controls the open-codex-computer-use MCP integration
+// (PRD §6.8). The full schema lives in internal/computeruse so the runtime
+// gating logic stays close to its consumers; this struct mirrors the
+// subset that lands in the root YAML config.
+type ComputerUseConfig struct {
+	// Enabled gates the integration. Defaults to false (off).
+	Enabled bool `yaml:"enabled"`
+
+	// Command overrides the binary path. Empty means the upstream default
+	// (`open-computer-use`, installed via `npm i -g open-computer-use`).
+	Command string `yaml:"command,omitempty"`
+
+	// Args overrides the launch args. Nil means the upstream default
+	// (["mcp"] — stdio transport).
+	Args []string `yaml:"args,omitempty"`
+
+	// Env is forwarded to the subprocess as "KEY=value" pairs.
+	Env []string `yaml:"env,omitempty"`
+
+	// Allowlist restricts which tools the upstream server may expose.
+	// Empty means all upstream tools are allowed.
+	Allowlist []string `yaml:"allowlist,omitempty"`
+
+	// ForceNonDarwin allows enabling the integration on non-macOS hosts
+	// (advanced; v1 permission flow is macOS-first — see PRD §6.8).
+	ForceNonDarwin bool `yaml:"force_non_darwin,omitempty"`
 }
 
 // ModelsConfig is the model-routing section.

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -80,7 +80,9 @@ func projectConfigPath() (string, error) {
 	return filepath.Join(cwd, ".conduit", "mcp.yaml"), nil
 }
 
-// LoadConfig reads and merges user-global + project-scoped MCP configs.
+// LoadConfig reads and merges user-global + project-scoped MCP configs,
+// then layers any process-registered built-in entries on top (lowest
+// precedence — user config always wins on a name collision).
 // Missing files are silently skipped; parse errors are returned.
 func LoadConfig() (Config, error) {
 	global, err := globalConfigPath()
@@ -91,7 +93,57 @@ func LoadConfig() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	return loadAndMerge(global, project)
+	cfg, err := loadAndMerge(global, project)
+	if err != nil {
+		return Config{}, err
+	}
+	return applyBuiltins(cfg), nil
+}
+
+// builtinServers is a process-wide registry of MCP server entries
+// contributed by Conduit subsystems (currently: computer-use, PRD §6.8).
+// Entries here are merged into LoadConfig's output as a base layer —
+// user-supplied entries with the same name always win.
+//
+// Registration is idempotent on Name. Intended caller: cmd/conduit at
+// startup. Tests can use ResetBuiltins to clean up.
+var builtinServers []ServerEntry
+
+// RegisterBuiltinServer adds (or replaces by Name) an entry that
+// LoadConfig should include unless the user has already configured a
+// server with the same name.
+func RegisterBuiltinServer(entry ServerEntry) {
+	for i, existing := range builtinServers {
+		if existing.Name == entry.Name {
+			builtinServers[i] = entry
+			return
+		}
+	}
+	builtinServers = append(builtinServers, entry)
+}
+
+// ResetBuiltins clears the built-in server registry. For tests.
+func ResetBuiltins() {
+	builtinServers = nil
+}
+
+// applyBuiltins merges builtinServers into cfg. User entries with the
+// same Name win.
+func applyBuiltins(cfg Config) Config {
+	if len(builtinServers) == 0 {
+		return cfg
+	}
+	existing := make(map[string]bool, len(cfg.Servers))
+	for _, s := range cfg.Servers {
+		existing[s.Name] = true
+	}
+	for _, b := range builtinServers {
+		if existing[b.Name] {
+			continue
+		}
+		cfg.Servers = append(cfg.Servers, b)
+	}
+	return cfg
 }
 
 func loadAndMerge(globalPath, projectPath string) (Config, error) {

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -56,6 +56,52 @@ func TestTransportKindConstants(t *testing.T) {
 	}
 }
 
+func TestRegisterBuiltinServer_AppendsAndDeduplicates(t *testing.T) {
+	t.Cleanup(mcp.ResetBuiltins)
+	mcp.ResetBuiltins()
+
+	mcp.RegisterBuiltinServer(mcp.ServerEntry{
+		Name:      "builtin-a",
+		Transport: mcp.TransportStdio,
+		Command:   "a",
+	})
+	// Re-register with the same name should replace, not duplicate.
+	mcp.RegisterBuiltinServer(mcp.ServerEntry{
+		Name:      "builtin-a",
+		Transport: mcp.TransportStdio,
+		Command:   "a-v2",
+	})
+	mcp.RegisterBuiltinServer(mcp.ServerEntry{
+		Name:      "builtin-b",
+		Transport: mcp.TransportStdio,
+		Command:   "b",
+	})
+
+	cfg, err := mcp.LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	var seenA, seenB bool
+	for _, s := range cfg.Servers {
+		switch s.Name {
+		case "builtin-a":
+			if seenA {
+				t.Errorf("builtin-a registered twice")
+			}
+			if s.Command != "a-v2" {
+				t.Errorf("builtin-a not replaced: %q", s.Command)
+			}
+			seenA = true
+		case "builtin-b":
+			seenB = true
+		}
+	}
+	if !seenA || !seenB {
+		t.Errorf("expected both builtins in config; seenA=%v seenB=%v", seenA, seenB)
+	}
+}
+
 // TestConfigServerAllowlist verifies that Allowlist field is parsed correctly.
 func TestConfigServerAllowlist(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- Wires [`open-codex-computer-use`](https://github.com/iFurySt/open-codex-computer-use) into Conduit's MCP runtime per PRD §6.8 (macOS Accessibility + Screen Recording).
- New `internal/computeruse` package owns the canonical server name, default stdio launch command (`open-computer-use mcp`), GOOS=darwin gating, and a small `Config` → `mcp.ServerEntry` translator.
- New `mcp.RegisterBuiltinServer` registry lets `cmd/conduit` contribute the entry at startup without creating an import cycle; user-supplied `mcp.yaml` entries with the same name always win.
- Off by default — enable with `computer_use.enabled: true` in `~/.conduit/config.yaml`.
- Adds README section documenting how to install upstream, grant macOS permissions, and verify with `conduit mcp list`.

## Test plan
- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes (new tests in `internal/computeruse` + `internal/mcp`)
- [x] `make build` produces the binary
- [x] Smoke test: with `computer_use.enabled: true` in an isolated `$HOME/.conduit/config.yaml`, `conduit mcp list` shows the `open-computer-use` entry attempting to launch (errors only because the upstream npm binary isn't installed in this sandbox)
- [ ] Manual verify on macOS: `npm i -g open-computer-use && open-computer-use` (grant a11y/screen recording), then `conduit mcp list` reports `ok` with the upstream tool list

## Notes for siblings (#38–#42)
- The exported `computeruse.ServerName` (`open-computer-use`) is the key to use for per-app approval (#39), allowlists, and telemetry. Don't rename without a migration.
- Extend `computeruse.Config` rather than reaching into `internal/mcp` — the package is intentionally narrow so #38–#42 can grow it.

Closes #37