### PR TITLE
feat(skills): registry with hierarchical resolution and adapter interface (#51)

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/jabreeflor/conduit/internal/computeruse"
 	"github.com/jabreeflor/conduit/internal/config"
+	"github.com/jabreeflor/conduit/internal/contracts"
 	"github.com/jabreeflor/conduit/internal/endpoint"
 	evalpkg "github.com/jabreeflor/conduit/internal/eval"
 	"github.com/jabreeflor/conduit/internal/localmodel"
 	"github.com/jabreeflor/conduit/internal/mcp"
 	"github.com/jabreeflor/conduit/internal/router"
+	"github.com/jabreeflor/conduit/internal/skills"
 	"github.com/jabreeflor/conduit/internal/tui"
 	"github.com/jabreeflor/conduit/internal/usage"
 )
@@ -71,6 +73,12 @@ func main() {
 		case "computer-use":
 			if err := computeruse.RunCLI(context.Background(), os.Args[2:], os.Stdout, os.Stderr); err != nil {
 				fmt.Fprintf(os.Stderr, "conduit computer-use: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		case "skills":
+			if err := runSkillsCLI(os.Args[2:], os.Stdout, os.Stderr); err != nil {
+				fmt.Fprintf(os.Stderr, "conduit skills: %v\n", err)
 				os.Exit(1)
 			}
 			return
@@ -237,4 +245,79 @@ func providerResponderFromEnv(model string) (evalpkg.Responder, bool) {
 	default:
 		return nil, false
 	}
+}
+
+// runSkillsCLI loads the skill registry on demand and dispatches the simple
+// list/lookup/search verbs. The CLI is intentionally thin — full task-start
+// integration lives in the agent loop, not here.
+func runSkillsCLI(args []string, stdout, stderr *os.File) error {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "usage: conduit skills <list|lookup|search> [args...]")
+		return flag.ErrHelp
+	}
+
+	registry, err := newSkillsRegistry()
+	if err != nil {
+		return err
+	}
+
+	switch args[0] {
+	case "list":
+		printSkillRows(stdout, registry.List())
+		return nil
+	case "lookup":
+		if len(args) < 2 {
+			return fmt.Errorf("usage: conduit skills lookup <name>")
+		}
+		skill, ok := registry.Lookup(args[1])
+		if !ok {
+			fmt.Fprintln(stderr, "not found")
+			os.Exit(1)
+		}
+		fmt.Fprintln(stdout, skill.Body)
+		return nil
+	case "search":
+		if len(args) < 2 {
+			return fmt.Errorf("usage: conduit skills search <query>")
+		}
+		printSkillRows(stdout, registry.Search(strings.Join(args[1:], " ")))
+		return nil
+	default:
+		return fmt.Errorf("unknown skills command %q", args[0])
+	}
+}
+
+func newSkillsRegistry() (*skills.Registry, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// A missing home dir is unusual but should not break the CLI; the
+		// registry will simply have no personal/imported/bundled tiers.
+		home = ""
+	}
+	workspace, err := os.Getwd()
+	if err != nil {
+		workspace = ""
+	}
+	registry := skills.NewRegistry(skills.DefaultRoots(home, workspace))
+	if err := registry.Load([]skills.Adapter{skills.NewMarkdownAdapter()}); err != nil {
+		return nil, err
+	}
+	return registry, nil
+}
+
+func printSkillRows(out *os.File, list []contracts.Skill) {
+	for _, skill := range list {
+		fmt.Fprintf(out, "%s\t%s\t%s\n", skill.Tier, skill.Name, truncate(skill.Description, 80))
+	}
+}
+
+func truncate(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= max {
+		return s
+	}
+	if max <= 1 {
+		return s[:max]
+	}
+	return s[:max-1] + "…"
 }

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -543,3 +543,39 @@ type ComputerUsePermissionReport struct {
 	AllGranted  bool                          `json:"all_granted"`
 	GeneratedAt time.Time                     `json:"generated_at"`
 }
+
+// SkillTier names a precedence layer in the skill hierarchy.
+// Workspace skills always shadow personal, which shadow imported, which shadow
+// bundled — the explicit ordering keeps user/team customization wins free of
+// runtime config.
+type SkillTier string
+
+const (
+	SkillTierWorkspace SkillTier = "workspace"
+	SkillTierPersonal  SkillTier = "personal"
+	SkillTierImported  SkillTier = "imported"
+	SkillTierBundled   SkillTier = "bundled"
+)
+
+// Skill is one indexed instruction file the registry can hand to the agent at
+// task start. Path is the absolute on-disk source so surfaces can deep-link to
+// "open the underlying file" without re-resolving the hierarchy.
+type Skill struct {
+	Name        string
+	Tier        SkillTier
+	Description string
+	Tags        []string
+	Path        string
+	Body        string
+	UpdatedAt   time.Time
+}
+
+// SkillConflict records a name collision the registry resolved during Load.
+// It is non-fatal: surfaces (TUI/GUI later) display the loser paths so users
+// can rename or delete duplicates without an import sweep failing.
+type SkillConflict struct {
+	Name   string
+	Tier   SkillTier
+	Winner string
+	Losers []string
+}

--- a/internal/skills/adapter.go
+++ b/internal/skills/adapter.go
@@ -1,0 +1,133 @@
+// Package skills owns Conduit's skill registry: filesystem-backed,
+// hierarchically resolved, indexed for task-start lookup.
+package skills
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+	"gopkg.in/yaml.v3"
+)
+
+// Adapter converts a single source file on disk into a contracts.Skill.
+// The interface is intentionally narrow so future adapters (Hermes, OpenClaw
+// SOUL.md, Cursor rules, AGENTS.md, ...) can be plugged in without changes
+// to the registry — they only need to recognize their own files.
+type Adapter interface {
+	// Name identifies the adapter for diagnostic logging.
+	Name() string
+	// CanHandle does a cheap shape sniff (extension, marker file, etc.) so the
+	// registry can pick the first matching adapter without reading the file
+	// twice.
+	CanHandle(path string) bool
+	// Parse converts file bytes into a Skill, attaching the caller-supplied
+	// tier so the same adapter implementation works in every layer.
+	Parse(path string, data []byte, tier contracts.SkillTier) (contracts.Skill, error)
+}
+
+// MarkdownAdapter parses plain markdown files with optional YAML frontmatter
+// fenced by `---`. It is the baseline adapter every conduit install ships
+// with; richer adapters layer on top of the same interface.
+type MarkdownAdapter struct{}
+
+// NewMarkdownAdapter returns the default markdown adapter. It is stateless,
+// but the constructor matches the project's New* convention so future caching
+// (compiled regex, mmap, ...) lands without touching call sites.
+func NewMarkdownAdapter() MarkdownAdapter {
+	return MarkdownAdapter{}
+}
+
+// Name implements Adapter.
+func (MarkdownAdapter) Name() string { return "markdown" }
+
+// CanHandle accepts any *.md file. Tier roots already constrain the search,
+// so we keep the sniff inexpensive and rely on Parse for stricter validation.
+func (MarkdownAdapter) CanHandle(path string) bool {
+	return strings.EqualFold(filepath.Ext(path), ".md")
+}
+
+type markdownFrontmatter struct {
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description"`
+	Tags        []string `yaml:"tags"`
+}
+
+// Parse implements Adapter. Files missing both frontmatter `name` and a
+// meaningful filename are rejected so the caller can log and skip them rather
+// than indexing nameless skills the user can never look up.
+func (MarkdownAdapter) Parse(path string, data []byte, tier contracts.SkillTier) (contracts.Skill, error) {
+	front, body, err := splitFrontmatter(data)
+	if err != nil {
+		return contracts.Skill{}, fmt.Errorf("skills: parse frontmatter %q: %w", path, err)
+	}
+
+	name := strings.TrimSpace(front.Name)
+	if name == "" {
+		base := filepath.Base(path)
+		name = strings.TrimSuffix(base, filepath.Ext(base))
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return contracts.Skill{}, fmt.Errorf("skills: %q has no usable name", path)
+	}
+
+	skill := contracts.Skill{
+		Name:        name,
+		Tier:        tier,
+		Description: strings.TrimSpace(front.Description),
+		Tags:        normaliseTags(front.Tags),
+		Path:        path,
+		Body:        strings.TrimSpace(body),
+		UpdatedAt:   time.Time{},
+	}
+	return skill, nil
+}
+
+// splitFrontmatter returns the parsed YAML header (zero-value when absent) and
+// the markdown body that follows it. We tolerate both LF and CRLF inputs
+// because skill libraries are routinely shared via Windows-edited zips.
+func splitFrontmatter(data []byte) (markdownFrontmatter, string, error) {
+	normalised := bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	if !bytes.HasPrefix(normalised, []byte("---\n")) && !bytes.Equal(bytes.TrimSpace(normalised), []byte("---")) {
+		return markdownFrontmatter{}, string(normalised), nil
+	}
+
+	rest := normalised[len("---\n"):]
+	end := bytes.Index(rest, []byte("\n---"))
+	if end < 0 {
+		return markdownFrontmatter{}, string(normalised), nil
+	}
+	header := rest[:end]
+	body := rest[end+len("\n---"):]
+	body = bytes.TrimPrefix(body, []byte("\n"))
+
+	var front markdownFrontmatter
+	if len(bytes.TrimSpace(header)) > 0 {
+		if err := yaml.Unmarshal(header, &front); err != nil {
+			return markdownFrontmatter{}, "", err
+		}
+	}
+	return front, string(body), nil
+}
+
+func normaliseTags(tags []string) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if tag == "" {
+			continue
+		}
+		out = append(out, tag)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/skills/adapter_test.go
+++ b/internal/skills/adapter_test.go
@@ -1,0 +1,116 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestMarkdownAdapterParsesFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "review.md")
+	body := "---\nname: review\ndescription: Run a thorough review\ntags:\n  - quality\n  - review\n---\nDo the thing.\n"
+	writeFile(t, path, body)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	skill, err := NewMarkdownAdapter().Parse(path, data, contracts.SkillTierPersonal)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if skill.Name != "review" {
+		t.Errorf("name: got %q want %q", skill.Name, "review")
+	}
+	if skill.Description != "Run a thorough review" {
+		t.Errorf("description: got %q", skill.Description)
+	}
+	if got, want := skill.Tags, []string{"quality", "review"}; !equalStrings(got, want) {
+		t.Errorf("tags: got %v want %v", got, want)
+	}
+	if skill.Tier != contracts.SkillTierPersonal {
+		t.Errorf("tier mismatch: %q", skill.Tier)
+	}
+	if strings.Contains(skill.Body, "---") {
+		t.Errorf("body should not contain frontmatter fence, got %q", skill.Body)
+	}
+	if !strings.Contains(skill.Body, "Do the thing.") {
+		t.Errorf("body missing markdown content, got %q", skill.Body)
+	}
+}
+
+func TestMarkdownAdapterFallsBackToFilename(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deploy-checklist.md")
+	body := "Plain markdown without frontmatter.\nLine two.\n"
+	writeFile(t, path, body)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	skill, err := NewMarkdownAdapter().Parse(path, data, contracts.SkillTierWorkspace)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if skill.Name != "deploy-checklist" {
+		t.Errorf("expected filename fallback, got %q", skill.Name)
+	}
+	if !strings.Contains(skill.Body, "Plain markdown without frontmatter.") {
+		t.Errorf("body must include full file when no frontmatter, got %q", skill.Body)
+	}
+	if len(skill.Tags) != 0 {
+		t.Errorf("expected no tags, got %v", skill.Tags)
+	}
+}
+
+func TestMarkdownAdapterMalformedYAMLErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.md")
+	body := "---\nname: [unterminated\n---\nbody\n"
+	writeFile(t, path, body)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if _, err := NewMarkdownAdapter().Parse(path, data, contracts.SkillTierImported); err == nil {
+		t.Fatalf("expected error on malformed YAML")
+	}
+}
+
+func TestMarkdownAdapterCanHandle(t *testing.T) {
+	a := NewMarkdownAdapter()
+	if !a.CanHandle("/x/y.md") || !a.CanHandle("/x/y.MD") {
+		t.Errorf("expected .md to be handled regardless of case")
+	}
+	if a.CanHandle("/x/y.txt") {
+		t.Errorf("expected .txt to be rejected")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/skills/paths.go
+++ b/internal/skills/paths.go
@@ -1,0 +1,25 @@
+package skills
+
+import (
+	"path/filepath"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// DefaultRoots returns the canonical filesystem layout for the four skill
+// tiers. Workspace lives next to the project so a `git clone` carries its
+// skills along; personal/imported/bundled live under the user's home so they
+// follow the user across projects. The bundled root is a placeholder for
+// shipped-with-binary skills the installer will populate later.
+func DefaultRoots(home, workspace string) map[contracts.SkillTier]string {
+	roots := map[contracts.SkillTier]string{}
+	if workspace != "" {
+		roots[contracts.SkillTierWorkspace] = filepath.Join(workspace, ".conduit", "skills")
+	}
+	if home != "" {
+		roots[contracts.SkillTierPersonal] = filepath.Join(home, ".conduit", "skills", "personal")
+		roots[contracts.SkillTierImported] = filepath.Join(home, ".conduit", "skills", "imported")
+		roots[contracts.SkillTierBundled] = filepath.Join(home, ".conduit", "skills", "bundled")
+	}
+	return roots
+}

--- a/internal/skills/registry.go
+++ b/internal/skills/registry.go
@@ -1,0 +1,227 @@
+package skills
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// tierPrecedence is the locked walk order. Workspace wins, bundled loses.
+// Skills loaded earlier win against the same name loaded later.
+var tierPrecedence = []contracts.SkillTier{
+	contracts.SkillTierWorkspace,
+	contracts.SkillTierPersonal,
+	contracts.SkillTierImported,
+	contracts.SkillTierBundled,
+}
+
+// Registry indexes user-authored skill files across the four-tier hierarchy.
+// It is built once at startup (or on explicit reload) so per-task lookups stay
+// in-memory; the filesystem layout is the source of truth.
+type Registry struct {
+	roots     map[contracts.SkillTier]string
+	skills    map[string]contracts.Skill
+	conflicts []contracts.SkillConflict
+}
+
+// NewRegistry constructs an empty registry pointed at the supplied per-tier
+// roots. Callers compute defaults via DefaultRoots so tests and embeddings
+// can override directories without env var hacks.
+func NewRegistry(roots map[contracts.SkillTier]string) *Registry {
+	cloned := make(map[contracts.SkillTier]string, len(roots))
+	for tier, path := range roots {
+		cloned[tier] = path
+	}
+	return &Registry{
+		roots:  cloned,
+		skills: map[string]contracts.Skill{},
+	}
+}
+
+// Load walks each tier root in precedence order, asks the first matching
+// adapter to parse each file, and resolves name collisions in place.
+//
+// Conflict policy: precedence by tier, first-loaded-wins within tier;
+// collisions surface via Conflicts() instead of erroring so import sweeps
+// don't fail.
+func (r *Registry) Load(adapters []Adapter) error {
+	r.skills = map[string]contracts.Skill{}
+	r.conflicts = nil
+
+	if len(adapters) == 0 {
+		return errors.New("skills: at least one adapter required")
+	}
+
+	for _, tier := range tierPrecedence {
+		root, ok := r.roots[tier]
+		if !ok || root == "" {
+			continue
+		}
+		paths, err := collectSkillPaths(root)
+		if err != nil {
+			return fmt.Errorf("skills: walk %s tier %q: %w", tier, root, err)
+		}
+		for _, path := range paths {
+			if err := r.loadFile(tier, path, adapters); err != nil {
+				// Per-file errors must not abort the sweep — surfaces will
+				// later show a "broken skills" pane. For now we swallow and
+				// keep going so a single bad markdown file can't hide the
+				// rest of the user's library.
+				continue
+			}
+		}
+	}
+	return nil
+}
+
+// Lookup returns the hierarchy-resolved skill for an exact name.
+func (r *Registry) Lookup(name string) (contracts.Skill, bool) {
+	skill, ok := r.skills[name]
+	return skill, ok
+}
+
+// Search runs a case-insensitive substring scan over name, description, and
+// tags. The first cut at "indexed semantic-ish" search is intentionally cheap;
+// embeddings will plug in by exposing this as a strategy later.
+func (r *Registry) Search(query string) []contracts.Skill {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return r.List()
+	}
+
+	matches := make([]contracts.Skill, 0, len(r.skills))
+	for _, skill := range r.skills {
+		if skillMatchesQuery(skill, query) {
+			matches = append(matches, skill)
+		}
+	}
+	sort.Slice(matches, func(i, j int) bool { return matches[i].Name < matches[j].Name })
+	return matches
+}
+
+// Conflicts returns a copy of the collisions recorded during Load.
+func (r *Registry) Conflicts() []contracts.SkillConflict {
+	out := make([]contracts.SkillConflict, len(r.conflicts))
+	copy(out, r.conflicts)
+	return out
+}
+
+// List returns every loaded skill in alphabetical order. Stable ordering keeps
+// the CLI/TUI output diffable across reloads.
+func (r *Registry) List() []contracts.Skill {
+	out := make([]contracts.Skill, 0, len(r.skills))
+	for _, skill := range r.skills {
+		out = append(out, skill)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func (r *Registry) loadFile(tier contracts.SkillTier, path string, adapters []Adapter) error {
+	adapter := pickAdapter(adapters, path)
+	if adapter == nil {
+		return fmt.Errorf("skills: no adapter handles %q", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("skills: read %q: %w", path, err)
+	}
+	skill, err := adapter.Parse(path, data, tier)
+	if err != nil {
+		return err
+	}
+	if info, statErr := os.Stat(path); statErr == nil {
+		skill.UpdatedAt = info.ModTime()
+	}
+
+	existing, ok := r.skills[skill.Name]
+	if !ok {
+		r.skills[skill.Name] = skill
+		return nil
+	}
+	r.recordConflict(existing, skill)
+	return nil
+}
+
+// recordConflict appends the loser to an existing entry in Conflicts() or
+// creates a new one. The winner is whichever skill was loaded first — by tier
+// precedence across tiers, by sorted filename within a tier.
+func (r *Registry) recordConflict(winner, loser contracts.Skill) {
+	for i := range r.conflicts {
+		if r.conflicts[i].Name == winner.Name && r.conflicts[i].Winner == winner.Path {
+			r.conflicts[i].Losers = append(r.conflicts[i].Losers, loser.Path)
+			return
+		}
+	}
+	r.conflicts = append(r.conflicts, contracts.SkillConflict{
+		Name:   winner.Name,
+		Tier:   winner.Tier,
+		Winner: winner.Path,
+		Losers: []string{loser.Path},
+	})
+}
+
+// collectSkillPaths walks a tier root and returns deterministic, sorted file
+// paths. Missing directories are normal on first run and are not errors.
+func collectSkillPaths(root string) ([]string, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, nil
+	}
+
+	var paths []string
+	walkErr := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func pickAdapter(adapters []Adapter, path string) Adapter {
+	for _, adapter := range adapters {
+		if adapter == nil {
+			continue
+		}
+		if adapter.CanHandle(path) {
+			return adapter
+		}
+	}
+	return nil
+}
+
+func skillMatchesQuery(skill contracts.Skill, query string) bool {
+	if strings.Contains(strings.ToLower(skill.Name), query) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(skill.Description), query) {
+		return true
+	}
+	for _, tag := range skill.Tags {
+		if strings.Contains(strings.ToLower(tag), query) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/skills/registry_test.go
+++ b/internal/skills/registry_test.go
@@ -1,0 +1,180 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func writeSkill(t *testing.T, dir, filename, body string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", dir, err)
+	}
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %q: %v", path, err)
+	}
+	return path
+}
+
+func newTestRegistry(t *testing.T, base string) (*Registry, map[contracts.SkillTier]string) {
+	t.Helper()
+	roots := map[contracts.SkillTier]string{
+		contracts.SkillTierWorkspace: filepath.Join(base, "workspace"),
+		contracts.SkillTierPersonal:  filepath.Join(base, "personal"),
+		contracts.SkillTierImported:  filepath.Join(base, "imported"),
+		contracts.SkillTierBundled:   filepath.Join(base, "bundled"),
+	}
+	return NewRegistry(roots), roots
+}
+
+func TestLoadCrossTierPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	reg, roots := newTestRegistry(t, dir)
+
+	wsPath := writeSkill(t, roots[contracts.SkillTierWorkspace], "lint.md", "---\nname: lint\ndescription: ws\n---\nworkspace body\n")
+	personalPath := writeSkill(t, roots[contracts.SkillTierPersonal], "lint.md", "---\nname: lint\ndescription: personal\n---\npersonal body\n")
+	importedPath := writeSkill(t, roots[contracts.SkillTierImported], "lint.md", "---\nname: lint\ndescription: imported\n---\nimported body\n")
+	bundledPath := writeSkill(t, roots[contracts.SkillTierBundled], "lint.md", "---\nname: lint\ndescription: bundled\n---\nbundled body\n")
+
+	if err := reg.Load([]Adapter{NewMarkdownAdapter()}); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got, ok := reg.Lookup("lint")
+	if !ok {
+		t.Fatalf("expected lint to be loaded")
+	}
+	if got.Tier != contracts.SkillTierWorkspace {
+		t.Errorf("expected workspace winner, got tier %q", got.Tier)
+	}
+	if got.Path != wsPath {
+		t.Errorf("expected winner path %q, got %q", wsPath, got.Path)
+	}
+
+	conflicts := reg.Conflicts()
+	if len(conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(conflicts))
+	}
+	losers := conflicts[0].Losers
+	sort.Strings(losers)
+	wantLosers := []string{bundledPath, importedPath, personalPath}
+	sort.Strings(wantLosers)
+	if !reflect.DeepEqual(losers, wantLosers) {
+		t.Errorf("losers mismatch: got %v want %v", losers, wantLosers)
+	}
+}
+
+func TestLoadWithinTierFirstLoadedWins(t *testing.T) {
+	dir := t.TempDir()
+	reg, roots := newTestRegistry(t, dir)
+
+	// Filenames sort: a.md before z.md, so a.md wins.
+	winnerPath := writeSkill(t, roots[contracts.SkillTierPersonal], "a.md", "---\nname: rename\n---\nfirst\n")
+	loserPath := writeSkill(t, roots[contracts.SkillTierPersonal], "z.md", "---\nname: rename\n---\nsecond\n")
+
+	if err := reg.Load([]Adapter{NewMarkdownAdapter()}); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got, ok := reg.Lookup("rename")
+	if !ok {
+		t.Fatalf("expected rename to load")
+	}
+	if got.Path != winnerPath {
+		t.Errorf("first-loaded should win: got %q want %q", got.Path, winnerPath)
+	}
+	conflicts := reg.Conflicts()
+	if len(conflicts) != 1 || conflicts[0].Winner != winnerPath {
+		t.Fatalf("expected 1 same-tier conflict for winner %q, got %+v", winnerPath, conflicts)
+	}
+	if len(conflicts[0].Losers) != 1 || conflicts[0].Losers[0] != loserPath {
+		t.Errorf("expected loser %q, got %v", loserPath, conflicts[0].Losers)
+	}
+}
+
+func TestSearchCaseInsensitiveDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	reg, roots := newTestRegistry(t, dir)
+
+	writeSkill(t, roots[contracts.SkillTierPersonal], "alpha.md", "---\nname: Alpha\ndescription: Refactor TypeScript\ntags: [ts, refactor]\n---\nbody\n")
+	writeSkill(t, roots[contracts.SkillTierPersonal], "beta.md", "---\nname: Beta\ndescription: Run benchmarks\ntags: [perf]\n---\nbody\n")
+	writeSkill(t, roots[contracts.SkillTierPersonal], "gamma.md", "---\nname: Gamma\ndescription: TypeScript codemod\ntags: [ts]\n---\nbody\n")
+
+	if err := reg.Load([]Adapter{NewMarkdownAdapter()}); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	results := reg.Search("typescript")
+	if len(results) != 2 {
+		t.Fatalf("expected 2 typescript matches, got %d (%v)", len(results), results)
+	}
+	if results[0].Name != "Alpha" || results[1].Name != "Gamma" {
+		t.Errorf("expected alphabetical order [Alpha, Gamma], got [%s, %s]", results[0].Name, results[1].Name)
+	}
+
+	if got := reg.Search("PERF"); len(got) != 1 || got[0].Name != "Beta" {
+		t.Errorf("expected case-insensitive tag match for PERF, got %v", got)
+	}
+}
+
+func TestLoadToleratesMissingTierDirectories(t *testing.T) {
+	dir := t.TempDir()
+	roots := map[contracts.SkillTier]string{
+		contracts.SkillTierWorkspace: filepath.Join(dir, "missing-workspace"),
+		contracts.SkillTierPersonal:  filepath.Join(dir, "personal"),
+	}
+	reg := NewRegistry(roots)
+	writeSkill(t, roots[contracts.SkillTierPersonal], "lone.md", "---\nname: lone\n---\nbody\n")
+
+	if err := reg.Load([]Adapter{NewMarkdownAdapter()}); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := reg.Lookup("lone"); !ok {
+		t.Fatalf("expected lone skill loaded despite missing workspace dir")
+	}
+}
+
+func TestLookupMissReturnsFalse(t *testing.T) {
+	dir := t.TempDir()
+	reg, _ := newTestRegistry(t, dir)
+	if err := reg.Load([]Adapter{NewMarkdownAdapter()}); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if skill, ok := reg.Lookup("does-not-exist"); ok {
+		t.Errorf("expected miss, got %+v", skill)
+	}
+}
+
+func TestLoadRequiresAdapter(t *testing.T) {
+	dir := t.TempDir()
+	reg, _ := newTestRegistry(t, dir)
+	if err := reg.Load(nil); err == nil {
+		t.Fatalf("expected error when no adapters supplied")
+	}
+}
+
+func TestListIsAlphabetical(t *testing.T) {
+	dir := t.TempDir()
+	reg, roots := newTestRegistry(t, dir)
+	writeSkill(t, roots[contracts.SkillTierPersonal], "z.md", "---\nname: zoo\n---\nz\n")
+	writeSkill(t, roots[contracts.SkillTierPersonal], "a.md", "---\nname: ant\n---\na\n")
+	writeSkill(t, roots[contracts.SkillTierPersonal], "m.md", "---\nname: mole\n---\nm\n")
+
+	if err := reg.Load([]Adapter{NewMarkdownAdapter()}); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	listed := reg.List()
+	if len(listed) != 3 {
+		t.Fatalf("expected 3 skills, got %d", len(listed))
+	}
+	want := []string{"ant", "mole", "zoo"}
+	for i, name := range want {
+		if listed[i].Name != name {
+			t.Errorf("position %d: got %q want %q", i, listed[i].Name, name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/skills` package: filesystem-backed registry with workspace > personal > imported > bundled precedence (PRD §6.18). First-loaded wins within a tier; collisions surface via `Conflicts()` instead of erroring so import sweeps don't fail.
- `Adapter` interface shaped for #52 — Markdown adapter (YAML frontmatter) ships now; Hermes / SOUL.md / Cursor rules / AGENTS.md adapters land in the follow-up PR.
- `conduit skills list | lookup | search` wired into the CLI.

Closes #51. Lays groundwork for #52.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` all packages pass (11 new tests in `internal/skills`)
- [x] `go vet ./...` clean
- [ ] Manual: `conduit skills list` against an empty `~/.conduit/skills/` is a no-op
- [ ] Manual: drop a markdown skill into `~/.conduit/skills/personal/` and verify `lookup` returns it

## Out of scope (follow-ups)
- Bundled tier seed library (installer hasn't shipped one yet)
- Semantic embedding search — substring match for now
- TUI/GUI conflict surfacing
- File-watch / hot reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)