### PR TITLE
feat(computer-use): Shell/Browser/Desktop capability adapters (#40)

### DIFF
--- a/internal/capabilities/browser.go
+++ b/internal/capabilities/browser.go
@@ -1,0 +1,15 @@
+package capabilities
+
+// BrowserCapability is the "Browser" tier of PRD §6.8 — web automation via
+// the Chrome MCP server. The adapter does not embed Chrome MCP; instead it
+// proxies to whichever MCP server the user has registered (default name:
+// "chrome") via MCPClientFactory. If that server is missing, ListTools and
+// Dispatch return UnavailableError so the rest of the harness keeps working.
+type BrowserCapability struct{ *mcpProxy }
+
+// NewBrowserCapability builds the Browser adapter. factory may be nil — the
+// adapter will then report itself as unavailable, which is the correct
+// behavior when Chrome MCP has not been configured.
+func NewBrowserCapability(cfg Config, approval Approval, factory MCPClientFactory) *BrowserCapability {
+	return &BrowserCapability{mcpProxy: newMCPProxy(KindBrowser, cfg.resolveServerName(KindBrowser), approval, factory)}
+}

--- a/internal/capabilities/capabilities_test.go
+++ b/internal/capabilities/capabilities_test.go
@@ -1,0 +1,369 @@
+package capabilities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// ---------- shared fakes ----------
+
+type fakeMCPClient struct {
+	tools    []MCPToolDef
+	listErr  error
+	calls    []mcpCall
+	closeErr error
+	closed   bool
+	respond  func(name string, args map[string]any) ([]MCPContent, error)
+}
+
+type mcpCall struct {
+	name string
+	args map[string]any
+}
+
+func (f *fakeMCPClient) ListTools(_ context.Context) ([]MCPToolDef, error) {
+	return f.tools, f.listErr
+}
+func (f *fakeMCPClient) CallTool(_ context.Context, name string, args map[string]any) ([]MCPContent, error) {
+	f.calls = append(f.calls, mcpCall{name: name, args: args})
+	if f.respond != nil {
+		return f.respond(name, args)
+	}
+	return []MCPContent{{Type: "text", Text: "ok:" + name}}, nil
+}
+func (f *fakeMCPClient) Close() error { f.closed = true; return f.closeErr }
+
+func factoryWith(clients map[string]*fakeMCPClient) MCPClientFactory {
+	return func(_ context.Context, name string) (MCPToolClient, error) {
+		c, ok := clients[name]
+		if !ok {
+			return nil, nil // server not registered
+		}
+		return c, nil
+	}
+}
+
+// ---------- Shell ----------
+
+func TestShellCapability_DispatchRunsCommand(t *testing.T) {
+	approval := ApprovalFunc(func(_ context.Context, app string, action string) (bool, error) {
+		if app != "shell" {
+			t.Fatalf("approval app = %q, want shell", app)
+		}
+		if !strings.HasPrefix(action, "echo ") {
+			t.Fatalf("approval action = %q, want echo prefix", action)
+		}
+		return true, nil
+	})
+
+	cap := NewShellCapability(Config{Shell: true}, approval).withRunner(
+		func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if name != "echo" {
+				t.Fatalf("runner name = %q, want echo", name)
+			}
+			return []byte(strings.Join(args, " ") + "\n"), nil
+		},
+	)
+	if err := cap.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := cap.Dispatch(context.Background(), "shell.exec", map[string]any{
+		"command": "echo",
+		"args":    []any{"hello", "world"},
+	})
+	if err != nil {
+		t.Fatalf("dispatch err = %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got %#v", res)
+	}
+	if res.Text != "hello world" {
+		t.Fatalf("text = %q, want %q", res.Text, "hello world")
+	}
+}
+
+func TestShellCapability_DenialReturnsErrorResult(t *testing.T) {
+	cap := NewShellCapability(Config{Shell: true}, DenyAllApproval).withRunner(
+		func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+			t.Fatal("runner must not run when approval denied")
+			return nil, nil
+		},
+	)
+	if err := cap.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	res, err := cap.Dispatch(context.Background(), "shell.exec", map[string]any{"command": "rm"})
+	if err != nil {
+		t.Fatalf("dispatch should not error on user denial, got %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("denied call must produce IsError=true, got %#v", res)
+	}
+}
+
+func TestShellCapability_AllowlistRejectsUnknownCommand(t *testing.T) {
+	cfg := Config{Shell: true, ShellAllowedCommands: []string{"git", "ls"}}
+	cap := NewShellCapability(cfg, AllowAllApproval).withRunner(
+		func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+			t.Fatal("runner must not run for disallowed command")
+			return nil, nil
+		},
+	)
+	_ = cap.Init(context.Background())
+	_, err := cap.Dispatch(context.Background(), "shell.exec", map[string]any{"command": "rm"})
+	if err == nil || !strings.Contains(err.Error(), "not in the allowed list") {
+		t.Fatalf("expected allow-list rejection, got %v", err)
+	}
+}
+
+func TestShellCapability_ListToolsExposesShellExec(t *testing.T) {
+	cap := NewShellCapability(Config{Shell: true}, AllowAllApproval)
+	if _, err := cap.ListTools(context.Background()); !errors.Is(err, ErrCapabilityUnavailable) {
+		t.Fatalf("list before init: err = %v, want unavailable", err)
+	}
+	_ = cap.Init(context.Background())
+	tools, err := cap.ListTools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Name != "shell.exec" || tools[0].Capability != KindShell {
+		t.Fatalf("tools = %#v", tools)
+	}
+}
+
+// ---------- Browser / Desktop (MCP-backed) ----------
+
+func TestBrowserCapability_Unavailable_WhenServerMissing(t *testing.T) {
+	cap := NewBrowserCapability(Config{Browser: true}, AllowAllApproval, factoryWith(nil))
+	if err := cap.Init(context.Background()); err != nil {
+		t.Fatalf("init err = %v", err)
+	}
+
+	_, err := cap.ListTools(context.Background())
+	if !errors.Is(err, ErrCapabilityUnavailable) {
+		t.Fatalf("ListTools err = %v, want unavailable", err)
+	}
+	if !strings.Contains(err.Error(), "chrome") {
+		t.Fatalf("unavailable reason should mention server name, got %q", err.Error())
+	}
+
+	_, err = cap.Dispatch(context.Background(), "browser.navigate", nil)
+	if !errors.Is(err, ErrCapabilityUnavailable) {
+		t.Fatalf("Dispatch err = %v, want unavailable", err)
+	}
+}
+
+func TestDesktopCapability_Unavailable_WhenFactoryNil(t *testing.T) {
+	cap := NewDesktopCapability(Config{Desktop: true}, AllowAllApproval, nil)
+	if err := cap.Init(context.Background()); err != nil {
+		t.Fatalf("init err = %v", err)
+	}
+	_, err := cap.Dispatch(context.Background(), "desktop.click", nil)
+	if !errors.Is(err, ErrCapabilityUnavailable) {
+		t.Fatalf("err = %v, want unavailable", err)
+	}
+	var ue *UnavailableError
+	if !errors.As(err, &ue) || ue.Kind != KindDesktop {
+		t.Fatalf("expected UnavailableError{Kind:desktop}, got %v", err)
+	}
+}
+
+func TestBrowserCapability_ListToolsAndDispatch_ProxyToMCP(t *testing.T) {
+	fake := &fakeMCPClient{
+		tools: []MCPToolDef{
+			{Name: "navigate", Description: "go to url", InputSchema: map[string]any{"type": "object"}},
+			{Name: "screenshot", Description: "snap", InputSchema: map[string]any{"type": "object"}},
+		},
+	}
+	clients := map[string]*fakeMCPClient{"chrome": fake}
+
+	cap := NewBrowserCapability(Config{Browser: true}, AllowAllApproval, factoryWith(clients))
+	if err := cap.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	tools, err := cap.ListTools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := []string{}
+	for _, t := range tools {
+		names = append(names, t.Name)
+	}
+	sort.Strings(names)
+	want := []string{"browser.navigate", "browser.screenshot"}
+	if fmt.Sprintf("%v", names) != fmt.Sprintf("%v", want) {
+		t.Fatalf("tools = %v, want %v", names, want)
+	}
+
+	res, err := cap.Dispatch(context.Background(), "browser.navigate", map[string]any{"url": "https://example.com"})
+	if err != nil {
+		t.Fatalf("dispatch err = %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got %#v", res)
+	}
+	if len(fake.calls) != 1 || fake.calls[0].name != "navigate" {
+		t.Fatalf("forwarded calls = %#v, want one with raw name 'navigate'", fake.calls)
+	}
+	if u, _ := fake.calls[0].args["url"].(string); u != "https://example.com" {
+		t.Fatalf("args lost in proxy: %#v", fake.calls[0].args)
+	}
+}
+
+func TestDesktopCapability_DefaultServerName(t *testing.T) {
+	fake := &fakeMCPClient{}
+	clients := map[string]*fakeMCPClient{"open-codex-computer-use": fake}
+	cap := NewDesktopCapability(Config{Desktop: true}, AllowAllApproval, factoryWith(clients))
+	if err := cap.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if cap.unavail != "" {
+		t.Fatalf("expected available, got unavailable=%q", cap.unavail)
+	}
+}
+
+func TestMCPProxy_DispatchDeniedByApproval(t *testing.T) {
+	fake := &fakeMCPClient{tools: []MCPToolDef{{Name: "click"}}}
+	cap := NewDesktopCapability(
+		Config{Desktop: true},
+		DenyAllApproval,
+		factoryWith(map[string]*fakeMCPClient{"open-codex-computer-use": fake}),
+	)
+	_ = cap.Init(context.Background())
+	res, err := cap.Dispatch(context.Background(), "desktop.click", map[string]any{"x": 10, "y": 20})
+	if err != nil {
+		t.Fatalf("err = %v, want clean denial", err)
+	}
+	if !res.IsError {
+		t.Fatalf("denial must surface as IsError, got %#v", res)
+	}
+	if len(fake.calls) != 0 {
+		t.Fatalf("server must not be called when denied; got %#v", fake.calls)
+	}
+}
+
+// ---------- Manager ----------
+
+func TestManager_OptInOnly(t *testing.T) {
+	mgr := NewManager(Config{Shell: false, Browser: false, Desktop: false}, AllowAllApproval, nil)
+	if got := mgr.Capabilities(); len(got) != 0 {
+		t.Fatalf("nothing enabled, got %v", got)
+	}
+}
+
+func TestManager_DefaultIsShellOnly(t *testing.T) {
+	mgr := NewManager(DefaultConfig(), AllowAllApproval, nil)
+	caps := mgr.Capabilities()
+	if len(caps) != 1 || caps[0] != KindShell {
+		t.Fatalf("default capabilities = %v, want [shell]", caps)
+	}
+}
+
+func TestManager_RoutesByPrefix(t *testing.T) {
+	fakeChrome := &fakeMCPClient{tools: []MCPToolDef{{Name: "navigate"}}}
+	fakeDesktop := &fakeMCPClient{tools: []MCPToolDef{{Name: "click"}}}
+	clients := map[string]*fakeMCPClient{
+		"chrome":                  fakeChrome,
+		"open-codex-computer-use": fakeDesktop,
+	}
+
+	mgr := NewManager(Config{Shell: true, Browser: true, Desktop: true}, AllowAllApproval, factoryWith(clients))
+	// Replace the shell adapter with one that uses a stub runner so we can
+	// assert routing without invoking real commands.
+	for i, c := range mgr.caps {
+		if c.Kind() == KindShell {
+			mgr.caps[i] = NewShellCapability(Config{Shell: true}, AllowAllApproval).withRunner(
+				func(_ context.Context, name string, args ...string) ([]byte, error) {
+					return []byte(name + "/" + strings.Join(args, ",")), nil
+				},
+			)
+		}
+	}
+	if err := mgr.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer mgr.Shutdown(context.Background())
+
+	res, err := mgr.Dispatch(context.Background(), "shell.exec", map[string]any{"command": "uname", "args": []any{"-a"}})
+	if err != nil || res.IsError {
+		t.Fatalf("shell dispatch: err=%v res=%#v", err, res)
+	}
+	if !strings.Contains(res.Text, "uname/-a") {
+		t.Fatalf("shell text = %q", res.Text)
+	}
+
+	if _, err := mgr.Dispatch(context.Background(), "browser.navigate", map[string]any{"url": "x"}); err != nil {
+		t.Fatalf("browser dispatch err = %v", err)
+	}
+	if len(fakeChrome.calls) != 1 || fakeChrome.calls[0].name != "navigate" {
+		t.Fatalf("chrome calls = %#v", fakeChrome.calls)
+	}
+
+	if _, err := mgr.Dispatch(context.Background(), "desktop.click", map[string]any{}); err != nil {
+		t.Fatalf("desktop dispatch err = %v", err)
+	}
+	if len(fakeDesktop.calls) != 1 || fakeDesktop.calls[0].name != "click" {
+		t.Fatalf("desktop calls = %#v", fakeDesktop.calls)
+	}
+}
+
+func TestManager_DispatchRejectsUnknownPrefix(t *testing.T) {
+	mgr := NewManager(DefaultConfig(), AllowAllApproval, nil)
+	_ = mgr.Init(context.Background())
+	_, err := mgr.Dispatch(context.Background(), "unknown.tool", nil)
+	if err == nil || !strings.Contains(err.Error(), "no capability prefix") && !strings.Contains(err.Error(), "not enabled") {
+		t.Fatalf("err = %v, want unknown-prefix rejection", err)
+	}
+
+	_, err = mgr.Dispatch(context.Background(), "noprefix", nil)
+	if err == nil || !strings.Contains(err.Error(), "no capability prefix") {
+		t.Fatalf("err = %v, want missing-prefix rejection", err)
+	}
+}
+
+func TestManager_DispatchDisabledCapabilityFails(t *testing.T) {
+	mgr := NewManager(Config{Shell: true}, AllowAllApproval, nil)
+	_ = mgr.Init(context.Background())
+	_, err := mgr.Dispatch(context.Background(), "browser.navigate", nil)
+	if err == nil || !strings.Contains(err.Error(), "not enabled") {
+		t.Fatalf("err = %v, want not-enabled", err)
+	}
+}
+
+func TestManager_ListToolsSkipsUnavailable(t *testing.T) {
+	// browser enabled but factory has no chrome client: should be skipped silently.
+	mgr := NewManager(Config{Shell: true, Browser: true}, AllowAllApproval, factoryWith(map[string]*fakeMCPClient{}))
+	for i, c := range mgr.caps {
+		if c.Kind() == KindShell {
+			mgr.caps[i] = NewShellCapability(Config{Shell: true}, AllowAllApproval).withRunner(
+				func(_ context.Context, _ string, _ ...string) ([]byte, error) { return nil, nil },
+			)
+		}
+	}
+	if err := mgr.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	tools, err := mgr.ListTools(context.Background())
+	if err != nil {
+		t.Fatalf("list err = %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "shell.exec" {
+		t.Fatalf("tools = %#v, want only shell.exec", tools)
+	}
+}
+
+func TestConfig_ResolveServerNameOverride(t *testing.T) {
+	cfg := Config{Browser: true, MCPServerNames: map[Kind]string{KindBrowser: "my-chrome"}}
+	if got := cfg.resolveServerName(KindBrowser); got != "my-chrome" {
+		t.Fatalf("override = %q, want my-chrome", got)
+	}
+	if got := cfg.resolveServerName(KindDesktop); got != "open-codex-computer-use" {
+		t.Fatalf("default desktop = %q", got)
+	}
+}

--- a/internal/capabilities/capability.go
+++ b/internal/capabilities/capability.go
@@ -1,0 +1,143 @@
+// Package capabilities implements PRD §6.8 — three modular, opt-in capability
+// adapters (Shell, Browser, Desktop) that expose computer-use tools through a
+// common, transport-agnostic interface.
+//
+// Each capability is independently togglable via Config. Browser and Desktop
+// are thin proxies to externally-configured MCP servers (Chrome MCP for
+// Browser; open-codex-computer-use for Desktop) so the underlying server can
+// evolve without touching this package. Shell wraps a local exec primitive
+// gated by the per-app approval hook.
+//
+// The package deliberately avoids hard-importing the MCP server packages so
+// that callers can wire concrete implementations (or stubs) in via the
+// MCPClientFactory hook. This keeps PR #40 independent of #37 and #39 while
+// still exposing a clean integration seam.
+package capabilities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Kind identifies one capability adapter.
+type Kind string
+
+const (
+	KindShell   Kind = "shell"
+	KindBrowser Kind = "browser"
+	KindDesktop Kind = "desktop"
+)
+
+// Tool is a capability-provided tool descriptor. It mirrors the shape used by
+// the MCP and tools packages but is deliberately decoupled — callers translate
+// to their preferred dialect.
+type Tool struct {
+	// Capability is the originating adapter (shell, browser, desktop).
+	Capability Kind
+	// Name is the fully-qualified tool name (e.g. "shell.exec",
+	// "browser.navigate", "desktop.click"). Names from MCP-backed adapters are
+	// prefixed with the capability kind so they cannot collide with built-in
+	// tools.
+	Name string
+	// Description is the short human-readable summary surfaced to models.
+	Description string
+	// Schema is the JSON Schema for the tool's input arguments.
+	Schema map[string]any
+}
+
+// Result is the normalized output of a Dispatch call.
+// Text is the human-readable result. Data carries optional structured payload
+// (for tools that emit JSON). IsError signals a tool-level failure that the
+// caller may surface back to the model without aborting the loop.
+type Result struct {
+	Text    string
+	Data    map[string]any
+	IsError bool
+}
+
+// Capability is the contract all adapters satisfy. Implementations must be
+// safe to call from a single goroutine; callers serialize Dispatch per
+// capability when concurrency is required.
+type Capability interface {
+	// Kind returns the adapter's identity.
+	Kind() Kind
+
+	// Init prepares the adapter (connects to MCP servers, validates config).
+	// Init may report a non-fatal "unavailable" error — callers should
+	// continue with the remaining capabilities and surface the message via
+	// ListTools / Dispatch when the user invokes this capability.
+	Init(ctx context.Context) error
+
+	// ListTools returns the tools currently exposed by this capability.
+	// Returning an empty slice with a nil error means the adapter is opted-in
+	// but has no tools yet (e.g. MCP server not connected).
+	ListTools(ctx context.Context) ([]Tool, error)
+
+	// Dispatch executes one tool invocation. The adapter is responsible for
+	// argument validation, approval-gate consultation, and translation to the
+	// underlying transport.
+	Dispatch(ctx context.Context, toolName string, args map[string]any) (Result, error)
+
+	// Shutdown releases any resources held by the adapter (subprocess
+	// connections, file handles). Idempotent.
+	Shutdown(ctx context.Context) error
+}
+
+// Approval is the per-app approval hook from issue #39. Adapters call
+// RequireApproval before performing a side-effecting action; the returned
+// boolean indicates whether the user has approved this app.
+//
+// When #39 lands, callers wire in a concrete implementation backed by the
+// persistent approval config. Until then, callers may pass the package-level
+// AllowAllApproval (open-by-default) or DenyAllApproval as appropriate; tests
+// also use these stubs.
+type Approval interface {
+	RequireApproval(ctx context.Context, app string, action string) (bool, error)
+}
+
+// ApprovalFunc adapts a function to the Approval interface for callers that
+// want to inline a closure (e.g. tests, CLI prompts).
+type ApprovalFunc func(ctx context.Context, app string, action string) (bool, error)
+
+// RequireApproval implements Approval.
+func (f ApprovalFunc) RequireApproval(ctx context.Context, app string, action string) (bool, error) {
+	return f(ctx, app, action)
+}
+
+// AllowAllApproval is a default-open stub used when issue #39's per-app
+// approval system has not been wired in yet. It records nothing and approves
+// every request. TODO(#39): replace with the persistent per-app gate.
+var AllowAllApproval Approval = ApprovalFunc(func(_ context.Context, _ string, _ string) (bool, error) {
+	return true, nil
+})
+
+// DenyAllApproval is a safe-by-default stub for unit tests and dry-runs.
+var DenyAllApproval Approval = ApprovalFunc(func(_ context.Context, _ string, _ string) (bool, error) {
+	return false, nil
+})
+
+// ErrCapabilityUnavailable is returned by Dispatch / ListTools when a
+// capability is opted-in but its underlying transport (MCP server, exec
+// runtime) is not reachable. Callers should surface the wrapped message to
+// the user instead of treating it as a hard failure.
+var ErrCapabilityUnavailable = errors.New("capability unavailable")
+
+// UnavailableError wraps ErrCapabilityUnavailable with adapter-specific
+// context (kind + reason) so users see a useful message in TUI/CLI output.
+type UnavailableError struct {
+	Kind   Kind
+	Reason string
+}
+
+func (e *UnavailableError) Error() string {
+	return fmt.Sprintf("%s capability unavailable: %s", e.Kind, e.Reason)
+}
+
+func (e *UnavailableError) Unwrap() error { return ErrCapabilityUnavailable }
+
+// newUnavailable builds an UnavailableError. Adapters use this from Dispatch
+// and ListTools when the underlying server is missing.
+func newUnavailable(kind Kind, reason string) error {
+	return &UnavailableError{Kind: kind, Reason: reason}
+}

--- a/internal/capabilities/config.go
+++ b/internal/capabilities/config.go
@@ -1,0 +1,100 @@
+package capabilities
+
+import (
+	"context"
+)
+
+// Config selects which capability adapters are active. All three default to
+// false so callers must opt in explicitly. The PRD-suggested safe minimum is
+// shell-only; see DefaultConfig.
+type Config struct {
+	// Shell enables ShellCapability (terminal commands, code execution, file
+	// ops via local exec). Gated by per-app approval (#39).
+	Shell bool `yaml:"shell"`
+
+	// Browser enables BrowserCapability — a thin proxy to Chrome MCP.
+	Browser bool `yaml:"browser"`
+
+	// Desktop enables DesktopCapability — a thin proxy to the
+	// open-codex-computer-use MCP server (#37).
+	Desktop bool `yaml:"desktop"`
+
+	// MCPServerNames overrides the default MCP server names this package
+	// looks up via MCPClientFactory. The defaults match the PRD wiring:
+	//   browser -> "chrome"
+	//   desktop -> "open-codex-computer-use"
+	MCPServerNames map[Kind]string `yaml:"mcp_server_names,omitempty"`
+
+	// ShellAllowedCommands restricts which executables ShellCapability will
+	// invoke. An empty slice means "all commands allowed" (subject to the
+	// approval gate). Specifying e.g. ["git", "ls", "cat"] is the safest
+	// default for non-interactive callers.
+	ShellAllowedCommands []string `yaml:"shell_allowed_commands,omitempty"`
+
+	// ShellAppName is the application identifier passed to the approval gate
+	// when ShellCapability runs a command. Defaults to "shell".
+	ShellAppName string `yaml:"shell_app_name,omitempty"`
+}
+
+// DefaultConfig returns Conduit's safe minimum: shell on, browser/desktop off.
+// The active approval gate (passed via NewManager) is what actually keeps
+// shell safe — DefaultConfig only flips the bit.
+func DefaultConfig() Config {
+	return Config{
+		Shell:   true,
+		Browser: false,
+		Desktop: false,
+	}
+}
+
+// resolveServerName returns the MCP server name to look up for a given kind,
+// falling back to PRD defaults when the user has not overridden it.
+func (c Config) resolveServerName(kind Kind) string {
+	if c.MCPServerNames != nil {
+		if v, ok := c.MCPServerNames[kind]; ok && v != "" {
+			return v
+		}
+	}
+	switch kind {
+	case KindBrowser:
+		return "chrome"
+	case KindDesktop:
+		return "open-codex-computer-use"
+	default:
+		return ""
+	}
+}
+
+// MCPToolClient is the minimal surface this package needs from an MCP client.
+// It matches the shape of internal/mcp.Client without forcing a hard import,
+// so callers can pass either the production client or a fake in tests.
+type MCPToolClient interface {
+	ListTools(ctx context.Context) ([]MCPToolDef, error)
+	CallTool(ctx context.Context, name string, args map[string]any) ([]MCPContent, error)
+	Close() error
+}
+
+// MCPToolDef mirrors mcp.ToolDef. Duplicated here so the capabilities package
+// has zero dependency on internal/mcp.
+type MCPToolDef struct {
+	Name        string
+	Description string
+	InputSchema map[string]any
+}
+
+// MCPContent mirrors mcp.Content. Only the text + data fields are needed for
+// capability dispatch.
+type MCPContent struct {
+	Type string
+	Text string
+	Data string
+	MIME string
+}
+
+// MCPClientFactory opens a connection to a named MCP server. Returns
+// (nil, nil) when the server is not configured — adapters treat this as
+// "capability unavailable" rather than a fatal error.
+//
+// Callers wire in a real factory backed by mcp.LoadConfig + mcp.Connect; this
+// package never imports internal/mcp directly so #37/#39 can ship in any order.
+type MCPClientFactory func(ctx context.Context, serverName string) (MCPToolClient, error)

--- a/internal/capabilities/desktop.go
+++ b/internal/capabilities/desktop.go
@@ -1,0 +1,21 @@
+package capabilities
+
+// DesktopCapability is the "Desktop" tier of PRD §6.8 — full macOS GUI
+// control (click, type, scroll, screenshot) via the open-codex-computer-use
+// MCP server (issue #37). The adapter does not import or launch the
+// open-codex-computer-use server itself; #37 owns the MCP wiring. This
+// adapter is a thin proxy that delegates to whatever MCP server name #37
+// registered (default: "open-codex-computer-use").
+//
+// When that server is not present, the adapter cleanly reports
+// UnavailableError("Desktop capability unavailable: ...") rather than
+// crashing the harness. This decoupling is what lets #37 and #40 land in
+// either order.
+type DesktopCapability struct{ *mcpProxy }
+
+// NewDesktopCapability builds the Desktop adapter. factory may be nil — the
+// adapter will then report itself as unavailable, matching the behavior the
+// PRD requires when computer use has not been opt-ed into.
+func NewDesktopCapability(cfg Config, approval Approval, factory MCPClientFactory) *DesktopCapability {
+	return &DesktopCapability{mcpProxy: newMCPProxy(KindDesktop, cfg.resolveServerName(KindDesktop), approval, factory)}
+}

--- a/internal/capabilities/manager.go
+++ b/internal/capabilities/manager.go
@@ -1,0 +1,140 @@
+package capabilities
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Manager owns the set of opt-in capability adapters and routes tool calls to
+// the right one. It is the entry point most callers use:
+//
+//	mgr := capabilities.NewManager(cfg, approval, factory)
+//	if err := mgr.Init(ctx); err != nil { ... }
+//	defer mgr.Shutdown(ctx)
+//	tools, _ := mgr.ListTools(ctx)
+//	res, err := mgr.Dispatch(ctx, "shell.exec", map[string]any{...})
+type Manager struct {
+	caps []Capability
+}
+
+// NewManager constructs a Manager with the standard set of adapters,
+// instantiating only those enabled in cfg. approval and factory may be nil:
+//
+//   - approval == nil  ⇒ AllowAllApproval (safe for tests; production callers
+//     should wire in the real per-app gate from #39).
+//   - factory == nil   ⇒ Browser and Desktop will report unavailable.
+func NewManager(cfg Config, approval Approval, factory MCPClientFactory) *Manager {
+	if approval == nil {
+		approval = AllowAllApproval
+	}
+
+	var caps []Capability
+	if cfg.Shell {
+		caps = append(caps, NewShellCapability(cfg, approval))
+	}
+	if cfg.Browser {
+		caps = append(caps, NewBrowserCapability(cfg, approval, factory))
+	}
+	if cfg.Desktop {
+		caps = append(caps, NewDesktopCapability(cfg, approval, factory))
+	}
+	return &Manager{caps: caps}
+}
+
+// NewManagerFromCapabilities builds a Manager from an explicit slice. Useful
+// for tests that want to inject fakes.
+func NewManagerFromCapabilities(caps ...Capability) *Manager {
+	return &Manager{caps: append([]Capability(nil), caps...)}
+}
+
+// Capabilities returns the active capability kinds in stable order.
+func (m *Manager) Capabilities() []Kind {
+	kinds := make([]Kind, 0, len(m.caps))
+	for _, c := range m.caps {
+		kinds = append(kinds, c.Kind())
+	}
+	sort.Slice(kinds, func(i, j int) bool { return kinds[i] < kinds[j] })
+	return kinds
+}
+
+// Init initializes every active capability. Errors from individual adapters
+// are aggregated; an adapter that fails Init still stays in the manager so
+// that ListTools and Dispatch report the unavailable reason consistently.
+func (m *Manager) Init(ctx context.Context) error {
+	var errs []error
+	for _, c := range m.caps {
+		if err := c.Init(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("init %s: %w", c.Kind(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// ListTools returns the union of tools advertised by every active capability.
+// Capabilities that report unavailable are silently skipped — ListTools is
+// for prompt construction, where missing tools should not appear, while
+// Dispatch is where the user-visible "unavailable" message is surfaced.
+func (m *Manager) ListTools(ctx context.Context) ([]Tool, error) {
+	var out []Tool
+	for _, c := range m.caps {
+		tools, err := c.ListTools(ctx)
+		if err != nil {
+			if errors.Is(err, ErrCapabilityUnavailable) {
+				continue
+			}
+			return nil, fmt.Errorf("list %s tools: %w", c.Kind(), err)
+		}
+		out = append(out, tools...)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// Dispatch routes a tool call to the capability that owns it. Tool ownership
+// is determined by the prefix before the first "." in the tool name (e.g.
+// "shell.exec" → KindShell). Unknown prefixes return an error.
+func (m *Manager) Dispatch(ctx context.Context, name string, args map[string]any) (Result, error) {
+	kind, ok := capabilityForTool(name)
+	if !ok {
+		return Result{}, fmt.Errorf("capabilities: tool %q has no capability prefix (expected e.g. shell.exec)", name)
+	}
+	for _, c := range m.caps {
+		if c.Kind() == kind {
+			return c.Dispatch(ctx, name, args)
+		}
+	}
+	return Result{}, fmt.Errorf("capabilities: %s is not enabled or registered", kind)
+}
+
+// Shutdown closes every capability. Errors are aggregated.
+func (m *Manager) Shutdown(ctx context.Context) error {
+	var errs []error
+	for _, c := range m.caps {
+		if err := c.Shutdown(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("shutdown %s: %w", c.Kind(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// capabilityForTool returns the capability kind responsible for a tool by
+// inspecting the prefix before the first ".".
+func capabilityForTool(toolName string) (Kind, bool) {
+	idx := strings.Index(toolName, ".")
+	if idx <= 0 {
+		return "", false
+	}
+	switch Kind(toolName[:idx]) {
+	case KindShell:
+		return KindShell, true
+	case KindBrowser:
+		return KindBrowser, true
+	case KindDesktop:
+		return KindDesktop, true
+	default:
+		return "", false
+	}
+}

--- a/internal/capabilities/mcp_proxy.go
+++ b/internal/capabilities/mcp_proxy.go
@@ -1,0 +1,163 @@
+package capabilities
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// mcpProxy is shared scaffolding for capabilities whose tools live in an
+// external MCP server (Browser via Chrome MCP, Desktop via
+// open-codex-computer-use). The proxy:
+//
+//   - Looks up the configured MCP server name on Init via MCPClientFactory.
+//   - Caches the client + tool list for the lifetime of the adapter.
+//   - Reports "capability unavailable" cleanly when the server is missing,
+//     instead of crashing the harness.
+//   - Prefixes every tool name with the capability kind so a Chrome MCP tool
+//     like "navigate" surfaces as "browser.navigate" — preserving uniqueness
+//     across capabilities.
+//   - Strips the prefix on Dispatch and forwards the raw tool name to MCP.
+type mcpProxy struct {
+	kind     Kind
+	server   string
+	approval Approval
+	factory  MCPClientFactory
+
+	mu      sync.Mutex
+	client  MCPToolClient
+	tools   []Tool
+	unavail string // when set, every method returns UnavailableError(reason)
+}
+
+// newMCPProxy builds a proxy. server is the configured MCP server name; an
+// empty server triggers immediate unavailability.
+func newMCPProxy(kind Kind, server string, approval Approval, factory MCPClientFactory) *mcpProxy {
+	if approval == nil {
+		approval = AllowAllApproval
+	}
+	return &mcpProxy{kind: kind, server: server, approval: approval, factory: factory}
+}
+
+func (p *mcpProxy) Kind() Kind { return p.kind }
+
+// Init resolves the underlying MCP client. A missing factory or unknown
+// server name marks the adapter unavailable but is not a fatal error — the
+// rest of the harness keeps running and Dispatch reports the reason.
+func (p *mcpProxy) Init(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.factory == nil {
+		p.unavail = fmt.Sprintf("no MCP client factory configured for %s capability", p.kind)
+		return nil
+	}
+	if p.server == "" {
+		p.unavail = fmt.Sprintf("no MCP server configured for %s capability", p.kind)
+		return nil
+	}
+
+	client, err := p.factory(ctx, p.server)
+	if err != nil {
+		p.unavail = fmt.Sprintf("connect to MCP server %q: %v", p.server, err)
+		return nil
+	}
+	if client == nil {
+		p.unavail = fmt.Sprintf("MCP server %q is not registered", p.server)
+		return nil
+	}
+	p.client = client
+
+	// Pre-fetch tools so ListTools is cheap and so connection problems
+	// surface immediately during Init.
+	defs, err := client.ListTools(ctx)
+	if err != nil {
+		p.unavail = fmt.Sprintf("list tools on %q: %v", p.server, err)
+		_ = client.Close()
+		p.client = nil
+		return nil
+	}
+	prefix := string(p.kind) + "."
+	tools := make([]Tool, 0, len(defs))
+	for _, d := range defs {
+		tools = append(tools, Tool{
+			Capability:  p.kind,
+			Name:        prefix + d.Name,
+			Description: d.Description,
+			Schema:      d.InputSchema,
+		})
+	}
+	p.tools = tools
+	return nil
+}
+
+// ListTools returns the cached tool list.
+func (p *mcpProxy) ListTools(_ context.Context) ([]Tool, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.unavail != "" {
+		return nil, newUnavailable(p.kind, p.unavail)
+	}
+	return append([]Tool(nil), p.tools...), nil
+}
+
+// Dispatch consults the approval gate and forwards the call to the MCP server.
+func (p *mcpProxy) Dispatch(ctx context.Context, name string, args map[string]any) (Result, error) {
+	p.mu.Lock()
+	if p.unavail != "" {
+		reason := p.unavail
+		p.mu.Unlock()
+		return Result{}, newUnavailable(p.kind, reason)
+	}
+	client := p.client
+	p.mu.Unlock()
+
+	prefix := string(p.kind) + "."
+	if !strings.HasPrefix(name, prefix) {
+		return Result{}, fmt.Errorf("%s: tool %q is not owned by this capability", p.kind, name)
+	}
+	rawName := strings.TrimPrefix(name, prefix)
+
+	approved, err := p.approval.RequireApproval(ctx, string(p.kind), rawName)
+	if err != nil {
+		return Result{}, fmt.Errorf("%s: approval check failed: %w", p.kind, err)
+	}
+	if !approved {
+		return Result{Text: fmt.Sprintf("%s tool %q denied by user", p.kind, rawName), IsError: true}, nil
+	}
+
+	content, err := client.CallTool(ctx, rawName, args)
+	if err != nil {
+		return Result{Text: err.Error(), IsError: true}, nil
+	}
+
+	var b strings.Builder
+	for i, c := range content {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		switch c.Type {
+		case "text", "":
+			b.WriteString(c.Text)
+		case "image":
+			fmt.Fprintf(&b, "[image %s, %d bytes]", c.MIME, len(c.Data))
+		default:
+			fmt.Fprintf(&b, "[%s content]", c.Type)
+		}
+	}
+	return Result{Text: b.String()}, nil
+}
+
+// Shutdown closes the underlying MCP client if one was opened.
+func (p *mcpProxy) Shutdown(_ context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.client == nil {
+		return nil
+	}
+	err := p.client.Close()
+	p.client = nil
+	p.tools = nil
+	return err
+}

--- a/internal/capabilities/shell.go
+++ b/internal/capabilities/shell.go
@@ -1,0 +1,171 @@
+package capabilities
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	osexec "os/exec"
+	"strings"
+	"time"
+)
+
+// ShellCapability exposes a small set of terminal primitives backed by the
+// host's local exec runtime. This is the "Shell" tier of PRD §6.8.
+//
+// The adapter intentionally exposes a single tool — shell.exec — rather than
+// a sprawling surface. File ops and code execution all flow through one
+// command, which keeps the per-app approval prompt simple ("allow shell to
+// run this?") and matches how Codex/Claude expose their bash tool.
+//
+// The adapter uses Go's exec.CommandContext (which is execFile-style: no
+// shell interpolation, args are passed positionally) so user-controlled
+// arguments cannot become shell metacharacters.
+type ShellCapability struct {
+	approval Approval
+	allow    map[string]struct{}
+	app      string
+	runner   commandRunner // injected for tests
+	timeout  time.Duration
+	ready    bool
+}
+
+// commandRunner abstracts os/exec.CommandContext so tests can stub command
+// execution without touching the host.
+type commandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// NewShellCapability constructs the Shell adapter.
+func NewShellCapability(cfg Config, approval Approval) *ShellCapability {
+	if approval == nil {
+		approval = AllowAllApproval
+	}
+	app := cfg.ShellAppName
+	if app == "" {
+		app = "shell"
+	}
+	allow := make(map[string]struct{}, len(cfg.ShellAllowedCommands))
+	for _, c := range cfg.ShellAllowedCommands {
+		c = strings.TrimSpace(c)
+		if c != "" {
+			allow[c] = struct{}{}
+		}
+	}
+	return &ShellCapability{
+		approval: approval,
+		allow:    allow,
+		app:      app,
+		runner:   defaultRunner,
+		timeout:  30 * time.Second,
+	}
+}
+
+// withRunner is a test hook that overrides the command runner.
+func (s *ShellCapability) withRunner(fn commandRunner) *ShellCapability {
+	s.runner = fn
+	return s
+}
+
+// Kind reports KindShell.
+func (s *ShellCapability) Kind() Kind { return KindShell }
+
+// Init validates the adapter is ready. Shell has no remote dependency so this
+// is effectively a flag flip.
+func (s *ShellCapability) Init(_ context.Context) error {
+	s.ready = true
+	return nil
+}
+
+// ListTools returns the single shell.exec tool.
+func (s *ShellCapability) ListTools(_ context.Context) ([]Tool, error) {
+	if !s.ready {
+		return nil, newUnavailable(KindShell, "adapter not initialized")
+	}
+	return []Tool{{
+		Capability:  KindShell,
+		Name:        "shell.exec",
+		Description: "Run a shell command on the host. Output is captured and returned. Subject to per-app approval.",
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"command": map[string]any{
+					"type":        "string",
+					"description": "The executable to run (e.g. \"git\", \"ls\").",
+				},
+				"args": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Optional arguments passed to the command.",
+				},
+			},
+			"required": []string{"command"},
+		},
+	}}, nil
+}
+
+// Dispatch handles shell.exec invocations.
+func (s *ShellCapability) Dispatch(ctx context.Context, name string, args map[string]any) (Result, error) {
+	if !s.ready {
+		return Result{}, newUnavailable(KindShell, "adapter not initialized")
+	}
+	if name != "shell.exec" {
+		return Result{}, fmt.Errorf("shell: unknown tool %q", name)
+	}
+
+	command, ok := args["command"].(string)
+	if !ok || strings.TrimSpace(command) == "" {
+		return Result{}, fmt.Errorf("shell: command is required and must be a string")
+	}
+
+	if len(s.allow) > 0 {
+		if _, allowed := s.allow[command]; !allowed {
+			return Result{}, fmt.Errorf("shell: command %q is not in the allowed list", command)
+		}
+	}
+
+	rawArgs, _ := args["args"].([]any)
+	cmdArgs := make([]string, 0, len(rawArgs))
+	for _, a := range rawArgs {
+		if s, ok := a.(string); ok {
+			cmdArgs = append(cmdArgs, s)
+		}
+	}
+
+	approved, err := s.approval.RequireApproval(ctx, s.app, command+" "+strings.Join(cmdArgs, " "))
+	if err != nil {
+		return Result{}, fmt.Errorf("shell: approval check failed: %w", err)
+	}
+	if !approved {
+		return Result{Text: "shell command denied by user", IsError: true}, nil
+	}
+
+	runCtx := ctx
+	if s.timeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, s.timeout)
+		defer cancel()
+	}
+
+	out, err := s.runner(runCtx, command, cmdArgs...)
+	if err != nil {
+		return Result{Text: fmt.Sprintf("%s\n%s", strings.TrimSpace(string(out)), err.Error()), IsError: true}, nil
+	}
+	return Result{Text: strings.TrimRight(string(out), "\n")}, nil
+}
+
+// Shutdown is a no-op for Shell.
+func (s *ShellCapability) Shutdown(_ context.Context) error {
+	s.ready = false
+	return nil
+}
+
+// defaultRunner runs a command via os/exec and returns combined stdout+stderr.
+// It uses CommandContext (the execFile-style API: no shell interpolation,
+// arguments are passed positionally) so caller-supplied input cannot become
+// shell metacharacters.
+func defaultRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := osexec.CommandContext(ctx, name, args...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.Bytes(), err
+}


### PR DESCRIPTION
## Summary

Introduces `internal/capabilities` — three modular, opt-in adapters that implement PRD §6.8: **Shell**, **Browser**, **Desktop**. Each adapter implements a common `Capability` interface (`Init`, `ListTools`, `Dispatch`, `Shutdown`).

- **Shell** — exposes a single `shell.exec` tool via `os/exec.CommandContext` (execFile-style: no shell interpolation), gated by the per-app approval hook from #39 (stub `Approval` interface defined here so #39 can wire its concrete impl in cleanly).
- **Browser** — thin proxy to Chrome MCP. Looks up server name `chrome` (configurable) via injected `MCPClientFactory`. No hard dependency on Chrome MCP setup.
- **Desktop** — thin proxy to `open-codex-computer-use` MCP from #37. Same factory pattern. Missing server cleanly reports `UnavailableError(\"Desktop capability unavailable: ...\")` rather than crashing.
- `Manager` routes tool calls by name prefix (`shell.` / `browser.` / `desktop.`) so collisions are impossible. Defaults: Shell on, Browser/Desktop off (safe minimum).
- Zero hard imports of `internal/mcp` — the package defines its own narrow `MCPToolClient` interface so #37 and #39 can land in any order.

## Design notes

- `Approval` interface + `AllowAllApproval` / `DenyAllApproval` stubs marked with `TODO(#39)` so the hand-off is explicit.
- `MCPClientFactory` is injected; an empty / nil factory makes Browser & Desktop self-report unavailable. This is the integration seam for the `internal/mcp` package and #37's `open-codex-computer-use` registration.
- `ListTools` silently skips unavailable capabilities (so prompts don't advertise broken tools), while `Dispatch` surfaces `UnavailableError` (so the user sees a useful message).

Closes #40

## Test plan

- [x] `go test ./internal/capabilities/...` (12 unit tests covering: shell happy path / denial / allow-list, Browser & Desktop unavailable paths, MCP proxy routing & approval gate, Manager opt-in / routing / unknown-prefix rejection)
- [x] `make lint` (gofmt + go vet)
- [x] `go test ./...` full repo suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)