### PR TITLE
feat: memory inspector in TUI

### DIFF
--- a/internal/core/engine.go
+++ b/internal/core/engine.go
@@ -350,6 +350,73 @@ func (e *Engine) SearchMemory(ctx context.Context, query string) ([]memory.Entry
 	return p.Search(ctx, query)
 }
 
+// DeleteMemory removes a single memory entry by ID. Used by the TUI memory
+// inspector for user-driven deletes; bypasses the Pinned guard because the
+// user is acting explicitly.
+func (e *Engine) DeleteMemory(ctx context.Context, id string) error {
+	p, _ := e.memRegistry.Active()
+	if p == nil {
+		return nil
+	}
+	if err := p.Delete(ctx, id); err != nil {
+		return err
+	}
+	e.sessionLog = append(e.sessionLog, contracts.SessionLogEntry{
+		At:      time.Now().UTC(),
+		Message: fmt.Sprintf("memory delete: %s", id),
+	})
+	return nil
+}
+
+// PruneMemory bulk-deletes entries matched by query, skipping pinned entries.
+// Returns the IDs removed. Used by the TUI memory inspector's "prune matching"
+// action.
+func (e *Engine) PruneMemory(ctx context.Context, query string) ([]string, error) {
+	p, _ := e.memRegistry.Active()
+	if p == nil {
+		return nil, nil
+	}
+	removed, err := p.Prune(ctx, query)
+	if err != nil {
+		return removed, err
+	}
+	e.sessionLog = append(e.sessionLog, contracts.SessionLogEntry{
+		At:      time.Now().UTC(),
+		Message: fmt.Sprintf("memory prune: %d entries (query=%q)", len(removed), query),
+	})
+	return removed, nil
+}
+
+// SetMemoryPinned toggles the protect/pin flag on a memory entry. Pinned
+// entries are skipped by PruneMemory and any future automatic compactor.
+func (e *Engine) SetMemoryPinned(ctx context.Context, id string, pinned bool) error {
+	p, _ := e.memRegistry.Active()
+	if p == nil {
+		return nil
+	}
+	// Re-write through the provider so existing storage layout (file paths,
+	// timestamps) is preserved without exposing a Pin-specific API.
+	entries, err := p.Search(ctx, "")
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.ID != id {
+			continue
+		}
+		entry.Pinned = pinned
+		if err := p.Write(ctx, entry); err != nil {
+			return err
+		}
+		e.sessionLog = append(e.sessionLog, contracts.SessionLogEntry{
+			At:      time.Now().UTC(),
+			Message: fmt.Sprintf("memory pin: %s = %t", id, pinned),
+		})
+		return nil
+	}
+	return nil
+}
+
 // SessionLog returns a copy of user-visible engine events.
 func (e *Engine) SessionLog() []contracts.SessionLogEntry {
 	return append([]contracts.SessionLogEntry(nil), e.sessionLog...)

--- a/internal/core/engine_memory_inspector_test.go
+++ b/internal/core/engine_memory_inspector_test.go
@@ -1,0 +1,105 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+	"github.com/jabreeflor/conduit/internal/memory"
+)
+
+// TestEngineDeleteMemory exercises the inspector's delete path end-to-end
+// against the real FlatFileProvider.
+func TestEngineDeleteMemory(t *testing.T) {
+	engine := New("test")
+	provider := memory.NewFlatFileProviderAt(t.TempDir())
+	if err := provider.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := engine.memRegistry.Replace(context.Background(), contracts.MemoryProviderKindFlatFile, provider); err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+
+	entry := memory.Entry{Kind: memory.KindFact, Title: "doomed", Body: "x"}
+	if err := engine.WriteMemory(context.Background(), entry); err != nil {
+		t.Fatalf("WriteMemory: %v", err)
+	}
+	stored, _ := engine.SearchMemory(context.Background(), "")
+	if len(stored) != 1 {
+		t.Fatalf("expected 1 entry pre-delete, got %d", len(stored))
+	}
+
+	if err := engine.DeleteMemory(context.Background(), stored[0].ID); err != nil {
+		t.Fatalf("DeleteMemory: %v", err)
+	}
+	left, _ := engine.SearchMemory(context.Background(), "")
+	if len(left) != 0 {
+		t.Fatalf("expected 0 entries post-delete, got %d", len(left))
+	}
+
+	found := false
+	for _, ev := range engine.SessionLog() {
+		if strings.Contains(ev.Message, "memory delete:") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("session log missing memory delete event")
+	}
+}
+
+// TestEnginePruneMemorySkipsPinned proves the engine wires Provider.Prune
+// honoring the pinned/manual-override semantics.
+func TestEnginePruneMemorySkipsPinned(t *testing.T) {
+	engine := New("test")
+	provider := memory.NewFlatFileProviderAt(t.TempDir())
+	provider.Initialize(context.Background())                                                        //nolint:errcheck
+	engine.memRegistry.Replace(context.Background(), contracts.MemoryProviderKindFlatFile, provider) //nolint:errcheck
+
+	pinned := memory.Entry{Title: "keeper", Body: "load-bearing", Pinned: true}
+	loose := memory.Entry{Title: "loose", Body: "go away"}
+	engine.WriteMemory(context.Background(), pinned) //nolint:errcheck
+	engine.WriteMemory(context.Background(), loose)  //nolint:errcheck
+
+	removed, err := engine.PruneMemory(context.Background(), "")
+	if err != nil {
+		t.Fatalf("PruneMemory: %v", err)
+	}
+	if len(removed) != 1 {
+		t.Fatalf("expected 1 removed (pinned skipped), got %d", len(removed))
+	}
+
+	all, _ := engine.SearchMemory(context.Background(), "")
+	if len(all) != 1 || !all[0].Pinned {
+		t.Fatalf("pinned entry should survive prune, got %+v", all)
+	}
+}
+
+// TestEngineSetMemoryPinnedToggles checks both directions of the pin toggle.
+func TestEngineSetMemoryPinnedToggles(t *testing.T) {
+	engine := New("test")
+	provider := memory.NewFlatFileProviderAt(t.TempDir())
+	provider.Initialize(context.Background())                                                        //nolint:errcheck
+	engine.memRegistry.Replace(context.Background(), contracts.MemoryProviderKindFlatFile, provider) //nolint:errcheck
+
+	engine.WriteMemory(context.Background(), memory.Entry{Title: "candidate", Body: "y"}) //nolint:errcheck
+	stored, _ := engine.SearchMemory(context.Background(), "")
+	id := stored[0].ID
+
+	if err := engine.SetMemoryPinned(context.Background(), id, true); err != nil {
+		t.Fatalf("SetMemoryPinned(true): %v", err)
+	}
+	got, _ := engine.SearchMemory(context.Background(), "")
+	if !got[0].Pinned {
+		t.Fatal("entry not pinned after SetMemoryPinned(true)")
+	}
+
+	if err := engine.SetMemoryPinned(context.Background(), id, false); err != nil {
+		t.Fatalf("SetMemoryPinned(false): %v", err)
+	}
+	got, _ = engine.SearchMemory(context.Background(), "")
+	if got[0].Pinned {
+		t.Fatal("entry still pinned after SetMemoryPinned(false)")
+	}
+}

--- a/internal/memory/flatfile.go
+++ b/internal/memory/flatfile.go
@@ -107,6 +107,58 @@ func (p *FlatFileProvider) Search(_ context.Context, query string) ([]Entry, err
 	return out, nil
 }
 
+// Delete removes the entry with the given ID. Idempotent: returns nil if no
+// matching file is present.
+func (p *FlatFileProvider) Delete(_ context.Context, id string) error {
+	if id == "" {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if path, ok := p.findFileByID(id); ok {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("memory: delete %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// Prune removes every entry matched by query (case-insensitive substring on
+// title/body/tags) except those with Pinned=true. An empty query prunes all
+// non-pinned entries. Returns the IDs that were removed.
+func (p *FlatFileProvider) Prune(_ context.Context, query string) ([]string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	entries, err := p.readAll()
+	if err != nil {
+		return nil, err
+	}
+	q := strings.ToLower(query)
+	var removed []string
+	for _, e := range entries {
+		if e.Pinned {
+			continue
+		}
+		if q != "" {
+			if !strings.Contains(strings.ToLower(e.Title), q) &&
+				!strings.Contains(strings.ToLower(e.Body), q) &&
+				!containsTag(e.Tags, q) {
+				continue
+			}
+		}
+		path, ok := p.findFileByID(e.ID)
+		if !ok {
+			continue
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return removed, fmt.Errorf("memory: prune %s: %w", path, err)
+		}
+		removed = append(removed, e.ID)
+	}
+	return removed, nil
+}
+
 // Compress is a no-op for the flat-file backend. Entry curation is agent-driven
 // and happens after task completion via Write calls.
 func (p *FlatFileProvider) Compress(_ context.Context) error { return nil }
@@ -166,6 +218,10 @@ func marshalEntry(e Entry) string {
 	fmt.Fprintf(&b, "tags: [%s]\n", strings.Join(e.Tags, ", "))
 	fmt.Fprintf(&b, "created: %s\n", e.CreatedAt.Format(time.RFC3339))
 	fmt.Fprintf(&b, "updated: %s\n", e.UpdatedAt.Format(time.RFC3339))
+	if e.Pinned {
+		// Only emit when true so existing files stay byte-identical.
+		b.WriteString("pinned: true\n")
+	}
 	b.WriteString("---\n\n")
 	fmt.Fprintf(&b, "# %s\n\n", e.Title)
 	b.WriteString(strings.TrimRight(e.Body, "\n"))
@@ -212,6 +268,8 @@ func parseEntry(s string) (Entry, bool) {
 			e.CreatedAt, _ = time.Parse(time.RFC3339, v)
 		case "updated":
 			e.UpdatedAt, _ = time.Parse(time.RFC3339, v)
+		case "pinned":
+			e.Pinned = strings.EqualFold(strings.TrimSpace(v), "true")
 		}
 	}
 	if e.ID == "" {

--- a/internal/memory/flatfile_prune_test.go
+++ b/internal/memory/flatfile_prune_test.go
@@ -1,0 +1,119 @@
+package memory
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDelete_removesEntry verifies single-entry deletion is idempotent and
+// actually removes the underlying markdown file.
+func TestDelete_removesEntry(t *testing.T) {
+	p := NewFlatFileProviderAt(t.TempDir())
+	if err := p.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	entry := Entry{ID: "abc123def456ffaa1234", Kind: KindFact, Title: "doomed", Body: "x"}
+	if err := p.Write(context.Background(), entry); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if err := p.Delete(context.Background(), entry.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	files, _ := filepath.Glob(filepath.Join(p.dir, "*.md"))
+	if len(files) != 0 {
+		t.Fatalf("expected 0 files after delete, got %d", len(files))
+	}
+
+	// Idempotent — second delete must succeed.
+	if err := p.Delete(context.Background(), entry.ID); err != nil {
+		t.Fatalf("second Delete should be idempotent, got %v", err)
+	}
+}
+
+// TestPrune_skipsPinned proves manual override semantics: pinned entries
+// survive a prune even when they match the filter.
+func TestPrune_skipsPinned(t *testing.T) {
+	p := NewFlatFileProviderAt(t.TempDir())
+	p.Initialize(context.Background()) //nolint:errcheck
+
+	pinned := Entry{ID: "111aa222bb33cc44dd55", Title: "pinned note", Body: "keep me", Pinned: true}
+	loose := Entry{ID: "999aa888bb77cc66dd55", Title: "loose note", Body: "drop me"}
+	p.Write(context.Background(), pinned) //nolint:errcheck
+	p.Write(context.Background(), loose)  //nolint:errcheck
+
+	removed, err := p.Prune(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if len(removed) != 1 || removed[0] != loose.ID {
+		t.Fatalf("expected to prune only the loose entry, got %v", removed)
+	}
+
+	all, _ := p.Search(context.Background(), "")
+	if len(all) != 1 || all[0].ID != pinned.ID {
+		t.Fatalf("pinned entry must survive prune, got %+v", all)
+	}
+}
+
+// TestPrune_byQuery prunes only entries matching the query.
+func TestPrune_byQuery(t *testing.T) {
+	p := NewFlatFileProviderAt(t.TempDir())
+	p.Initialize(context.Background()) //nolint:errcheck
+
+	p.Write(context.Background(), Entry{Title: "alpha thing", Body: "foo"})  //nolint:errcheck
+	p.Write(context.Background(), Entry{Title: "beta thing", Body: "alpha"}) //nolint:errcheck
+	p.Write(context.Background(), Entry{Title: "gamma", Body: "unrelated"})  //nolint:errcheck
+
+	removed, err := p.Prune(context.Background(), "alpha")
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if len(removed) != 2 {
+		t.Fatalf("expected 2 removals (title and body matches), got %d (%v)", len(removed), removed)
+	}
+
+	remaining, _ := p.Search(context.Background(), "")
+	if len(remaining) != 1 || remaining[0].Title != "gamma" {
+		t.Fatalf("expected only gamma to remain, got %+v", remaining)
+	}
+}
+
+// TestPinnedRoundTripsThroughFile ensures the pinned flag survives a
+// write→read cycle via the YAML frontmatter.
+func TestPinnedRoundTripsThroughFile(t *testing.T) {
+	p := NewFlatFileProviderAt(t.TempDir())
+	p.Initialize(context.Background()) //nolint:errcheck
+
+	entry := Entry{Title: "Constitution", Body: "do not delete", Pinned: true}
+	if err := p.Write(context.Background(), entry); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	results, err := p.Search(context.Background(), "Constitution")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Search returned %d, want 1", len(results))
+	}
+	if !results[0].Pinned {
+		t.Fatalf("Pinned flag did not round-trip through frontmatter")
+	}
+
+	// Default (false) entries must not emit a pinned line — keeps existing
+	// fixtures byte-stable.
+	plain := Entry{Title: "Ordinary"}
+	p.Write(context.Background(), plain) //nolint:errcheck
+	files, _ := filepath.Glob(filepath.Join(p.dir, "ordinary-*.md"))
+	if len(files) != 1 {
+		t.Fatalf("expected 1 ordinary file, got %d", len(files))
+	}
+	raw, _ := os.ReadFile(files[0])
+	data := string(raw)
+	if strings.Contains(data, "pinned:") {
+		t.Fatalf("non-pinned entry should not emit pinned key, got:\n%s", data)
+	}
+}

--- a/internal/memory/noop.go
+++ b/internal/memory/noop.go
@@ -10,5 +10,7 @@ func (NoOpProvider) Initialize(_ context.Context) error                    { ret
 func (NoOpProvider) Prefetch(_ context.Context, _ string) ([]Entry, error) { return nil, nil }
 func (NoOpProvider) Write(_ context.Context, _ Entry) error                { return nil }
 func (NoOpProvider) Search(_ context.Context, _ string) ([]Entry, error)   { return nil, nil }
+func (NoOpProvider) Delete(_ context.Context, _ string) error              { return nil }
+func (NoOpProvider) Prune(_ context.Context, _ string) ([]string, error)   { return nil, nil }
 func (NoOpProvider) Compress(_ context.Context) error                      { return nil }
 func (NoOpProvider) Shutdown(_ context.Context) error                      { return nil }

--- a/internal/memory/provider.go
+++ b/internal/memory/provider.go
@@ -26,6 +26,10 @@ type Entry struct {
 	Tags      []string
 	CreatedAt time.Time
 	UpdatedAt time.Time
+	// Pinned marks an entry as protected from automatic pruning. The memory
+	// inspector lets users toggle this manually (PRD §19 "Memory pruning /
+	// manual override"); any future automatic compactor must skip pinned entries.
+	Pinned bool
 }
 
 // Provider is the abstract memory layer. Only one external provider may be
@@ -39,6 +43,14 @@ type Provider interface {
 	Write(ctx context.Context, entry Entry) error
 	// Search returns entries whose title, body, or tags contain the query.
 	Search(ctx context.Context, query string) ([]Entry, error)
+	// Delete removes the entry with the given ID. Returns nil if no entry
+	// matches (idempotent). Pinned entries are still deleted — Delete is the
+	// explicit user-driven path; pruners must check Pinned themselves.
+	Delete(ctx context.Context, id string) error
+	// Prune removes every entry matched by query (same matching rules as
+	// Search) except those with Pinned=true. Returns the IDs that were removed.
+	// An empty query prunes everything not pinned.
+	Prune(ctx context.Context, query string) ([]string, error)
 	// Compress merges or prunes stale entries to keep the store lean.
 	Compress(ctx context.Context) error
 	// Shutdown flushes any pending writes and releases resources.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -86,7 +86,8 @@ func RunInteractive() error {
 		return err
 	}
 
-	m := newModel(modelStatus.SelectedModel, setup, engine.SetupLocalAI)
+	m := newModel(modelStatus.SelectedModel, setup, engine.SetupLocalAI).
+		WithMemoryController(engine)
 	p := tea.NewProgram(
 		m,
 		tea.WithAltScreen(),

--- a/internal/tui/memory_inspector.go
+++ b/internal/tui/memory_inspector.go
@@ -1,0 +1,363 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jabreeflor/conduit/internal/memory"
+)
+
+// MemoryInspector is the in-TUI memory browser. It owns its own state (entry
+// list, filter query, cursor, mode) and is intentionally free of any Bubble
+// Tea dependency — the same model is exercised by tests via plain method
+// calls and surfaced in the interactive TUI through a thin Update wrapper.
+//
+// Modes:
+//   - inspectorList    — browse + filter the entry list
+//   - inspectorDetail  — full content of one entry
+//   - inspectorConfirm — single-entry delete confirmation prompt
+//   - inspectorPrune   — bulk-prune-by-filter confirmation prompt
+type MemoryInspector struct {
+	entries []memory.Entry // unfiltered, sorted snapshot from the provider
+	filter  string         // live substring filter
+	cursor  int            // index into the *filtered* slice
+	mode    inspectorMode
+	editing bool   // when true, keystrokes append to the filter
+	last    string // last status / action message shown at the footer
+}
+
+type inspectorMode int
+
+const (
+	inspectorList inspectorMode = iota
+	inspectorDetail
+	inspectorConfirm
+	inspectorPrune
+)
+
+// NewMemoryInspector returns an empty inspector in list mode.
+func NewMemoryInspector() *MemoryInspector {
+	return &MemoryInspector{}
+}
+
+// SetEntries replaces the entry list; cursor is clamped to the new length.
+// Entries are sorted by UpdatedAt descending (newest first), with pinned
+// entries surfaced ahead of unpinned within the same window so they're easy
+// to find.
+func (mi *MemoryInspector) SetEntries(entries []memory.Entry) {
+	cp := make([]memory.Entry, len(entries))
+	copy(cp, entries)
+	sort.SliceStable(cp, func(i, j int) bool {
+		if cp[i].Pinned != cp[j].Pinned {
+			return cp[i].Pinned
+		}
+		return cp[i].UpdatedAt.After(cp[j].UpdatedAt)
+	})
+	mi.entries = cp
+	mi.clampCursor()
+}
+
+// Filter returns the live filter query.
+func (mi *MemoryInspector) Filter() string { return mi.filter }
+
+// SetFilter sets the live substring filter. Resets cursor to top so the user
+// always sees the first match.
+func (mi *MemoryInspector) SetFilter(q string) {
+	mi.filter = q
+	mi.cursor = 0
+}
+
+// Mode reports the current view mode (list / detail / confirm / prune).
+func (mi *MemoryInspector) Mode() inspectorMode { return mi.mode }
+
+// Editing reports whether the filter input has focus.
+func (mi *MemoryInspector) Editing() bool { return mi.editing }
+
+// Filtered returns the entries matching the live filter, in display order.
+func (mi *MemoryInspector) Filtered() []memory.Entry {
+	if mi.filter == "" {
+		return mi.entries
+	}
+	q := strings.ToLower(mi.filter)
+	out := make([]memory.Entry, 0, len(mi.entries))
+	for _, e := range mi.entries {
+		if matchesFilter(e, q) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Cursor returns the current cursor position within the filtered slice.
+func (mi *MemoryInspector) Cursor() int { return mi.cursor }
+
+// Selected returns the currently highlighted entry, or false if there is none.
+func (mi *MemoryInspector) Selected() (memory.Entry, bool) {
+	f := mi.Filtered()
+	if mi.cursor < 0 || mi.cursor >= len(f) {
+		return memory.Entry{}, false
+	}
+	return f[mi.cursor], true
+}
+
+// CursorUp / CursorDown / CursorHome / CursorEnd move the highlight within the
+// filtered slice. They are no-ops at the boundaries.
+func (mi *MemoryInspector) CursorUp() {
+	if mi.cursor > 0 {
+		mi.cursor--
+	}
+}
+
+func (mi *MemoryInspector) CursorDown() {
+	if mi.cursor < len(mi.Filtered())-1 {
+		mi.cursor++
+	}
+}
+
+func (mi *MemoryInspector) CursorHome() { mi.cursor = 0 }
+
+func (mi *MemoryInspector) CursorEnd() {
+	n := len(mi.Filtered())
+	if n == 0 {
+		mi.cursor = 0
+		return
+	}
+	mi.cursor = n - 1
+}
+
+// OpenDetail shows full content of the highlighted entry. No-op when nothing
+// is selected.
+func (mi *MemoryInspector) OpenDetail() {
+	if _, ok := mi.Selected(); !ok {
+		return
+	}
+	mi.mode = inspectorDetail
+}
+
+// CloseDetail returns to the list view.
+func (mi *MemoryInspector) CloseDetail() { mi.mode = inspectorList }
+
+// PromptDelete enters single-entry delete confirmation. No-op when nothing
+// is selected.
+func (mi *MemoryInspector) PromptDelete() {
+	if _, ok := mi.Selected(); !ok {
+		return
+	}
+	mi.mode = inspectorConfirm
+}
+
+// PromptPrune enters bulk-prune confirmation for the current filter. The
+// confirmation summarises how many non-pinned entries will be removed.
+func (mi *MemoryInspector) PromptPrune() { mi.mode = inspectorPrune }
+
+// CancelPrompt dismisses any open confirmation modal.
+func (mi *MemoryInspector) CancelPrompt() { mi.mode = inspectorList }
+
+// StartFilterEdit gives the filter input focus.
+func (mi *MemoryInspector) StartFilterEdit() {
+	mi.editing = true
+	mi.mode = inspectorList
+}
+
+// StopFilterEdit blurs the filter input.
+func (mi *MemoryInspector) StopFilterEdit() { mi.editing = false }
+
+// AppendFilter adds a single rune to the filter input — wired to keystrokes
+// when editing is true.
+func (mi *MemoryInspector) AppendFilter(r rune) {
+	mi.filter += string(r)
+	mi.cursor = 0
+}
+
+// BackspaceFilter removes the last rune from the filter (no-op when empty).
+func (mi *MemoryInspector) BackspaceFilter() {
+	if mi.filter == "" {
+		return
+	}
+	rs := []rune(mi.filter)
+	mi.filter = string(rs[:len(rs)-1])
+	mi.cursor = 0
+}
+
+// LastMessage returns the most recent action result for the footer.
+func (mi *MemoryInspector) LastMessage() string { return mi.last }
+
+// SetMessage exposes the footer message slot to callers (engine wrappers
+// surface delete / prune / pin results here).
+func (mi *MemoryInspector) SetMessage(msg string) { mi.last = msg }
+
+// PruneCandidates returns the entries that PromptPrune would actually remove
+// given the current filter. Pinned entries are excluded — used by the prune
+// confirmation prompt and tested directly.
+func (mi *MemoryInspector) PruneCandidates() []memory.Entry {
+	f := mi.Filtered()
+	out := make([]memory.Entry, 0, len(f))
+	for _, e := range f {
+		if !e.Pinned {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Render returns the full string view for the current mode. Width-aware
+// formatting is intentionally minimal — the inspector is a single-column
+// view that flows naturally inside the existing context-panel viewport.
+func (mi *MemoryInspector) Render() string {
+	switch mi.mode {
+	case inspectorDetail:
+		return mi.renderDetail()
+	case inspectorConfirm:
+		return mi.renderConfirm()
+	case inspectorPrune:
+		return mi.renderPruneConfirm()
+	default:
+		return mi.renderList()
+	}
+}
+
+func (mi *MemoryInspector) renderList() string {
+	var sb strings.Builder
+	sb.WriteString("── memory inspector ──────────\n")
+	sb.WriteString(mi.renderFilterLine() + "\n\n")
+
+	filtered := mi.Filtered()
+	if len(filtered) == 0 {
+		if len(mi.entries) == 0 {
+			sb.WriteString(" no memory entries\n")
+		} else {
+			sb.WriteString(" no entries match filter\n")
+		}
+	} else {
+		for i, e := range filtered {
+			caret := "  "
+			if i == mi.cursor {
+				caret = "> "
+			}
+			pin := " "
+			if e.Pinned {
+				pin = "📌"
+			}
+			ts := e.UpdatedAt.Format("2006-01-02 15:04")
+			sb.WriteString(fmt.Sprintf("%s%s %s [%s] %s\n", caret, pin, ts, e.Kind, truncate(e.Title, 48)))
+		}
+	}
+
+	sb.WriteString("\n" + mi.renderHelp())
+	if mi.last != "" {
+		sb.WriteString("\n " + mi.last)
+	}
+	return sb.String()
+}
+
+func (mi *MemoryInspector) renderDetail() string {
+	e, ok := mi.Selected()
+	if !ok {
+		return mi.renderList()
+	}
+	var sb strings.Builder
+	sb.WriteString("── memory entry ──────────────\n\n")
+	fmt.Fprintf(&sb, " id:      %s\n", e.ID)
+	fmt.Fprintf(&sb, " kind:    %s\n", e.Kind)
+	fmt.Fprintf(&sb, " title:   %s\n", e.Title)
+	fmt.Fprintf(&sb, " tags:    %s\n", strings.Join(e.Tags, ", "))
+	fmt.Fprintf(&sb, " created: %s\n", e.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(&sb, " updated: %s\n", e.UpdatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(&sb, " pinned:  %t\n", e.Pinned)
+	sb.WriteString("\n──── body ────\n\n")
+	sb.WriteString(strings.TrimSpace(e.Body))
+	sb.WriteString("\n\n esc: back   p: pin/unpin   d: delete\n")
+	return sb.String()
+}
+
+func (mi *MemoryInspector) renderConfirm() string {
+	e, ok := mi.Selected()
+	if !ok {
+		return mi.renderList()
+	}
+	return fmt.Sprintf(
+		"── confirm delete ────────────\n\n"+
+			" Delete this entry?\n\n"+
+			"   %s [%s]\n   %s\n\n"+
+			" y: confirm   n/esc: cancel\n",
+		e.Title, e.Kind, e.ID,
+	)
+}
+
+func (mi *MemoryInspector) renderPruneConfirm() string {
+	candidates := mi.PruneCandidates()
+	label := "all non-pinned entries"
+	if mi.filter != "" {
+		label = fmt.Sprintf("entries matching %q (non-pinned)", mi.filter)
+	}
+	return fmt.Sprintf(
+		"── confirm prune ─────────────\n\n"+
+			" Delete %d %s?\n\n"+
+			" Pinned entries are skipped.\n\n"+
+			" y: confirm   n/esc: cancel\n",
+		len(candidates), label,
+	)
+}
+
+func (mi *MemoryInspector) renderFilterLine() string {
+	cursor := ""
+	if mi.editing {
+		cursor = "▌"
+	}
+	if mi.filter == "" && !mi.editing {
+		return " filter: (none)   /: edit"
+	}
+	return fmt.Sprintf(" filter: %s%s", mi.filter, cursor)
+}
+
+func (mi *MemoryInspector) renderHelp() string {
+	if mi.editing {
+		return " enter/esc: stop editing   backspace: remove"
+	}
+	return " ↑/↓: move  enter: open  /: filter  p: pin  d: delete  P: prune  esc: close"
+}
+
+func (mi *MemoryInspector) clampCursor() {
+	n := len(mi.Filtered())
+	if n == 0 {
+		mi.cursor = 0
+		return
+	}
+	if mi.cursor < 0 {
+		mi.cursor = 0
+	}
+	if mi.cursor >= n {
+		mi.cursor = n - 1
+	}
+}
+
+// matchesFilter is the inspector's local search predicate. Mirrors the
+// FlatFileProvider's substring rules so pruning by filter has no surprises.
+func matchesFilter(e memory.Entry, qLower string) bool {
+	if strings.Contains(strings.ToLower(e.Title), qLower) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(e.Body), qLower) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(string(e.Kind)), qLower) {
+		return true
+	}
+	for _, t := range e.Tags {
+		if strings.Contains(strings.ToLower(t), qLower) {
+			return true
+		}
+	}
+	return false
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}

--- a/internal/tui/memory_inspector_input.go
+++ b/internal/tui/memory_inspector_input.go
@@ -1,0 +1,187 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jabreeflor/conduit/internal/memory"
+)
+
+// MemoryController is the small slice of engine functionality the memory
+// inspector needs. The interface keeps the TUI free of a hard dependency on
+// the core engine — tests inject a fake implementation.
+type MemoryController interface {
+	SearchMemory(ctx context.Context, query string) ([]memory.Entry, error)
+	DeleteMemory(ctx context.Context, id string) error
+	PruneMemory(ctx context.Context, query string) ([]string, error)
+	SetMemoryPinned(ctx context.Context, id string, pinned bool) error
+}
+
+// openMemoryInspector loads the latest entry list and switches the model into
+// inspector mode. Failures surface in the inspector footer; we never crash
+// the TUI just because the memory layer hiccuped.
+func (m Model) openMemoryInspector() Model {
+	if m.inspector == nil {
+		m.inspector = NewMemoryInspector()
+	}
+	m.inspectorOpen = true
+	m = m.refreshInspectorEntries("")
+	return m
+}
+
+// closeMemoryInspector hides the inspector and returns to the normal panels.
+func (m Model) closeMemoryInspector() Model {
+	m.inspectorOpen = false
+	if m.inspector != nil {
+		m.inspector.StopFilterEdit()
+		m.inspector.CancelPrompt()
+	}
+	return m
+}
+
+// refreshInspectorEntries reloads entries from the controller using query
+// (empty = all). Updates the inspector's entry list in place.
+func (m Model) refreshInspectorEntries(query string) Model {
+	if m.memoryController == nil || m.inspector == nil {
+		return m
+	}
+	entries, err := m.memoryController.SearchMemory(context.Background(), query)
+	if err != nil {
+		m.inspector.SetMessage("error: " + err.Error())
+		return m
+	}
+	m.inspector.SetEntries(entries)
+	return m
+}
+
+// handleInspectorKey routes key events while the inspector is open. Returns
+// the (possibly mutated) model and a flag indicating whether the key was
+// consumed. Anything not consumed falls through to the normal Update path.
+func (m Model) handleInspectorKey(msg tea.KeyMsg) (Model, bool) {
+	if !m.inspectorOpen || m.inspector == nil {
+		return m, false
+	}
+
+	// While the filter input has focus, most keys feed the filter directly.
+	if m.inspector.Editing() {
+		switch msg.Type {
+		case tea.KeyEsc, tea.KeyEnter:
+			m.inspector.StopFilterEdit()
+		case tea.KeyBackspace:
+			m.inspector.BackspaceFilter()
+		case tea.KeyRunes, tea.KeySpace:
+			for _, r := range msg.Runes {
+				m.inspector.AppendFilter(r)
+			}
+		}
+		return m, true
+	}
+
+	// Confirmation modals: y / n / esc.
+	switch m.inspector.Mode() {
+	case inspectorConfirm:
+		switch msg.String() {
+		case "y", "Y":
+			m = m.confirmDelete()
+		case "n", "N", "esc":
+			m.inspector.CancelPrompt()
+		}
+		return m, true
+	case inspectorPrune:
+		switch msg.String() {
+		case "y", "Y":
+			m = m.confirmPrune()
+		case "n", "N", "esc":
+			m.inspector.CancelPrompt()
+		}
+		return m, true
+	case inspectorDetail:
+		switch msg.String() {
+		case "esc":
+			m.inspector.CloseDetail()
+		case "p":
+			m = m.togglePinSelected()
+		case "d":
+			m.inspector.PromptDelete()
+		}
+		return m, true
+	}
+
+	// List mode keystrokes.
+	switch msg.String() {
+	case "esc":
+		m = m.closeMemoryInspector()
+	case "up", "k":
+		m.inspector.CursorUp()
+	case "down", "j":
+		m.inspector.CursorDown()
+	case "home", "g":
+		m.inspector.CursorHome()
+	case "end", "G":
+		m.inspector.CursorEnd()
+	case "/":
+		m.inspector.StartFilterEdit()
+	case "enter":
+		m.inspector.OpenDetail()
+	case "p":
+		m = m.togglePinSelected()
+	case "d":
+		m.inspector.PromptDelete()
+	case "P":
+		m.inspector.PromptPrune()
+	case "r":
+		m = m.refreshInspectorEntries("")
+		m.inspector.SetMessage("reloaded")
+	}
+	return m, true
+}
+
+func (m Model) confirmDelete() Model {
+	entry, ok := m.inspector.Selected()
+	if !ok || m.memoryController == nil {
+		m.inspector.CancelPrompt()
+		return m
+	}
+	if err := m.memoryController.DeleteMemory(context.Background(), entry.ID); err != nil {
+		m.inspector.SetMessage("delete failed: " + err.Error())
+	} else {
+		m.inspector.SetMessage(fmt.Sprintf("deleted %s", truncate(entry.Title, 40)))
+	}
+	m.inspector.CancelPrompt()
+	return m.refreshInspectorEntries("")
+}
+
+func (m Model) confirmPrune() Model {
+	if m.memoryController == nil {
+		m.inspector.CancelPrompt()
+		return m
+	}
+	removed, err := m.memoryController.PruneMemory(context.Background(), m.inspector.Filter())
+	if err != nil {
+		m.inspector.SetMessage("prune failed: " + err.Error())
+	} else {
+		m.inspector.SetMessage(fmt.Sprintf("pruned %d entries", len(removed)))
+	}
+	m.inspector.CancelPrompt()
+	return m.refreshInspectorEntries("")
+}
+
+func (m Model) togglePinSelected() Model {
+	entry, ok := m.inspector.Selected()
+	if !ok || m.memoryController == nil {
+		return m
+	}
+	want := !entry.Pinned
+	if err := m.memoryController.SetMemoryPinned(context.Background(), entry.ID, want); err != nil {
+		m.inspector.SetMessage("pin failed: " + err.Error())
+		return m
+	}
+	if want {
+		m.inspector.SetMessage("pinned: " + truncate(entry.Title, 40))
+	} else {
+		m.inspector.SetMessage("unpinned: " + truncate(entry.Title, 40))
+	}
+	return m.refreshInspectorEntries("")
+}

--- a/internal/tui/memory_inspector_test.go
+++ b/internal/tui/memory_inspector_test.go
@@ -1,0 +1,256 @@
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/memory"
+)
+
+func sampleEntries() []memory.Entry {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	return []memory.Entry{
+		{ID: "id-fact-1", Kind: memory.KindFact, Title: "Likes dark theme",
+			Body: "User prefers dark UI everywhere.", Tags: []string{"ui"},
+			CreatedAt: now, UpdatedAt: now},
+		{ID: "id-decision-1", Kind: memory.KindDecision, Title: "Use FlatFileProvider",
+			Body: "Spotlight indexes ~/.conduit/memory/.", Tags: []string{"memory", "design"},
+			CreatedAt: now.Add(time.Hour), UpdatedAt: now.Add(time.Hour),
+			Pinned: true},
+		{ID: "id-pref-1", Kind: memory.KindPreference, Title: "Voice off by default",
+			Body: "TTS disabled until invoked.", Tags: []string{"voice"},
+			CreatedAt: now.Add(2 * time.Hour), UpdatedAt: now.Add(2 * time.Hour)},
+	}
+}
+
+func TestInspectorEmptyState(t *testing.T) {
+	mi := NewMemoryInspector()
+	out := mi.Render()
+	if !strings.Contains(out, "no memory entries") {
+		t.Fatalf("empty inspector should render placeholder, got:\n%s", out)
+	}
+}
+
+func TestInspectorListShowsEntries(t *testing.T) {
+	mi := NewMemoryInspector()
+	mi.SetEntries(sampleEntries())
+
+	out := mi.Render()
+	for _, want := range []string{"Likes dark theme", "Use FlatFileProvider", "Voice off by default"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("inspector list missing %q in:\n%s", want, out)
+		}
+	}
+	// pinned glyph should appear at least once
+	if !strings.Contains(out, "📌") {
+		t.Errorf("inspector list missing pinned glyph in:\n%s", out)
+	}
+}
+
+func TestInspectorPinnedSurfaceFirst(t *testing.T) {
+	mi := NewMemoryInspector()
+	mi.SetEntries(sampleEntries())
+
+	got := mi.Filtered()
+	if len(got) == 0 || !got[0].Pinned {
+		t.Fatalf("expected first filtered entry to be pinned, got %+v", got)
+	}
+}
+
+func TestInspectorFilterMatchesTitleBodyTagsKind(t *testing.T) {
+	mi := NewMemoryInspector()
+	mi.SetEntries(sampleEntries())
+
+	cases := map[string]int{
+		"dark":      1, // title
+		"Spotlight": 1, // body
+		"voice":     1, // tag
+		"decision":  1, // kind
+		"nope-zzz":  0,
+		"":          3,
+	}
+	for q, want := range cases {
+		mi.SetFilter(q)
+		got := len(mi.Filtered())
+		if got != want {
+			t.Errorf("filter %q: got %d entries, want %d", q, got, want)
+		}
+	}
+}
+
+func TestInspectorPruneCandidatesExcludePinned(t *testing.T) {
+	mi := NewMemoryInspector()
+	mi.SetEntries(sampleEntries())
+	mi.SetFilter("") // include all
+	candidates := mi.PruneCandidates()
+	for _, e := range candidates {
+		if e.Pinned {
+			t.Fatalf("PruneCandidates returned pinned entry %s", e.ID)
+		}
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("expected 2 prune candidates (sample has 1 pinned of 3), got %d", len(candidates))
+	}
+}
+
+func TestInspectorCursorBoundsClamped(t *testing.T) {
+	mi := NewMemoryInspector()
+	mi.SetEntries(sampleEntries())
+
+	mi.CursorUp() // already at 0
+	if mi.Cursor() != 0 {
+		t.Fatalf("CursorUp at top should be no-op, cursor=%d", mi.Cursor())
+	}
+	mi.CursorEnd()
+	if mi.Cursor() != len(mi.Filtered())-1 {
+		t.Fatalf("CursorEnd should land on last entry, got %d", mi.Cursor())
+	}
+	mi.CursorDown()
+	if mi.Cursor() != len(mi.Filtered())-1 {
+		t.Fatalf("CursorDown at end should be no-op, got %d", mi.Cursor())
+	}
+}
+
+func TestInspectorDetailModeRendersBody(t *testing.T) {
+	mi := NewMemoryInspector()
+	mi.SetEntries(sampleEntries())
+	mi.OpenDetail()
+
+	if mi.Mode() != inspectorDetail {
+		t.Fatalf("OpenDetail should switch to detail mode, got %v", mi.Mode())
+	}
+	out := mi.Render()
+	for _, want := range []string{"id:", "kind:", "tags:", "body"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("detail view missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// ── memory controller integration ────────────────────────────────────────────
+
+// fakeController is an in-memory MemoryController for testing the inspector
+// against the same surface the real engine implements.
+type fakeController struct {
+	entries map[string]memory.Entry
+}
+
+func newFakeController(seed []memory.Entry) *fakeController {
+	c := &fakeController{entries: make(map[string]memory.Entry)}
+	for _, e := range seed {
+		c.entries[e.ID] = e
+	}
+	return c
+}
+
+func (c *fakeController) SearchMemory(_ context.Context, q string) ([]memory.Entry, error) {
+	out := make([]memory.Entry, 0, len(c.entries))
+	for _, e := range c.entries {
+		if q == "" || matchesFilter(e, strings.ToLower(q)) {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+func (c *fakeController) DeleteMemory(_ context.Context, id string) error {
+	delete(c.entries, id)
+	return nil
+}
+
+func (c *fakeController) PruneMemory(_ context.Context, q string) ([]string, error) {
+	var removed []string
+	ql := strings.ToLower(q)
+	for id, e := range c.entries {
+		if e.Pinned {
+			continue
+		}
+		if q != "" && !matchesFilter(e, ql) {
+			continue
+		}
+		delete(c.entries, id)
+		removed = append(removed, id)
+	}
+	return removed, nil
+}
+
+func (c *fakeController) SetMemoryPinned(_ context.Context, id string, pinned bool) error {
+	if e, ok := c.entries[id]; ok {
+		e.Pinned = pinned
+		c.entries[id] = e
+	}
+	return nil
+}
+
+func TestInspectorIntegration_DeleteAndPrune(t *testing.T) {
+	ctrl := newFakeController(sampleEntries())
+	m := newModel("test", testSetupSnapshot(), nil).WithMemoryController(ctrl)
+	m = m.openMemoryInspector()
+
+	if !m.inspectorOpen {
+		t.Fatal("inspector should be open after openMemoryInspector")
+	}
+	if got := len(m.inspector.Filtered()); got != 3 {
+		t.Fatalf("expected 3 entries loaded, got %d", got)
+	}
+
+	// Move cursor off the pinned entry then delete the highlighted entry.
+	m.inspector.CursorDown()
+	target, _ := m.inspector.Selected()
+	if target.Pinned {
+		t.Fatalf("test setup error: expected unpinned entry under cursor, got %s", target.Title)
+	}
+	m.inspector.PromptDelete()
+	m = m.confirmDelete()
+	if _, ok := ctrl.entries[target.ID]; ok {
+		t.Fatalf("delete didn't remove %s from controller", target.ID)
+	}
+
+	// Prune everything (filter empty) — pinned must survive.
+	m.inspector.SetFilter("")
+	m = m.confirmPrune()
+
+	leftPinned := false
+	for _, e := range ctrl.entries {
+		if e.Pinned {
+			leftPinned = true
+		} else {
+			t.Fatalf("prune should have removed unpinned entry %s", e.ID)
+		}
+	}
+	if !leftPinned {
+		t.Fatal("prune removed the pinned entry; manual override broken")
+	}
+}
+
+func TestInspectorIntegration_TogglePin(t *testing.T) {
+	ctrl := newFakeController(sampleEntries())
+	m := newModel("test", testSetupSnapshot(), nil).WithMemoryController(ctrl)
+	m = m.openMemoryInspector()
+
+	// Cursor starts on the pinned entry — toggling unpins it.
+	first, _ := m.inspector.Selected()
+	if !first.Pinned {
+		t.Fatalf("expected first entry pinned, got %+v", first)
+	}
+	m = m.togglePinSelected()
+	if ctrl.entries[first.ID].Pinned {
+		t.Fatal("toggle did not unpin entry")
+	}
+
+	// Toggle again to re-pin.
+	// Cursor index may now point at a different entry because re-sort moved
+	// pinned entries around — re-find by ID to remain robust.
+	for i, e := range m.inspector.Filtered() {
+		if e.ID == first.ID {
+			m.inspector.cursor = i
+			break
+		}
+	}
+	m = m.togglePinSelected()
+	if !ctrl.entries[first.ID].Pinned {
+		t.Fatal("toggle did not re-pin entry")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -74,12 +74,13 @@ type message struct {
 // ── key bindings ─────────────────────────────────────────────────────────────
 
 type keyMap struct {
-	TogglePanel key.Binding
-	Quit        key.Binding
-	Submit      key.Binding
-	ExpandTool  key.Binding
-	SetupLocal  key.Binding
-	ExternalAPI key.Binding
+	TogglePanel     key.Binding
+	Quit            key.Binding
+	Submit          key.Binding
+	ExpandTool      key.Binding
+	SetupLocal      key.Binding
+	ExternalAPI     key.Binding
+	MemoryInspector key.Binding
 }
 
 var keys = keyMap{
@@ -107,27 +108,34 @@ var keys = keyMap{
 		key.WithKeys("a"),
 		key.WithHelp("a", "external api"),
 	),
+	MemoryInspector: key.NewBinding(
+		key.WithKeys("ctrl+m"),
+		key.WithHelp("ctrl+m", "memory inspector"),
+	),
 }
 
 // ── model ─────────────────────────────────────────────────────────────────────
 
 // Model is the Bubble Tea application state for the three-panel layout.
 type Model struct {
-	width        int
-	height       int
-	conversation viewport.Model
-	contextPanel viewport.Model
-	input        textarea.Model
-	messages     []message
-	toolCalls    []toolCall
-	showContext  bool
-	sessionCost  float64
-	activeModel  string
-	setup        contracts.FirstRunSetupSnapshot
-	setupLocalAI func() (contracts.FirstRunSetupSnapshot, error)
-	streaming    bool
-	streamBuffer string
-	tickCount    int
+	width            int
+	height           int
+	conversation     viewport.Model
+	contextPanel     viewport.Model
+	input            textarea.Model
+	messages         []message
+	toolCalls        []toolCall
+	showContext      bool
+	sessionCost      float64
+	activeModel      string
+	setup            contracts.FirstRunSetupSnapshot
+	setupLocalAI     func() (contracts.FirstRunSetupSnapshot, error)
+	streaming        bool
+	streamBuffer     string
+	tickCount        int
+	inspector        *MemoryInspector
+	inspectorOpen    bool
+	memoryController MemoryController // backing engine for inspector actions; may be nil in tests
 }
 
 func newModel(activeModel string, setup contracts.FirstRunSetupSnapshot, setupLocalAI func() (contracts.FirstRunSetupSnapshot, error)) Model {
@@ -145,10 +153,19 @@ func newModel(activeModel string, setup contracts.FirstRunSetupSnapshot, setupLo
 		activeModel:  activeModel,
 		setup:        setup,
 		setupLocalAI: setupLocalAI,
+		inspector:    NewMemoryInspector(),
 		messages: []message{
 			{role: roleAgent, text: "Welcome to Conduit."},
 		},
 	}
+}
+
+// WithMemoryController attaches the engine adapter that backs the memory
+// inspector. Returning the model keeps newModel pure for tests that don't
+// need a live provider.
+func (m Model) WithMemoryController(c MemoryController) Model {
+	m.memoryController = c
+	return m
 }
 
 func (m Model) Init() tea.Cmd {
@@ -174,9 +191,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m = m.recalculateLayout()
 
 	case tea.KeyMsg:
+		// Memory inspector takes precedence over normal input when open so
+		// its scoped key bindings (delete, pin, filter) do not collide with
+		// the chat textarea.
+		if m.inspectorOpen {
+			var consumed bool
+			m, consumed = m.handleInspectorKey(msg)
+			if consumed {
+				return m, nil
+			}
+		}
 		switch {
 		case key.Matches(msg, keys.Quit):
+			if m.inspectorOpen {
+				m = m.closeMemoryInspector()
+				return m, nil
+			}
 			return m, tea.Quit
+		case key.Matches(msg, keys.MemoryInspector):
+			m = m.openMemoryInspector()
+			return m, nil
 		case key.Matches(msg, keys.TogglePanel):
 			m.showContext = !m.showContext
 			m = m.recalculateLayout()

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -136,6 +136,14 @@ func (m Model) View() string {
 	}
 
 	statusBar := m.renderStatusBar()
+
+	// When the memory inspector is open it takes over the main row entirely;
+	// the input row is hidden so its keystrokes don't bleed into the chat.
+	if m.inspectorOpen && m.inspector != nil {
+		body := styleActivePanel.Render(m.inspector.Render())
+		return lipgloss.JoinVertical(lipgloss.Left, statusBar, body)
+	}
+
 	mainRow := m.renderMainRow()
 	inputRow := m.renderInputRow()
 
@@ -161,7 +169,7 @@ func (m Model) renderMainRow() string {
 }
 
 func (m Model) renderInputRow() string {
-	help := " enter:send  ctrl+p:panel  x:expand  esc:quit"
+	help := " enter:send  ctrl+p:panel  ctrl+m:memory  x:expand  esc:quit"
 	if m.setup.Phase == "welcome" {
 		help = " l:local setup  a:external api  enter:send  ctrl+p:panel  esc:quit"
 	}


### PR DESCRIPTION
## Summary

- Adds in-TUI memory inspector: browse, live-filter, drill-in, delete, bulk-prune, and pin/unpin entries from `~/.conduit/memory/` (PRD §19 Phase 2 — "Memory inspector in TUI", "Memory pruning / manual override").
- Extends `memory.Provider` with `Delete` and `Prune`, adds a `Pinned bool` flag on `Entry` (round-trips through YAML frontmatter only when true so existing files stay byte-identical), and wires `Engine.{Delete,Prune,SetMemoryPinned}Memory` with session-log entries for each action.
- Inspector opens from the main TUI with `ctrl+m`. Pruning explicitly skips pinned entries; single-entry delete is the explicit user-driven path and bypasses the pin guard. Pinned entries surface at the top of the list so they're easy to find.
- New code is scoped to dedicated files (`internal/tui/memory_inspector*.go`) — only the smallest possible diff lands in shared `model.go` / `view.go` to keep merge surface with #13 (configurable keybindings) minimal.

## Design notes

- **Manual override = `Pinned bool` on `memory.Entry`**, persisted as `pinned: true` in the existing markdown frontmatter (omitted when false). `Provider.Prune` is the canonical pruner and treats `Pinned` as a hard skip; any future automatic compactor must do the same.
- The inspector itself (`MemoryInspector`) is Bubble-Tea-agnostic — a pure state machine — so its filter, cursor, and prune-candidate logic are unit-tested directly without spinning up a TUI program.
- The Bubble Tea wrapper consumes inspector keystrokes only when open, otherwise falls through to the existing chat input. The Quit key closes the inspector first instead of exiting.
- A `MemoryController` interface in the TUI package decouples the inspector from `core.Engine`, giving tests a small in-memory fake.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `make lint` — gofmt + go vet clean
- [x] Inspector unit tests: filter substring/tag/kind matching, cursor clamp, pinned-first ordering, prune candidate exclusion of pinned, detail-mode rendering
- [x] Inspector integration tests with a fake `MemoryController`: delete, bulk prune (pinned survives), pin toggle round-trip
- [x] FlatFileProvider tests: Delete idempotency, Prune skip-pinned, Prune-by-query, pinned flag round-trips through YAML frontmatter
- [x] Engine tests: `DeleteMemory` / `PruneMemory` / `SetMemoryPinned` with the real FlatFileProvider on a temp dir

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)