### PR TITLE
feat: structured reply tag parser

### DIFF
--- a/internal/coding/repl.go
+++ b/internal/coding/repl.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/jabreeflor/conduit/internal/contracts"
+	"github.com/jabreeflor/conduit/internal/replytags"
 	"github.com/jabreeflor/conduit/internal/tools"
 )
 
@@ -61,6 +62,14 @@ type REPL struct {
 	// long structured responses without enabling runaway loops on a
 	// misbehaving provider.
 	MaxAutoContinue int
+
+	// TagSink, if non-nil, receives structured reply tags ([[silent]],
+	// [[voice: ...]], [[media: ...]], [[heartbeat]], [[canvas: ...]]) parsed
+	// out of the assistant stream. Tag bytes are filtered from Out; only
+	// plain text reaches the user. The session journal still records the
+	// full unfiltered turn so replays can re-dispatch tags. Leave nil to
+	// keep the legacy passthrough behavior. See PRD §6.14.
+	TagSink func(replytags.Event)
 }
 
 // Run drives the read/stream/append loop until the input is exhausted or
@@ -127,10 +136,40 @@ func (r *REPL) streamAssistant(ctx context.Context, prompt string, isContinuatio
 	current := prompt
 	for {
 		var assistantBuf strings.Builder
+
+		// When a TagSink is wired in, deltas flow through the reply-tag
+		// parser so [[silent]] / [[voice: ...]] / etc. never reach the
+		// terminal verbatim. The raw stream is still buffered into
+		// assistantBuf for the session journal.
+		var tagParser *replytags.Parser
+		var silenced bool
+		if r.TagSink != nil {
+			tagParser = replytags.New(replytags.Sink{
+				Text: func(s string) {
+					if !silenced {
+						fmt.Fprint(r.Out, s)
+					}
+				},
+				Tag: func(ev replytags.Event) {
+					if ev.Kind == replytags.KindSilent {
+						silenced = true
+					}
+					r.TagSink(ev)
+				},
+			})
+		}
+
 		full, finish, err := r.Streamer.Stream(ctx, current, func(delta string) {
 			assistantBuf.WriteString(delta)
+			if tagParser != nil {
+				_, _ = tagParser.Write(delta)
+				return
+			}
 			fmt.Fprint(r.Out, delta)
 		})
+		if tagParser != nil {
+			tagParser.Close()
+		}
 		if err != nil {
 			return err
 		}

--- a/internal/coding/repl_test.go
+++ b/internal/coding/repl_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/jabreeflor/conduit/internal/replytags"
 )
 
 // fakeStreamer returns a configured sequence of finishReasons so tests can
@@ -114,6 +116,124 @@ func TestREPLEOFExitsCleanly(t *testing.T) {
 	}
 	if err := repl.Run(context.Background()); err != nil {
 		t.Fatalf("Run on empty input: %v", err)
+	}
+}
+
+// chunkStreamer emits a fixed sequence of deltas so we can test that the
+// REPL's reply-tag parsing tolerates tags split across streamed chunks.
+type chunkStreamer struct {
+	chunks []string
+	finish string
+}
+
+func (c *chunkStreamer) Stream(_ context.Context, _ string, onDelta func(string)) (string, string, error) {
+	var sb strings.Builder
+	for _, ch := range c.chunks {
+		sb.WriteString(ch)
+		if onDelta != nil {
+			onDelta(ch)
+		}
+	}
+	finish := c.finish
+	if finish == "" {
+		finish = "stop"
+	}
+	return sb.String(), finish, nil
+}
+
+func TestREPL_TagSinkFiltersTagsFromOutput(t *testing.T) {
+	home := t.TempDir()
+	session, err := NewSession(home)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	// Tag split across multiple chunks to also exercise streaming tolerance.
+	streamer := &chunkStreamer{chunks: []string{
+		"answer: 42 ", "[", "[voice: ", "say it]] done",
+	}}
+
+	var events []replytags.Event
+	out := &bytes.Buffer{}
+	repl := &REPL{
+		Session:  session,
+		Streamer: streamer,
+		In:       bytes.NewBufferString("hi\n"),
+		Out:      out,
+		TagSink:  func(ev replytags.Event) { events = append(events, ev) },
+	}
+	if err := repl.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "answer: 42  done") {
+		t.Errorf("output missing filtered text; got %q", out.String())
+	}
+	if strings.Contains(out.String(), "[[voice") {
+		t.Errorf("output leaked tag bytes; got %q", out.String())
+	}
+	if len(events) != 1 || events[0].Kind != replytags.KindVoice ||
+		events[0].Body != "say it" {
+		t.Errorf("events = %+v, want one voice event with body \"say it\"", events)
+	}
+
+	// Session journal must preserve the raw, unfiltered assistant turn so
+	// replays can re-dispatch tags downstream.
+	if len(session.Turns) != 2 {
+		t.Fatalf("expected 2 turns, got %d", len(session.Turns))
+	}
+	if !strings.Contains(session.Turns[1].Content, "[[voice: say it]]") {
+		t.Errorf("assistant turn lost tag bytes: %q", session.Turns[1].Content)
+	}
+}
+
+func TestREPL_TagSinkSilentSuppressesOutput(t *testing.T) {
+	home := t.TempDir()
+	session, err := NewSession(home)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	streamer := &chunkStreamer{chunks: []string{"[[silent]]hidden trailing text"}}
+	out := &bytes.Buffer{}
+	var events []replytags.Event
+	repl := &REPL{
+		Session:  session,
+		Streamer: streamer,
+		In:       bytes.NewBufferString("hi\n"),
+		Out:      out,
+		TagSink:  func(ev replytags.Event) { events = append(events, ev) },
+	}
+	if err := repl.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if strings.Contains(out.String(), "hidden trailing text") {
+		t.Errorf("expected post-[[silent]] text suppressed, got %q", out.String())
+	}
+	if len(events) != 1 || events[0].Kind != replytags.KindSilent {
+		t.Errorf("events = %+v, want one silent event", events)
+	}
+}
+
+func TestREPL_NoTagSinkPreservesLegacyPassthrough(t *testing.T) {
+	// Regression guard: when TagSink is nil, the REPL must not parse or
+	// rewrite assistant output. Tag bytes are written verbatim.
+	home := t.TempDir()
+	session, err := NewSession(home)
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	streamer := &chunkStreamer{chunks: []string{"plain [[voice: hi]] text"}}
+	out := &bytes.Buffer{}
+	repl := &REPL{
+		Session:  session,
+		Streamer: streamer,
+		In:       bytes.NewBufferString("hi\n"),
+		Out:      out,
+	}
+	if err := repl.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(out.String(), "[[voice: hi]]") {
+		t.Errorf("expected legacy passthrough; got %q", out.String())
 	}
 }
 

--- a/internal/replytags/replytags.go
+++ b/internal/replytags/replytags.go
@@ -1,0 +1,238 @@
+// Package replytags parses structured reply tags emitted by agents and
+// dispatches them to surface-specific handlers (TTS, Canvas, GUI media).
+// See PRD §6.14 for the tag protocol.
+//
+// Supported tags:
+//
+//	[[silent]]         — suppress visible output for this turn
+//	[[voice: text]]    — speak `text` via TTS
+//	[[media: url]]     — render media at `url` inline
+//	[[heartbeat]]      — keep-alive ping for long-running operations
+//	[[canvas: html]]   — render `html` to the GUI Canvas panel
+//
+// The parser is streaming-tolerant: a tag may arrive split across an
+// arbitrary number of Write calls (e.g. "[[voi" then "ce: hi]]"). Plain
+// text outside of tags is forwarded to the Sink's Text handler verbatim.
+// Unrecognized or malformed tags are passed through as plain text so a
+// stray "[[foo]]" never disappears silently.
+package replytags
+
+import (
+	"strings"
+)
+
+// Kind identifies one of the five recognized tag types.
+type Kind string
+
+const (
+	KindSilent    Kind = "silent"
+	KindVoice     Kind = "voice"
+	KindMedia     Kind = "media"
+	KindHeartbeat Kind = "heartbeat"
+	KindCanvas    Kind = "canvas"
+)
+
+// Event is a structured tag emission. Body is empty for marker tags
+// (silent, heartbeat) and carries the trimmed payload for content tags
+// (voice, media, canvas).
+type Event struct {
+	Kind Kind
+	Body string
+}
+
+// Sink receives parser output. Text is invoked for plain text outside any
+// tag; Tag is invoked for each recognized tag. Either field may be nil —
+// nil handlers drop their input, which is how callers implement
+// suppression (e.g. set Text=nil after observing [[silent]]).
+type Sink struct {
+	Text func(string)
+	Tag  func(Event)
+}
+
+// openDelim and closeDelim are the literal tag boundaries. Kept as
+// constants (not regex) so the streaming state machine stays cheap and
+// allocation-free on the hot delta path.
+const (
+	openDelim  = "[["
+	closeDelim = "]]"
+)
+
+// Parser is a streaming tag extractor. Feed it deltas via Write; flush
+// any trailing buffered text with Close. A Parser is single-use and not
+// safe for concurrent Write calls — callers serialize delta delivery
+// (which the REPL already does).
+type Parser struct {
+	sink Sink
+
+	// buf holds bytes that may belong to either an in-progress tag or a
+	// trailing partial open delimiter. The parser only emits text once
+	// it can prove the bytes are not part of a tag.
+	buf strings.Builder
+
+	// inTag tracks whether we have observed an open delimiter and are
+	// accumulating the tag body in buf (which excludes the delimiter
+	// itself once inTag flips true).
+	inTag bool
+}
+
+// New returns a Parser that dispatches to sink.
+func New(sink Sink) *Parser {
+	return &Parser{sink: sink}
+}
+
+// Write feeds a chunk of streamed assistant output through the parser.
+// It always returns len(s), nil — the io.Writer signature is for
+// convenience when wiring into existing pipelines.
+func (p *Parser) Write(s string) (int, error) {
+	n := len(s)
+	if s == "" {
+		return 0, nil
+	}
+	p.buf.WriteString(s)
+	p.drain()
+	return n, nil
+}
+
+// Close flushes any buffered bytes. An unclosed tag (e.g. "[[voice: hi"
+// with no terminating "]]") is emitted as plain text so the user sees
+// what the agent actually said instead of losing the tail of the turn.
+func (p *Parser) Close() {
+	if p.inTag {
+		// Re-prepend the open delimiter that was stripped when inTag
+		// flipped, so the user sees the literal source text.
+		p.emitText(openDelim + p.buf.String())
+		p.buf.Reset()
+		p.inTag = false
+		return
+	}
+	if p.buf.Len() > 0 {
+		p.emitText(p.buf.String())
+		p.buf.Reset()
+	}
+}
+
+// drain consumes as much of the buffer as can be unambiguously
+// classified, leaving only bytes that might still be part of an
+// in-progress tag (a trailing "[" or partial "[[...]" body).
+func (p *Parser) drain() {
+	for {
+		current := p.buf.String()
+		if current == "" {
+			return
+		}
+
+		if !p.inTag {
+			// Hunt for the next potential open delimiter.
+			idx := strings.Index(current, openDelim)
+			if idx < 0 {
+				// No "[[" anywhere. Hold back a single trailing "["
+				// because the next chunk might complete the delimiter.
+				if strings.HasSuffix(current, "[") {
+					if len(current) > 1 {
+						p.emitText(current[:len(current)-1])
+					}
+					p.buf.Reset()
+					p.buf.WriteByte('[')
+					return
+				}
+				p.emitText(current)
+				p.buf.Reset()
+				return
+			}
+			if idx > 0 {
+				p.emitText(current[:idx])
+			}
+			// Skip the "[[" delimiter itself; remaining buffer is the
+			// tag body candidate.
+			p.buf.Reset()
+			p.buf.WriteString(current[idx+len(openDelim):])
+			p.inTag = true
+			continue
+		}
+
+		// inTag: scan for the close delimiter.
+		end := strings.Index(current, closeDelim)
+		if end < 0 {
+			// Need more bytes. If the buffer is getting long without a
+			// close, that's still tolerated — the agent might be
+			// emitting a large [[canvas:...]] payload.
+			return
+		}
+		body := current[:end]
+		rest := current[end+len(closeDelim):]
+		p.dispatchTag(body)
+		p.inTag = false
+		p.buf.Reset()
+		p.buf.WriteString(rest)
+	}
+}
+
+// dispatchTag classifies the body of a closed [[...]] tag and emits the
+// appropriate Event. Unknown tags pass through as plain text wrapped in
+// the original delimiters so the user never silently loses content.
+func (p *Parser) dispatchTag(body string) {
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" {
+		// "[[]]" — almost certainly not intended as a tag. Echo it.
+		p.emitText(openDelim + body + closeDelim)
+		return
+	}
+
+	// Marker tags: exact (case-insensitive) match, no payload allowed.
+	switch strings.ToLower(trimmed) {
+	case "silent":
+		p.emitTag(Event{Kind: KindSilent})
+		return
+	case "heartbeat":
+		p.emitTag(Event{Kind: KindHeartbeat})
+		return
+	}
+
+	// Content tags: "<name>:<payload>". Split on the first colon so
+	// payloads (URLs, HTML, prose) can contain colons freely.
+	colon := strings.IndexByte(trimmed, ':')
+	if colon < 0 {
+		p.emitText(openDelim + body + closeDelim)
+		return
+	}
+	name := strings.ToLower(strings.TrimSpace(trimmed[:colon]))
+	payload := strings.TrimSpace(trimmed[colon+1:])
+	switch name {
+	case "voice":
+		p.emitTag(Event{Kind: KindVoice, Body: payload})
+	case "media":
+		p.emitTag(Event{Kind: KindMedia, Body: payload})
+	case "canvas":
+		p.emitTag(Event{Kind: KindCanvas, Body: payload})
+	default:
+		p.emitText(openDelim + body + closeDelim)
+	}
+}
+
+func (p *Parser) emitText(s string) {
+	if s == "" || p.sink.Text == nil {
+		return
+	}
+	p.sink.Text(s)
+}
+
+func (p *Parser) emitTag(ev Event) {
+	if p.sink.Tag == nil {
+		return
+	}
+	p.sink.Tag(ev)
+}
+
+// Parse is a one-shot helper for non-streaming callers (eval assertions,
+// hook payloads, tests). It runs Write+Close once and returns the
+// collected events plus the plain-text remainder.
+func Parse(input string) (text string, events []Event) {
+	var sb strings.Builder
+	p := New(Sink{
+		Text: func(s string) { sb.WriteString(s) },
+		Tag:  func(ev Event) { events = append(events, ev) },
+	})
+	_, _ = p.Write(input)
+	p.Close()
+	return sb.String(), events
+}

--- a/internal/replytags/replytags_test.go
+++ b/internal/replytags/replytags_test.go
@@ -1,0 +1,244 @@
+package replytags_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/replytags"
+)
+
+func TestParse_PlainText(t *testing.T) {
+	text, events := replytags.Parse("hello world")
+	if text != "hello world" {
+		t.Errorf("text = %q, want %q", text, "hello world")
+	}
+	if len(events) != 0 {
+		t.Errorf("events = %v, want none", events)
+	}
+}
+
+func TestParse_SilentTag(t *testing.T) {
+	text, events := replytags.Parse("[[silent]]")
+	if text != "" {
+		t.Errorf("text = %q, want empty", text)
+	}
+	if len(events) != 1 || events[0].Kind != replytags.KindSilent {
+		t.Fatalf("events = %v, want one silent event", events)
+	}
+	if events[0].Body != "" {
+		t.Errorf("silent body = %q, want empty", events[0].Body)
+	}
+}
+
+func TestParse_HeartbeatTag(t *testing.T) {
+	text, events := replytags.Parse("working...[[heartbeat]] still here")
+	if text != "working... still here" {
+		t.Errorf("text = %q", text)
+	}
+	if len(events) != 1 || events[0].Kind != replytags.KindHeartbeat {
+		t.Fatalf("events = %v, want one heartbeat", events)
+	}
+}
+
+func TestParse_VoiceTag(t *testing.T) {
+	text, events := replytags.Parse("[[voice: hello there]]")
+	if text != "" {
+		t.Errorf("text = %q, want empty", text)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %v, want one", events)
+	}
+	if events[0].Kind != replytags.KindVoice || events[0].Body != "hello there" {
+		t.Errorf("event = %+v", events[0])
+	}
+}
+
+func TestParse_MediaTag(t *testing.T) {
+	text, events := replytags.Parse("see [[media: https://example.com/x.png]] !")
+	if text != "see  !" {
+		t.Errorf("text = %q", text)
+	}
+	if len(events) != 1 || events[0].Kind != replytags.KindMedia ||
+		events[0].Body != "https://example.com/x.png" {
+		t.Errorf("event = %+v", events[0])
+	}
+}
+
+func TestParse_CanvasTag(t *testing.T) {
+	html := "<h1>Hello</h1><p>colon-friendly: yes</p>"
+	text, events := replytags.Parse("[[canvas: " + html + "]]done")
+	if text != "done" {
+		t.Errorf("text = %q", text)
+	}
+	if len(events) != 1 || events[0].Kind != replytags.KindCanvas ||
+		events[0].Body != html {
+		t.Errorf("event = %+v", events[0])
+	}
+}
+
+func TestParse_MixedTagsAndText(t *testing.T) {
+	in := "Pre [[heartbeat]] mid [[voice: speak]] post [[media: u]] end"
+	text, events := replytags.Parse(in)
+
+	wantText := "Pre  mid  post  end"
+	if text != wantText {
+		t.Errorf("text = %q, want %q", text, wantText)
+	}
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+	wantKinds := []replytags.Kind{
+		replytags.KindHeartbeat, replytags.KindVoice, replytags.KindMedia,
+	}
+	for i, k := range wantKinds {
+		if events[i].Kind != k {
+			t.Errorf("events[%d].Kind = %s, want %s", i, events[i].Kind, k)
+		}
+	}
+	if events[1].Body != "speak" {
+		t.Errorf("voice body = %q", events[1].Body)
+	}
+	if events[2].Body != "u" {
+		t.Errorf("media body = %q", events[2].Body)
+	}
+}
+
+func TestParse_UnclosedTagPassesThrough(t *testing.T) {
+	in := "okay [[voice: never closed"
+	text, events := replytags.Parse(in)
+	if text != in {
+		t.Errorf("text = %q, want original %q", text, in)
+	}
+	if len(events) != 0 {
+		t.Errorf("events = %v, want none", events)
+	}
+}
+
+func TestParse_UnknownTagPassesThrough(t *testing.T) {
+	in := "[[bogus]] and [[also: thing]]"
+	text, events := replytags.Parse(in)
+	if text != in {
+		t.Errorf("text = %q, want original %q", text, in)
+	}
+	if len(events) != 0 {
+		t.Errorf("events = %v, want none", events)
+	}
+}
+
+func TestParse_EmptyTagPassesThrough(t *testing.T) {
+	text, events := replytags.Parse("[[]]")
+	if text != "[[]]" {
+		t.Errorf("text = %q, want literal", text)
+	}
+	if len(events) != 0 {
+		t.Errorf("events = %v, want none", events)
+	}
+}
+
+func TestParse_TagNameIsCaseInsensitive(t *testing.T) {
+	text, events := replytags.Parse("[[Silent]] [[VOICE: hi]] [[Canvas: x]]")
+	if text != "  " {
+		t.Errorf("text = %q", text)
+	}
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+	if events[0].Kind != replytags.KindSilent ||
+		events[1].Kind != replytags.KindVoice || events[1].Body != "hi" ||
+		events[2].Kind != replytags.KindCanvas || events[2].Body != "x" {
+		t.Errorf("events = %+v", events)
+	}
+}
+
+func TestParse_LoneOpenBracketsArePlainText(t *testing.T) {
+	text, events := replytags.Parse("a [ b [c d")
+	if text != "a [ b [c d" {
+		t.Errorf("text = %q", text)
+	}
+	if len(events) != 0 {
+		t.Errorf("events = %v, want none", events)
+	}
+}
+
+func TestStreaming_TagAcrossManyChunks(t *testing.T) {
+	chunks := []string{"hello ", "[", "[", "voi", "ce", ": stre", "amed]", "]", " bye"}
+
+	var textBuf strings.Builder
+	var events []replytags.Event
+	p := replytags.New(replytags.Sink{
+		Text: func(s string) { textBuf.WriteString(s) },
+		Tag:  func(ev replytags.Event) { events = append(events, ev) },
+	})
+	for _, c := range chunks {
+		if _, err := p.Write(c); err != nil {
+			t.Fatalf("Write(%q): %v", c, err)
+		}
+	}
+	p.Close()
+
+	if textBuf.String() != "hello  bye" {
+		t.Errorf("text = %q, want %q", textBuf.String(), "hello  bye")
+	}
+	if len(events) != 1 || events[0].Kind != replytags.KindVoice ||
+		events[0].Body != "streamed" {
+		t.Errorf("events = %+v", events)
+	}
+}
+
+func TestStreaming_TextIsForwardedIncrementally(t *testing.T) {
+	// Plain text without any "[" must flush eagerly so the surface can
+	// render tokens as they arrive. We assert by counting Text calls.
+	var calls int
+	p := replytags.New(replytags.Sink{
+		Text: func(string) { calls++ },
+	})
+	for _, c := range []string{"a", "b", "c"} {
+		_, _ = p.Write(c)
+	}
+	p.Close()
+	if calls != 3 {
+		t.Errorf("Text invocations = %d, want 3 (one per chunk)", calls)
+	}
+}
+
+func TestStreaming_TrailingOpenBracketHeldUntilFlush(t *testing.T) {
+	// A trailing "[" might be the start of "[[". The parser must hold it
+	// back until either the next chunk arrives or Close is called.
+	var sb strings.Builder
+	p := replytags.New(replytags.Sink{
+		Text: func(s string) { sb.WriteString(s) },
+	})
+	_, _ = p.Write("hello[")
+	if sb.String() != "hello" {
+		t.Errorf("after partial: %q, want %q", sb.String(), "hello")
+	}
+	p.Close()
+	if sb.String() != "hello[" {
+		t.Errorf("after close: %q, want %q", sb.String(), "hello[")
+	}
+}
+
+func TestStreaming_AdjacentTags(t *testing.T) {
+	text, events := replytags.Parse("[[silent]][[heartbeat]][[voice: x]]")
+	if text != "" {
+		t.Errorf("text = %q, want empty", text)
+	}
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+	if events[0].Kind != replytags.KindSilent ||
+		events[1].Kind != replytags.KindHeartbeat ||
+		events[2].Kind != replytags.KindVoice || events[2].Body != "x" {
+		t.Errorf("events = %+v", events)
+	}
+}
+
+func TestSink_NilHandlersDropSilently(t *testing.T) {
+	// Verify a Sink with nil Text and nil Tag is valid (callers use this
+	// to implement [[silent]] suppression).
+	p := replytags.New(replytags.Sink{})
+	if _, err := p.Write("text [[heartbeat]] more"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	p.Close()
+}


### PR DESCRIPTION
## Summary

Closes #11. Implements the structured reply tag parser called out in PRD §6.14.

- New `internal/replytags` package with a streaming-tolerant `Parser` and one-shot `Parse` helper.
- Handles all five tags: `[[silent]]`, `[[voice: text]]`, `[[media: url]]`, `[[heartbeat]]`, `[[canvas: html]]`.
- Tolerant of partial input (a tag may arrive split across many chunks, e.g. `[`, `[voi`, `ce: hi]`, `]`).
- Unknown / malformed / unclosed tags pass through as plain text so nothing is silently dropped.
- Wired into the coding REPL via an opt-in `TagSink` hook: when set, tag bytes are filtered from terminal output while the raw assistant turn is still preserved in the session journal for replay.

## Design notes

- Tag matching uses a small hand-rolled state machine (no regex) so the streaming hot path stays allocation-light.
- Tag names are matched case-insensitively; payloads after the first `:` are kept verbatim (trimmed) so colons in URLs/HTML are fine.
- `[[silent]]` flips a per-turn suppression flag; subsequent text in the same turn is also suppressed, matching PRD intent ("task runs in background with no visible response").
- `Sink{}` with nil handlers is valid — surfaces can opt out of either text or tag streams without ceremony.
- The REPL's legacy passthrough path is preserved when `TagSink` is nil, so this PR is a no-op for callers that haven't migrated yet (current `cmd/conduit` echo streamer included).

## Test plan

- [x] `make lint`
- [x] `make typecheck`
- [x] `make test`
- [x] Unit tests cover each tag kind, mixed plaintext + tags, malformed/unclosed tags, unknown tags, adjacent tags, case-insensitivity, lone `[`, and tag bytes split across many stream chunks.
- [x] REPL integration tests verify tag filtering, `[[silent]]` suppression, raw-turn journaling, and legacy passthrough when `TagSink` is unset.