### PR TITLE
feat: session JSONL tree (fork/replay/inspect)

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jabreeflor/conduit/internal/localmodel"
 	"github.com/jabreeflor/conduit/internal/mcp"
 	"github.com/jabreeflor/conduit/internal/router"
+	"github.com/jabreeflor/conduit/internal/sessions"
 	"github.com/jabreeflor/conduit/internal/skills"
 	"github.com/jabreeflor/conduit/internal/tools"
 	"github.com/jabreeflor/conduit/internal/tui"
@@ -87,6 +88,12 @@ func main() {
 		case "code":
 			if err := runCodeCLI(context.Background(), os.Args[2:], os.Stdin, os.Stdout, os.Stderr); err != nil {
 				fmt.Fprintf(os.Stderr, "conduit code: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		case "sessions":
+			if err := runSessionsCLI(os.Args[2:], os.Stdout, os.Stderr); err != nil {
+				fmt.Fprintf(os.Stderr, "conduit sessions: %v\n", err)
 				os.Exit(1)
 			}
 			return
@@ -388,4 +395,24 @@ func truncate(s string, max int) string {
 		return s[:max]
 	}
 	return s[:max-1] + "…"
+}
+
+// runSessionsCLI dispatches `conduit sessions <verb>` to the same
+// dispatcher the TUI slash commands use, so behaviour stays consistent
+// across surfaces. Replay is intentionally disabled at the CLI for now —
+// no Responder is injected here because the live provider client lands
+// in a follow-up; users who want CLI replay should use `conduit eval
+// replay`, which already supports it.
+func runSessionsCLI(args []string, stdout, stderr *os.File) error {
+	store, err := sessions.NewStore("")
+	if err != nil {
+		return err
+	}
+	d := &sessions.Dispatcher{Store: store}
+	res, err := d.Dispatch(args)
+	if err != nil {
+		return err
+	}
+	sessions.WriteResult(stdout, res)
+	return nil
 }

--- a/internal/sessions/cmd.go
+++ b/internal/sessions/cmd.go
@@ -1,0 +1,211 @@
+package sessions
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+// Dispatcher executes /sessions slash commands against a Store. The
+// dispatcher is intentionally surface-agnostic: it returns text the
+// caller writes to its own output (TUI, CLI, GUI log) and an optional
+// LoadID the surface should switch into when the user requested a load.
+type Dispatcher struct {
+	Store     *Store
+	Responder ReplayResponder // injected by surfaces; nil disables /sessions replay.
+}
+
+// Result is the structured outcome of a slash command. Output is the
+// human-readable text the surface should render. LoadSessionID is set
+// when the user asked to switch to a different session (via load,
+// fork, or replay).
+type Result struct {
+	Output        string
+	LoadSessionID string
+}
+
+// Dispatch parses the args (everything after `/sessions `) and routes
+// to the right verb. The command string is split on whitespace; quoted
+// arguments are not supported because none of the verbs need them.
+func (d *Dispatcher) Dispatch(args []string) (Result, error) {
+	if d == nil || d.Store == nil {
+		return Result{}, errors.New("sessions: dispatcher not configured")
+	}
+	if len(args) == 0 {
+		return Result{Output: helpText()}, nil
+	}
+	switch args[0] {
+	case "list":
+		return d.list()
+	case "fork":
+		return d.fork(args[1:])
+	case "replay":
+		return d.replay(args[1:])
+	case "load":
+		return d.load(args[1:])
+	case "help", "-h", "--help":
+		return Result{Output: helpText()}, nil
+	default:
+		return Result{}, fmt.Errorf("unknown /sessions subcommand %q; try: list, fork, replay, load", args[0])
+	}
+}
+
+// DispatchLine is a convenience wrapper that accepts the raw input line
+// (with or without the leading "/sessions" prefix) and splits it into
+// args before dispatching.
+func (d *Dispatcher) DispatchLine(line string) (Result, error) {
+	line = strings.TrimSpace(line)
+	line = strings.TrimPrefix(line, "/sessions")
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return d.Dispatch(nil)
+	}
+	return d.Dispatch(strings.Fields(line))
+}
+
+// WriteResult is a small helper that writes r.Output followed by a
+// trailing newline when the writer is non-nil and r has output to write.
+func WriteResult(w io.Writer, r Result) {
+	if w == nil || r.Output == "" {
+		return
+	}
+	out := r.Output
+	if !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	io.WriteString(w, out)
+}
+
+func helpText() string {
+	return strings.Join([]string{
+		"/sessions list                        list known sessions",
+		"/sessions fork <turn-id>              fork a new session from <turn-id>",
+		"/sessions replay <turn-id> [--model M] re-issue assistant turn from <turn-id>",
+		"/sessions load <session-id>           load <session-id> in the current surface",
+	}, "\n")
+}
+
+func (d *Dispatcher) list() (Result, error) {
+	infos, err := d.Store.List()
+	if err != nil {
+		return Result{}, err
+	}
+	if len(infos) == 0 {
+		return Result{Output: "no sessions found in " + d.Store.Dir()}, nil
+	}
+	var b strings.Builder
+	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tTURNS\tFORKED FROM\tUPDATED\tTITLE")
+	for _, info := range infos {
+		forked := info.ForkParentID
+		if forked == "" {
+			forked = "-"
+		}
+		updated := "-"
+		if !info.UpdatedAt.IsZero() {
+			updated = info.UpdatedAt.Format("2006-01-02 15:04")
+		}
+		fmt.Fprintf(tw, "%s\t%d\t%s\t%s\t%s\n", info.ID, info.TurnCount, forked, updated, info.Title)
+	}
+	tw.Flush()
+	return Result{Output: strings.TrimRight(b.String(), "\n")}, nil
+}
+
+func (d *Dispatcher) fork(args []string) (Result, error) {
+	if len(args) < 1 {
+		return Result{}, errors.New("usage: /sessions fork <turn-id>")
+	}
+	turnID := args[0]
+	parentSess, _, err := d.Store.FindTurn(turnID)
+	if err != nil {
+		return Result{}, err
+	}
+	newSess, err := d.Store.Fork(parentSess.ID, turnID)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Output:        fmt.Sprintf("forked %s from turn %s -> new session %s", parentSess.ID, turnID, newSess.ID),
+		LoadSessionID: newSess.ID,
+	}, nil
+}
+
+func (d *Dispatcher) replay(args []string) (Result, error) {
+	if len(args) < 1 {
+		return Result{}, errors.New("usage: /sessions replay <turn-id> [--model M] [--key=val...]")
+	}
+	turnID := args[0]
+	model, params, err := parseReplayFlags(args[1:])
+	if err != nil {
+		return Result{}, err
+	}
+	if d.Responder == nil {
+		return Result{}, errors.New("sessions: replay disabled (no Responder injected)")
+	}
+	parentSess, _, err := d.Store.FindTurn(turnID)
+	if err != nil {
+		return Result{}, err
+	}
+	newSess, newTurn, err := d.Store.Replay(parentSess.ID, turnID, ReplayOptions{
+		Model:     model,
+		Params:    params,
+		Responder: d.Responder,
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Output: fmt.Sprintf("replayed %s from turn %s with model %q -> session %s, new turn %s",
+			parentSess.ID, turnID, model, newSess.ID, newTurn.ID),
+		LoadSessionID: newSess.ID,
+	}, nil
+}
+
+func (d *Dispatcher) load(args []string) (Result, error) {
+	if len(args) < 1 {
+		return Result{}, errors.New("usage: /sessions load <session-id>")
+	}
+	id := args[0]
+	sess, err := d.Store.Load(id)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Output:        fmt.Sprintf("loaded session %s (%d turns)", sess.ID, len(sess.Turns)),
+		LoadSessionID: sess.ID,
+	}, nil
+}
+
+func parseReplayFlags(args []string) (model string, params map[string]string, err error) {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--model":
+			if i+1 >= len(args) {
+				return "", nil, errors.New("--model requires a value")
+			}
+			i++
+			model = args[i]
+		case strings.HasPrefix(a, "--model="):
+			model = strings.TrimPrefix(a, "--model=")
+		case strings.HasPrefix(a, "--"):
+			// Generic --key=value passthrough so callers can override
+			// arbitrary inference parameters (temperature=0.2, etc.)
+			// without us knowing the schema.
+			body := strings.TrimPrefix(a, "--")
+			eq := strings.IndexByte(body, '=')
+			if eq < 0 {
+				return "", nil, fmt.Errorf("flag %q must be --key=value", a)
+			}
+			if params == nil {
+				params = map[string]string{}
+			}
+			params[body[:eq]] = body[eq+1:]
+		default:
+			return "", nil, fmt.Errorf("unexpected positional argument %q", a)
+		}
+	}
+	return model, params, nil
+}

--- a/internal/sessions/cmd_test.go
+++ b/internal/sessions/cmd_test.go
@@ -1,0 +1,112 @@
+package sessions
+
+import (
+	"strings"
+	"testing"
+)
+
+func newDispatcherWithSession(t *testing.T) (*Dispatcher, *Session, Turn) {
+	t.Helper()
+	store := newTestStore(t)
+	sess, _ := store.Create()
+	a, _ := store.Append(sess, Turn{Role: "user", Content: "hello"})
+	store.Append(sess, Turn{Role: "assistant", Content: "world", ParentID: a.ID})
+	return &Dispatcher{Store: store, Responder: &stubResponder{out: "stub"}}, sess, a
+}
+
+func TestDispatchHelpDefault(t *testing.T) {
+	d, _, _ := newDispatcherWithSession(t)
+	res, err := d.Dispatch(nil)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if !strings.Contains(res.Output, "/sessions list") {
+		t.Errorf("help missing list verb: %q", res.Output)
+	}
+}
+
+func TestDispatchListIncludesSession(t *testing.T) {
+	d, sess, _ := newDispatcherWithSession(t)
+	res, err := d.Dispatch([]string{"list"})
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if !strings.Contains(res.Output, sess.ID) {
+		t.Errorf("list output missing session id %q: %q", sess.ID, res.Output)
+	}
+}
+
+func TestDispatchForkProducesNewSession(t *testing.T) {
+	d, sess, a := newDispatcherWithSession(t)
+	res, err := d.Dispatch([]string{"fork", a.ID})
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if res.LoadSessionID == "" {
+		t.Error("fork should set LoadSessionID for the surface to switch to")
+	}
+	if res.LoadSessionID == sess.ID {
+		t.Error("fork must point at a new session id")
+	}
+	if !strings.Contains(res.Output, "forked") {
+		t.Errorf("fork output should describe what happened: %q", res.Output)
+	}
+}
+
+func TestDispatchReplayUsesResponderAndModelOverride(t *testing.T) {
+	d, _, a := newDispatcherWithSession(t)
+	res, err := d.Dispatch([]string{"replay", a.ID, "--model", "claude-opus-4-6", "--temperature=0.2"})
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if res.LoadSessionID == "" {
+		t.Error("replay should set LoadSessionID")
+	}
+	if !strings.Contains(res.Output, "claude-opus-4-6") {
+		t.Errorf("replay output should mention chosen model: %q", res.Output)
+	}
+}
+
+func TestDispatchReplayWithoutResponderErrors(t *testing.T) {
+	d, _, a := newDispatcherWithSession(t)
+	d.Responder = nil
+	if _, err := d.Dispatch([]string{"replay", a.ID, "--model", "x"}); err == nil {
+		t.Fatal("expected error when Responder is nil")
+	}
+}
+
+func TestDispatchLoadSwitchesSession(t *testing.T) {
+	d, sess, _ := newDispatcherWithSession(t)
+	res, err := d.Dispatch([]string{"load", sess.ID})
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if res.LoadSessionID != sess.ID {
+		t.Errorf("LoadSessionID: got %q want %q", res.LoadSessionID, sess.ID)
+	}
+}
+
+func TestDispatchUnknownVerbErrors(t *testing.T) {
+	d, _, _ := newDispatcherWithSession(t)
+	if _, err := d.Dispatch([]string{"explode"}); err == nil {
+		t.Fatal("expected error for unknown verb")
+	}
+}
+
+func TestDispatchLineStripsPrefix(t *testing.T) {
+	d, sess, _ := newDispatcherWithSession(t)
+	res, err := d.DispatchLine("/sessions load " + sess.ID)
+	if err != nil {
+		t.Fatalf("DispatchLine: %v", err)
+	}
+	if res.LoadSessionID != sess.ID {
+		t.Errorf("LoadSessionID: got %q want %q", res.LoadSessionID, sess.ID)
+	}
+}
+
+func TestDispatchForkUnknownTurnErrors(t *testing.T) {
+	d, _, _ := newDispatcherWithSession(t)
+	if _, err := d.Dispatch([]string{"fork", "no-such-turn"}); err == nil {
+		t.Fatal("expected error for unknown turn id")
+	}
+}

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -1,0 +1,442 @@
+// Package sessions persists Conduit conversation sessions as JSONL files
+// with parent-child links between turns, enabling Git-for-conversations
+// semantics: fork from any turn, replay from any checkpoint, and browse
+// the resulting tree in any surface.
+//
+// Storage layout:
+//
+//	~/.conduit/sessions/
+//	  <session-id>.jsonl   # one Turn per line; first line is the root meta turn.
+//
+// Every Turn carries a stable ID and an optional ParentID. A nil ParentID
+// indicates the root of a session. Forks create a new session whose root
+// turn copies the source turn's ID into its ParentID; this preserves the
+// fork link across files so the tree can be reconstructed by walking the
+// directory and following ParentID across sessions.
+package sessions
+
+import (
+	"bufio"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// defaultSubdir matches PRD §6.13 layout (~/.conduit/sessions/).
+	defaultSubdir = "sessions"
+	dirPerm       = 0o700
+	filePerm      = 0o600
+)
+
+// Turn is one entry persisted to a session JSONL file. The schema is
+// intentionally close to PRD §6.13: {id, parentId, role, content,
+// timestamp, metadata}, with extra fields (Model, Params) so replays can
+// reconstruct the exact inference parameters.
+type Turn struct {
+	ID        string            `json:"id"`
+	ParentID  string            `json:"parent_id,omitempty"`
+	SessionID string            `json:"session_id"`
+	Role      string            `json:"role"`
+	Content   string            `json:"content"`
+	Model     string            `json:"model,omitempty"`
+	Params    map[string]string `json:"params,omitempty"`
+	At        time.Time         `json:"timestamp"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+}
+
+// Session is one JSONL file: a logical conversation thread. The root turn
+// always has empty ParentID (when the session is itself a root) or carries
+// the source turn's ID (when this session was created via Fork).
+type Session struct {
+	ID        string
+	Path      string
+	StartedAt time.Time
+	// ForkParentID is set when this session was forked from another
+	// session's turn; empty for natural root sessions.
+	ForkParentID string
+	Turns        []Turn
+
+	mu sync.Mutex
+}
+
+// Store is the on-disk repository of all sessions. A single Store instance
+// can be safely reused; per-session writes are serialized via the Session
+// mutex.
+type Store struct {
+	dir string
+}
+
+// NewStore opens (or creates) the sessions directory under the given root.
+// Pass an empty rootDir to use ~/.conduit/sessions.
+func NewStore(rootDir string) (*Store, error) {
+	if rootDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("sessions: resolve home: %w", err)
+		}
+		rootDir = filepath.Join(home, ".conduit", defaultSubdir)
+	}
+	if err := os.MkdirAll(rootDir, dirPerm); err != nil {
+		return nil, fmt.Errorf("sessions: create dir: %w", err)
+	}
+	return &Store{dir: rootDir}, nil
+}
+
+// Dir returns the on-disk directory backing the store.
+func (s *Store) Dir() string { return s.dir }
+
+// Create starts a brand-new session. The session has no turns and no
+// fork parent.
+func (s *Store) Create() (*Session, error) {
+	id, err := newSessionID()
+	if err != nil {
+		return nil, err
+	}
+	return &Session{
+		ID:        id,
+		Path:      filepath.Join(s.dir, id+".jsonl"),
+		StartedAt: time.Now().UTC(),
+	}, nil
+}
+
+// Append persists turn to disk and returns the assigned turn id. If
+// turn.ID is empty a new id is generated. If turn.At is zero, time.Now is
+// used. The on-disk file is created lazily so an aborted session never
+// leaves a zero-byte journal.
+func (s *Store) Append(sess *Session, turn Turn) (Turn, error) {
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+
+	if turn.At.IsZero() {
+		turn.At = time.Now().UTC()
+	}
+	if turn.ID == "" {
+		id, err := newTurnID(turn.At)
+		if err != nil {
+			return Turn{}, err
+		}
+		turn.ID = id
+	}
+	turn.SessionID = sess.ID
+
+	line, err := json.Marshal(turn)
+	if err != nil {
+		return Turn{}, fmt.Errorf("sessions: marshal turn: %w", err)
+	}
+	line = append(line, '\n')
+
+	f, err := os.OpenFile(sess.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, filePerm)
+	if err != nil {
+		return Turn{}, fmt.Errorf("sessions: open journal: %w", err)
+	}
+	if _, err := f.Write(line); err != nil {
+		f.Close()
+		return Turn{}, fmt.Errorf("sessions: write turn: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return Turn{}, fmt.Errorf("sessions: close journal: %w", err)
+	}
+
+	sess.Turns = append(sess.Turns, turn)
+	return turn, nil
+}
+
+// Load reads a previously written session JSONL into memory. Returns
+// os.ErrNotExist (wrapped) when the session file does not exist.
+func (s *Store) Load(id string) (*Session, error) {
+	if id == "" {
+		return nil, errors.New("sessions: load requires non-empty id")
+	}
+	path := filepath.Join(s.dir, id+".jsonl")
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("sessions: open %s: %w", id, err)
+	}
+	defer f.Close()
+
+	sess := &Session{ID: id, Path: path}
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var t Turn
+		if err := json.Unmarshal([]byte(line), &t); err != nil {
+			return nil, fmt.Errorf("sessions: decode turn: %w", err)
+		}
+		if sess.StartedAt.IsZero() || t.At.Before(sess.StartedAt) {
+			sess.StartedAt = t.At
+		}
+		// The first turn is treated as the session root for fork tracking;
+		// its ParentID, when set, points at the source turn we forked from.
+		if len(sess.Turns) == 0 && t.ParentID != "" {
+			sess.ForkParentID = t.ParentID
+		}
+		sess.Turns = append(sess.Turns, t)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("sessions: scan journal: %w", err)
+	}
+	return sess, nil
+}
+
+// SessionInfo is the lightweight summary returned by List for slash
+// commands and the TUI tree browser. It does not load every turn into
+// memory; it just stats the file and reads the first/last turn lazily.
+type SessionInfo struct {
+	ID           string
+	Path         string
+	StartedAt    time.Time
+	UpdatedAt    time.Time
+	TurnCount    int
+	ForkParentID string
+	Title        string // first user content snippet, for human-readable lists
+}
+
+// List returns one SessionInfo per session file in the store directory,
+// sorted by UpdatedAt descending (most recent first).
+func (s *Store) List() ([]SessionInfo, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("sessions: read dir: %w", err)
+	}
+	var infos []SessionInfo
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".jsonl")
+		sess, err := s.Load(id)
+		if err != nil {
+			// Skip unreadable files rather than failing the whole list;
+			// callers can still load known-good sessions individually.
+			continue
+		}
+		info := SessionInfo{
+			ID:           sess.ID,
+			Path:         sess.Path,
+			StartedAt:    sess.StartedAt,
+			TurnCount:    len(sess.Turns),
+			ForkParentID: sess.ForkParentID,
+		}
+		if len(sess.Turns) > 0 {
+			info.UpdatedAt = sess.Turns[len(sess.Turns)-1].At
+			for _, t := range sess.Turns {
+				if t.Role == "user" && t.Content != "" {
+					info.Title = truncate(t.Content, 60)
+					break
+				}
+			}
+		}
+		infos = append(infos, info)
+	}
+	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].UpdatedAt.After(infos[j].UpdatedAt)
+	})
+	return infos, nil
+}
+
+// FindTurn locates a turn by ID across all sessions in the store. The
+// returned session is the file the turn lives in. Returns os.ErrNotExist
+// (wrapped) when no session contains the turn.
+func (s *Store) FindTurn(turnID string) (*Session, Turn, error) {
+	if turnID == "" {
+		return nil, Turn{}, errors.New("sessions: turn id required")
+	}
+	infos, err := s.List()
+	if err != nil {
+		return nil, Turn{}, err
+	}
+	for _, info := range infos {
+		sess, err := s.Load(info.ID)
+		if err != nil {
+			continue
+		}
+		for _, t := range sess.Turns {
+			if t.ID == turnID {
+				return sess, t, nil
+			}
+		}
+	}
+	return nil, Turn{}, fmt.Errorf("sessions: turn %q: %w", turnID, os.ErrNotExist)
+}
+
+// Fork creates a new session whose ancestry chain copies the source
+// session's history up to and including parentTurnID. The new session's
+// first turn carries ParentID=parentTurnID so the fork link survives a
+// reload from disk. The new session is persisted before return.
+func (s *Store) Fork(srcID, parentTurnID string) (*Session, error) {
+	src, err := s.Load(srcID)
+	if err != nil {
+		return nil, err
+	}
+	prefix, ok := historyUpTo(src.Turns, parentTurnID)
+	if !ok {
+		return nil, fmt.Errorf("sessions: turn %q not found in session %q", parentTurnID, srcID)
+	}
+
+	dst, err := s.Create()
+	if err != nil {
+		return nil, err
+	}
+	dst.ForkParentID = parentTurnID
+
+	// Replay the prefix into the new session, rewriting parent pointers so
+	// the new session is internally consistent. The new root carries the
+	// original parentTurnID as its ParentID — the only cross-session link.
+	idMap := map[string]string{}
+	for i, t := range prefix {
+		newTurn := Turn{
+			Role:     t.Role,
+			Content:  t.Content,
+			Model:    t.Model,
+			Params:   cloneStringMap(t.Params),
+			Metadata: cloneStringMap(t.Metadata),
+			At:       time.Now().UTC(),
+		}
+		if i == 0 {
+			newTurn.ParentID = parentTurnID
+		} else {
+			newTurn.ParentID = idMap[t.ParentID]
+		}
+		written, err := s.Append(dst, newTurn)
+		if err != nil {
+			return nil, err
+		}
+		idMap[t.ID] = written.ID
+	}
+	return dst, nil
+}
+
+// ReplayResponder is the model adapter used during Replay; it returns a
+// new assistant turn for the given history. Tests inject a deterministic
+// stub; real surfaces inject a provider client.
+type ReplayResponder interface {
+	Respond(history []Turn, model string, params map[string]string) (string, error)
+}
+
+// ReplayOptions configures a Replay run.
+type ReplayOptions struct {
+	Model     string
+	Params    map[string]string
+	Responder ReplayResponder
+}
+
+// Replay forks from parentTurnID and re-issues the next assistant turn
+// using the provided responder. The forked session is persisted with the
+// new assistant turn appended; both are returned so callers can navigate
+// straight into the new branch.
+func (s *Store) Replay(srcID, parentTurnID string, opts ReplayOptions) (*Session, Turn, error) {
+	if opts.Responder == nil {
+		return nil, Turn{}, errors.New("sessions: replay requires a Responder")
+	}
+	dst, err := s.Fork(srcID, parentTurnID)
+	if err != nil {
+		return nil, Turn{}, err
+	}
+	output, err := opts.Responder.Respond(dst.Turns, opts.Model, opts.Params)
+	if err != nil {
+		return nil, Turn{}, fmt.Errorf("sessions: replay respond: %w", err)
+	}
+	parent := ""
+	if len(dst.Turns) > 0 {
+		parent = dst.Turns[len(dst.Turns)-1].ID
+	}
+	turn, err := s.Append(dst, Turn{
+		Role:     "assistant",
+		Content:  output,
+		Model:    opts.Model,
+		Params:   cloneStringMap(opts.Params),
+		ParentID: parent,
+		Metadata: map[string]string{"source": "replay"},
+	})
+	if err != nil {
+		return nil, Turn{}, err
+	}
+	return dst, turn, nil
+}
+
+// historyUpTo returns the prefix of turns up to and including the turn
+// with id matchID, walking ancestry instead of slice order so out-of-order
+// branches (created via fork) still produce a valid linear history.
+func historyUpTo(turns []Turn, matchID string) ([]Turn, bool) {
+	idx := map[string]Turn{}
+	for _, t := range turns {
+		idx[t.ID] = t
+	}
+	target, ok := idx[matchID]
+	if !ok {
+		return nil, false
+	}
+	// Walk up the parent chain to the root, then reverse.
+	var chain []Turn
+	cur := target
+	for {
+		chain = append(chain, cur)
+		if cur.ParentID == "" {
+			break
+		}
+		next, ok := idx[cur.ParentID]
+		if !ok {
+			break
+		}
+		cur = next
+	}
+	// reverse
+	for i, j := 0, len(chain)-1; i < j; i, j = i+1, j-1 {
+		chain[i], chain[j] = chain[j], chain[i]
+	}
+	return chain, true
+}
+
+func cloneStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func newSessionID() (string, error) {
+	buf := make([]byte, 4)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("sessions: random session id: %w", err)
+	}
+	return fmt.Sprintf("sess-%d-%s", time.Now().UTC().Unix(), hex.EncodeToString(buf)), nil
+}
+
+func newTurnID(at time.Time) (string, error) {
+	buf := make([]byte, 3)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("sessions: random turn id: %w", err)
+	}
+	return fmt.Sprintf("turn-%d-%s", at.UTC().UnixNano(), hex.EncodeToString(buf)), nil
+}
+
+func truncate(s string, max int) string {
+	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+	if len(s) <= max {
+		return s
+	}
+	if max <= 1 {
+		return s[:max]
+	}
+	return s[:max-1] + "…"
+}

--- a/internal/sessions/store_test.go
+++ b/internal/sessions/store_test.go
@@ -1,0 +1,214 @@
+package sessions
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "sessions")
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return store
+}
+
+func TestStoreCreateAndAppendRoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	sess, err := store.Create()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	turns := []Turn{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi", Model: "claude-sonnet-4-6"},
+	}
+	var lastID string
+	for i := range turns {
+		turns[i].ParentID = lastID
+		written, err := store.Append(sess, turns[i])
+		if err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+		if written.ID == "" {
+			t.Fatalf("Append returned empty turn id")
+		}
+		if written.SessionID != sess.ID {
+			t.Errorf("session id stamp: got %q want %q", written.SessionID, sess.ID)
+		}
+		lastID = written.ID
+	}
+
+	loaded, err := store.Load(sess.ID)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Turns) != len(turns) {
+		t.Fatalf("turn count: got %d want %d", len(loaded.Turns), len(turns))
+	}
+	if loaded.Turns[1].ParentID != loaded.Turns[0].ID {
+		t.Errorf("parent link broken: got %q want %q", loaded.Turns[1].ParentID, loaded.Turns[0].ID)
+	}
+	data, err := os.ReadFile(sess.Path)
+	if err != nil {
+		t.Fatalf("read journal: %v", err)
+	}
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Fatalf("journal not JSONL-terminated: %q", string(data))
+	}
+}
+
+func TestStoreListSortsByUpdatedAtDesc(t *testing.T) {
+	store := newTestStore(t)
+	older, _ := store.Create()
+	if _, err := store.Append(older, Turn{Role: "user", Content: "older"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	newer, _ := store.Create()
+	if _, err := store.Append(newer, Turn{Role: "user", Content: "newer"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	infos, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("List len: got %d want 2", len(infos))
+	}
+	if infos[0].UpdatedAt.Before(infos[1].UpdatedAt) {
+		t.Errorf("expected newest first; got %v then %v", infos[0].UpdatedAt, infos[1].UpdatedAt)
+	}
+	if infos[0].Title == "" {
+		t.Errorf("expected title from first user turn, got empty")
+	}
+}
+
+func TestStoreFindTurn(t *testing.T) {
+	store := newTestStore(t)
+	sess, _ := store.Create()
+	target, err := store.Append(sess, Turn{Role: "user", Content: "find me"})
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	got, gotTurn, err := store.FindTurn(target.ID)
+	if err != nil {
+		t.Fatalf("FindTurn: %v", err)
+	}
+	if got.ID != sess.ID {
+		t.Errorf("session id: got %q want %q", got.ID, sess.ID)
+	}
+	if gotTurn.ID != target.ID {
+		t.Errorf("turn id: got %q want %q", gotTurn.ID, target.ID)
+	}
+	if _, _, err := store.FindTurn("no-such-turn"); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("missing turn should wrap ErrNotExist, got %v", err)
+	}
+}
+
+func TestStoreForkPreservesPrefix(t *testing.T) {
+	store := newTestStore(t)
+	sess, _ := store.Create()
+	a, _ := store.Append(sess, Turn{Role: "user", Content: "one"})
+	b, _ := store.Append(sess, Turn{Role: "assistant", Content: "two", ParentID: a.ID})
+	c, _ := store.Append(sess, Turn{Role: "user", Content: "three", ParentID: b.ID})
+	_ = c // not in fork prefix
+
+	forked, err := store.Fork(sess.ID, b.ID)
+	if err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+	if forked.ID == sess.ID {
+		t.Fatalf("fork must produce a new session id")
+	}
+	if forked.ForkParentID != b.ID {
+		t.Errorf("ForkParentID: got %q want %q", forked.ForkParentID, b.ID)
+	}
+	if len(forked.Turns) != 2 {
+		t.Fatalf("forked turn count: got %d want 2", len(forked.Turns))
+	}
+	if forked.Turns[0].ParentID != b.ID {
+		t.Errorf("forked root ParentID should reference source turn id; got %q", forked.Turns[0].ParentID)
+	}
+	if forked.Turns[0].Role != "user" || forked.Turns[1].Role != "assistant" {
+		t.Errorf("forked roles: got %q,%q", forked.Turns[0].Role, forked.Turns[1].Role)
+	}
+
+	// Reload from disk to make sure ForkParentID survives a round trip.
+	reloaded, err := store.Load(forked.ID)
+	if err != nil {
+		t.Fatalf("Load forked: %v", err)
+	}
+	if reloaded.ForkParentID != b.ID {
+		t.Errorf("reloaded ForkParentID: got %q want %q", reloaded.ForkParentID, b.ID)
+	}
+}
+
+type stubResponder struct {
+	last []Turn
+	out  string
+}
+
+func (s *stubResponder) Respond(history []Turn, model string, params map[string]string) (string, error) {
+	s.last = history
+	if s.out == "" {
+		return "stub response from " + model, nil
+	}
+	return s.out, nil
+}
+
+func TestStoreReplayCreatesNewBranch(t *testing.T) {
+	store := newTestStore(t)
+	sess, _ := store.Create()
+	a, _ := store.Append(sess, Turn{Role: "user", Content: "ask"})
+	b, _ := store.Append(sess, Turn{Role: "assistant", Content: "first answer", ParentID: a.ID})
+
+	resp := &stubResponder{out: "replayed answer"}
+	forked, newTurn, err := store.Replay(sess.ID, b.ID, ReplayOptions{
+		Model:     "claude-opus-4-6",
+		Responder: resp,
+	})
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if forked.ID == sess.ID {
+		t.Fatal("replay must create a new session")
+	}
+	if newTurn.Role != "assistant" || newTurn.Content != "replayed answer" {
+		t.Errorf("new turn role/content: got %q/%q", newTurn.Role, newTurn.Content)
+	}
+	if newTurn.Model != "claude-opus-4-6" {
+		t.Errorf("new turn model not propagated, got %q", newTurn.Model)
+	}
+	if len(resp.last) == 0 {
+		t.Fatal("responder received empty history")
+	}
+}
+
+func TestStoreReplayRequiresResponder(t *testing.T) {
+	store := newTestStore(t)
+	sess, _ := store.Create()
+	a, _ := store.Append(sess, Turn{Role: "user", Content: "ask"})
+	if _, _, err := store.Replay(sess.ID, a.ID, ReplayOptions{Model: "x"}); err == nil {
+		t.Fatal("expected error when Responder is nil")
+	}
+}
+
+func TestNewStoreDefaultDirCreated(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	store, err := NewStore("")
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if !strings.HasPrefix(store.Dir(), root) {
+		t.Errorf("default dir should sit under HOME (%s); got %s", root, store.Dir())
+	}
+	if _, err := os.Stat(store.Dir()); err != nil {
+		t.Fatalf("default dir not created: %v", err)
+	}
+}

--- a/internal/sessions/tree.go
+++ b/internal/sessions/tree.go
@@ -1,0 +1,161 @@
+package sessions
+
+import (
+	"sort"
+)
+
+// Node is one entry in the materialised session tree. A node may be
+// either a Turn (Kind=NodeKindTurn, Turn populated) or a Session header
+// (Kind=NodeKindSession, Session populated). Sessions appear as roots
+// when they have no fork parent; otherwise they hang off the turn they
+// were forked from.
+type Node struct {
+	Kind     NodeKind
+	Turn     Turn         // populated when Kind == NodeKindTurn
+	Session  *SessionInfo // populated when Kind == NodeKindSession
+	Children []*Node
+}
+
+// NodeKind identifies whether a Node represents a Turn or a Session
+// header.
+type NodeKind int
+
+const (
+	// NodeKindTurn marks a turn-level node.
+	NodeKindTurn NodeKind = iota
+	// NodeKindSession marks a session-level node (a JSONL file).
+	NodeKindSession
+)
+
+// Tree is the materialised forest of all sessions in a Store. Roots are
+// sessions that were not forked; each session contains a chain of turn
+// nodes; forks attach as session children to the turn they branched from.
+type Tree struct {
+	Roots []*Node
+	// turnIndex maps turn id -> node so callers can navigate by id without
+	// re-walking the tree.
+	turnIndex map[string]*Node
+}
+
+// LookupTurn returns the node for the given turn id, or nil if absent.
+func (t *Tree) LookupTurn(id string) *Node {
+	if t == nil {
+		return nil
+	}
+	return t.turnIndex[id]
+}
+
+// BuildTree assembles the full session forest. Each session expands into
+// a chain of turn nodes; sessions whose first turn has a ParentID hang
+// off that parent turn as a child Session node. Turns missing parents
+// (orphans) attach to the session header.
+func BuildTree(store *Store) (*Tree, error) {
+	infos, err := store.List()
+	if err != nil {
+		return nil, err
+	}
+	tree := &Tree{turnIndex: map[string]*Node{}}
+	sessionNodes := map[string]*Node{}
+
+	// First pass: build per-session subtrees of turns.
+	loaded := make(map[string]*Session, len(infos))
+	for _, info := range infos {
+		sess, err := store.Load(info.ID)
+		if err != nil {
+			continue
+		}
+		loaded[sess.ID] = sess
+		// Snapshot the info loop variable so taking its address is safe.
+		info := info
+		root := &Node{Kind: NodeKindSession, Session: &info}
+		sessionNodes[sess.ID] = root
+
+		// Index turns by id and attach them to their parent within the
+		// same session. Turns whose parent lives in another session
+		// (fork roots) attach to the session node as the in-session root.
+		nodes := map[string]*Node{}
+		for _, t := range sess.Turns {
+			t := t
+			n := &Node{Kind: NodeKindTurn, Turn: t}
+			nodes[t.ID] = n
+			tree.turnIndex[t.ID] = n
+		}
+		for _, t := range sess.Turns {
+			n := nodes[t.ID]
+			if t.ParentID == "" {
+				root.Children = append(root.Children, n)
+				continue
+			}
+			parent, ok := nodes[t.ParentID]
+			if ok {
+				parent.Children = append(parent.Children, n)
+			} else {
+				// Parent is in another session — defer; we'll attach in
+				// pass 2 once every session's turn index exists.
+				root.Children = append(root.Children, n)
+			}
+		}
+	}
+
+	// Second pass: re-parent fork-root turns onto their cross-session
+	// parents so the global tree shows the fork relationship.
+	for _, sess := range loaded {
+		root := sessionNodes[sess.ID]
+		if root == nil || len(sess.Turns) == 0 {
+			continue
+		}
+		first := sess.Turns[0]
+		if first.ParentID == "" {
+			continue
+		}
+		// If the parent turn lives in a different session, transplant
+		// the in-session root chain onto that turn.
+		parentNode := tree.turnIndex[first.ParentID]
+		if parentNode == nil {
+			continue
+		}
+		// Detach from session header and reattach under parent turn.
+		var keep []*Node
+		var moved []*Node
+		for _, child := range root.Children {
+			if child.Kind == NodeKindTurn && child.Turn.ID == first.ID {
+				moved = append(moved, child)
+			} else {
+				keep = append(keep, child)
+			}
+		}
+		root.Children = keep
+		parentNode.Children = append(parentNode.Children, moved...)
+	}
+
+	// Identify roots: sessions with no fork parent.
+	for id, sess := range loaded {
+		if sess.ForkParentID == "" {
+			tree.Roots = append(tree.Roots, sessionNodes[id])
+		}
+	}
+	sort.Slice(tree.Roots, func(i, j int) bool {
+		ai := tree.Roots[i].Session.UpdatedAt
+		bi := tree.Roots[j].Session.UpdatedAt
+		return ai.After(bi)
+	})
+	return tree, nil
+}
+
+// Walk pre-order traverses the tree and invokes fn for each node with
+// its depth (root sessions are depth 0).
+func (t *Tree) Walk(fn func(node *Node, depth int)) {
+	if t == nil {
+		return
+	}
+	var visit func(*Node, int)
+	visit = func(n *Node, depth int) {
+		fn(n, depth)
+		for _, c := range n.Children {
+			visit(c, depth+1)
+		}
+	}
+	for _, r := range t.Roots {
+		visit(r, 0)
+	}
+}

--- a/internal/sessions/tree_test.go
+++ b/internal/sessions/tree_test.go
@@ -1,0 +1,86 @@
+package sessions
+
+import (
+	"testing"
+)
+
+func TestBuildTreeFlatSession(t *testing.T) {
+	store := newTestStore(t)
+	sess, _ := store.Create()
+	a, _ := store.Append(sess, Turn{Role: "user", Content: "one"})
+	b, _ := store.Append(sess, Turn{Role: "assistant", Content: "two", ParentID: a.ID})
+
+	tree, err := BuildTree(store)
+	if err != nil {
+		t.Fatalf("BuildTree: %v", err)
+	}
+	if len(tree.Roots) != 1 {
+		t.Fatalf("expected one root session, got %d", len(tree.Roots))
+	}
+	root := tree.Roots[0]
+	if root.Kind != NodeKindSession {
+		t.Errorf("root kind: got %v", root.Kind)
+	}
+	if len(root.Children) != 1 {
+		t.Fatalf("session should have one direct child (turn a); got %d", len(root.Children))
+	}
+	if root.Children[0].Turn.ID != a.ID {
+		t.Errorf("first turn under session should be %q; got %q", a.ID, root.Children[0].Turn.ID)
+	}
+	if len(root.Children[0].Children) != 1 || root.Children[0].Children[0].Turn.ID != b.ID {
+		t.Errorf("turn b should hang off turn a")
+	}
+	if got := tree.LookupTurn(b.ID); got == nil || got.Turn.ID != b.ID {
+		t.Errorf("LookupTurn(b) returned %v", got)
+	}
+}
+
+func TestBuildTreeForkAttachesAcrossSessions(t *testing.T) {
+	store := newTestStore(t)
+	src, _ := store.Create()
+	a, _ := store.Append(src, Turn{Role: "user", Content: "a"})
+	b, _ := store.Append(src, Turn{Role: "assistant", Content: "b", ParentID: a.ID})
+	if _, err := store.Fork(src.ID, b.ID); err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+
+	tree, err := BuildTree(store)
+	if err != nil {
+		t.Fatalf("BuildTree: %v", err)
+	}
+	// Only the source session should be a root; the fork hangs off turn b.
+	if len(tree.Roots) != 1 {
+		t.Fatalf("expected one root, got %d", len(tree.Roots))
+	}
+	parentNode := tree.LookupTurn(b.ID)
+	if parentNode == nil {
+		t.Fatal("turn b not indexed")
+	}
+	foundFork := false
+	for _, child := range parentNode.Children {
+		if child.Kind == NodeKindTurn {
+			// First fork turn should reference b as parent.
+			if child.Turn.ParentID == b.ID && child.Turn.SessionID != src.ID {
+				foundFork = true
+				break
+			}
+		}
+	}
+	if !foundFork {
+		t.Errorf("fork turn not attached under turn %q; children=%+v", b.ID, parentNode.Children)
+	}
+}
+
+func TestTreeWalkVisitsAllNodes(t *testing.T) {
+	store := newTestStore(t)
+	sess, _ := store.Create()
+	a, _ := store.Append(sess, Turn{Role: "user", Content: "a"})
+	store.Append(sess, Turn{Role: "assistant", Content: "b", ParentID: a.ID})
+
+	tree, _ := BuildTree(store)
+	count := 0
+	tree.Walk(func(n *Node, depth int) { count++ })
+	if count < 3 { // session header + 2 turns
+		t.Errorf("expected >=3 nodes visited, got %d", count)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jabreeflor/conduit/internal/contracts"
 	"github.com/jabreeflor/conduit/internal/core"
+	"github.com/jabreeflor/conduit/internal/sessions"
 )
 
 // formatStatusBar returns the status line from a UsageSummary.
@@ -87,6 +88,13 @@ func RunInteractive() error {
 	}
 
 	m := newModel(modelStatus.SelectedModel, setup, engine.SetupLocalAI)
+	// Best-effort sessions wiring: a missing home dir is non-fatal and just
+	// disables /sessions until a store is reachable. The Responder is left
+	// nil because the live provider client lands in a follow-up; replay
+	// surfaces a friendly error in the meantime.
+	if store, err := sessions.NewStore(""); err == nil {
+		m = m.AttachSessions(&sessions.Dispatcher{Store: store})
+	}
 	p := tea.NewProgram(
 		m,
 		tea.WithAltScreen(),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jabreeflor/conduit/internal/contracts"
+	"github.com/jabreeflor/conduit/internal/sessions"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textarea"
@@ -74,12 +75,13 @@ type message struct {
 // ── key bindings ─────────────────────────────────────────────────────────────
 
 type keyMap struct {
-	TogglePanel key.Binding
-	Quit        key.Binding
-	Submit      key.Binding
-	ExpandTool  key.Binding
-	SetupLocal  key.Binding
-	ExternalAPI key.Binding
+	TogglePanel    key.Binding
+	Quit           key.Binding
+	Submit         key.Binding
+	ExpandTool     key.Binding
+	SetupLocal     key.Binding
+	ExternalAPI    key.Binding
+	SessionBrowser key.Binding
 }
 
 var keys = keyMap{
@@ -107,6 +109,10 @@ var keys = keyMap{
 		key.WithKeys("a"),
 		key.WithHelp("a", "external api"),
 	),
+	SessionBrowser: key.NewBinding(
+		key.WithKeys("ctrl+s"),
+		key.WithHelp("ctrl+s", "session tree browser"),
+	),
 }
 
 // ── model ─────────────────────────────────────────────────────────────────────
@@ -128,6 +134,13 @@ type Model struct {
 	streaming    bool
 	streamBuffer string
 	tickCount    int
+
+	// Sessions wiring. The dispatcher is optional — when nil, slash commands
+	// surface a friendly error instead of crashing. The browser is opened
+	// on ctrl+s and on /sessions invocations with no args.
+	sessions        *sessions.Dispatcher
+	sessionsBrowser *SessionsBrowser
+	activeSessionID string
 }
 
 func newModel(activeModel string, setup contracts.FirstRunSetupSnapshot, setupLocalAI func() (contracts.FirstRunSetupSnapshot, error)) Model {
@@ -166,6 +179,17 @@ func tick() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
+	// When the sessions browser is open, route key/window events to it
+	// first; everything else falls through to the normal model update.
+	if m.sessionsBrowser != nil {
+		next, cmd := m.sessionsBrowser.Update(msg)
+		m.sessionsBrowser = &next
+		if next.IsClosed() {
+			m = m.handleSessionsBrowserClose(next.Selected())
+		}
+		return m, cmd
+	}
+
 	switch msg := msg.(type) {
 
 	case tea.WindowSizeMsg:
@@ -177,6 +201,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case key.Matches(msg, keys.Quit):
 			return m, tea.Quit
+		case key.Matches(msg, keys.SessionBrowser):
+			m = m.openSessionsBrowser()
+			return m, nil
 		case key.Matches(msg, keys.TogglePanel):
 			m.showContext = !m.showContext
 			m = m.recalculateLayout()
@@ -215,6 +242,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case key.Matches(msg, keys.Submit):
 			if text := strings.TrimSpace(m.input.Value()); text != "" {
+				if strings.HasPrefix(text, "/sessions") {
+					m.input.Reset()
+					m = m.handleSessionsSlash(text)
+					return m, nil
+				}
 				m.messages = append(m.messages, message{role: roleUser, text: text})
 				m.input.Reset()
 				m.streaming = true

--- a/internal/tui/sessions_browser.go
+++ b/internal/tui/sessions_browser.go
@@ -1,0 +1,250 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jabreeflor/conduit/internal/sessions"
+)
+
+// SessionsBrowser is a navigable visualisation of the session JSONL forest.
+// It is intentionally lightweight: the visible tree is flattened into a
+// row list ahead of time so navigation is O(1) and the renderer is trivial.
+//
+// Keybindings:
+//
+//	up / k        : move selection up
+//	down / j      : move selection down
+//	enter         : Load currently selected session (or session a turn lives in)
+//	f             : Fork from selected turn
+//	r             : Replay from selected turn
+//	q / esc       : close the browser without doing anything
+//
+// The browser does not persist anywhere on its own; it returns one of three
+// "actions" via Selected() so the embedding TUI / test driver can wire the
+// outcome (load a session, fork, replay) into its own state.
+type SessionsBrowser struct {
+	tree    *sessions.Tree
+	rows    []sessionsRow
+	cursor  int
+	width   int
+	height  int
+	action  SessionsBrowserAction
+	closed  bool
+	help    string
+	errText string
+}
+
+// SessionsBrowserAction is the choice made by the user when they close
+// the browser. ActionNone means the browser was dismissed without input.
+type SessionsBrowserAction int
+
+const (
+	// ActionNone signals a clean dismissal — nothing should happen.
+	ActionNone SessionsBrowserAction = iota
+	// ActionLoad asks the host to load the chosen session id.
+	ActionLoad
+	// ActionFork asks the host to fork from the chosen turn id.
+	ActionFork
+	// ActionReplay asks the host to replay from the chosen turn id.
+	ActionReplay
+)
+
+// SessionsBrowserSelection is the user's chosen action plus the ids the
+// host needs to act on it.
+type SessionsBrowserSelection struct {
+	Action    SessionsBrowserAction
+	SessionID string
+	TurnID    string
+}
+
+type sessionsRow struct {
+	depth     int
+	kind      sessions.NodeKind
+	sessionID string
+	turnID    string
+	label     string
+	preview   string
+}
+
+// NewSessionsBrowser constructs the browser model from a fully built tree.
+func NewSessionsBrowser(tree *sessions.Tree) SessionsBrowser {
+	b := SessionsBrowser{tree: tree, help: "↑/↓ navigate · enter load · f fork · r replay · q quit"}
+	b.rebuildRows()
+	return b
+}
+
+// SetSize updates the panel dimensions; called on tea.WindowSizeMsg.
+func (b *SessionsBrowser) SetSize(w, h int) {
+	b.width = w
+	b.height = h
+}
+
+// Init satisfies tea.Model.
+func (b SessionsBrowser) Init() tea.Cmd { return nil }
+
+var sessionsBrowserKeys = struct {
+	Up, Down, Load, Fork, Replay, Quit key.Binding
+}{
+	Up:     key.NewBinding(key.WithKeys("up", "k")),
+	Down:   key.NewBinding(key.WithKeys("down", "j")),
+	Load:   key.NewBinding(key.WithKeys("enter")),
+	Fork:   key.NewBinding(key.WithKeys("f")),
+	Replay: key.NewBinding(key.WithKeys("r")),
+	Quit:   key.NewBinding(key.WithKeys("q", "esc")),
+}
+
+// Update handles the small set of key events this browser cares about.
+// It never produces tea.Cmds — outcomes are read by the host via
+// Selected() / IsClosed() once the user dismisses the browser.
+func (b SessionsBrowser) Update(msg tea.Msg) (SessionsBrowser, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		b.width = msg.Width
+		b.height = msg.Height
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, sessionsBrowserKeys.Up):
+			if b.cursor > 0 {
+				b.cursor--
+			}
+		case key.Matches(msg, sessionsBrowserKeys.Down):
+			if b.cursor+1 < len(b.rows) {
+				b.cursor++
+			}
+		case key.Matches(msg, sessionsBrowserKeys.Load):
+			b.completeWith(ActionLoad)
+		case key.Matches(msg, sessionsBrowserKeys.Fork):
+			b.completeWith(ActionFork)
+		case key.Matches(msg, sessionsBrowserKeys.Replay):
+			b.completeWith(ActionReplay)
+		case key.Matches(msg, sessionsBrowserKeys.Quit):
+			b.action = ActionNone
+			b.closed = true
+		}
+	}
+	return b, nil
+}
+
+// IsClosed reports whether the user has finished interacting with the browser.
+func (b SessionsBrowser) IsClosed() bool { return b.closed }
+
+// Selected returns the user's chosen action and ids. Only meaningful once
+// IsClosed() returns true.
+func (b SessionsBrowser) Selected() SessionsBrowserSelection {
+	row, ok := b.currentRow()
+	sel := SessionsBrowserSelection{Action: b.action}
+	if !ok {
+		return sel
+	}
+	sel.SessionID = row.sessionID
+	sel.TurnID = row.turnID
+	return sel
+}
+
+// View renders the browser as a self-contained string.
+func (b SessionsBrowser) View() string {
+	var sb strings.Builder
+	sb.WriteString(styleAgent.Render("Session Tree Browser") + "\n")
+	sb.WriteString(styleDim.Render(b.help) + "\n\n")
+	if b.errText != "" {
+		sb.WriteString(styleToolFail.Render(b.errText) + "\n\n")
+	}
+	if len(b.rows) == 0 {
+		sb.WriteString(styleDim.Render(" no sessions yet — start a conversation to populate the tree"))
+		return sb.String()
+	}
+	for i, row := range b.rows {
+		marker := "  "
+		if i == b.cursor {
+			marker = "▶ "
+		}
+		indent := strings.Repeat("  ", row.depth)
+		line := fmt.Sprintf("%s%s%s", marker, indent, row.label)
+		if row.preview != "" {
+			line += "  " + styleDim.Render(row.preview)
+		}
+		if i == b.cursor {
+			line = styleUser.Render(line)
+		}
+		sb.WriteString(line + "\n")
+	}
+	return sb.String()
+}
+
+func (b *SessionsBrowser) completeWith(a SessionsBrowserAction) {
+	row, ok := b.currentRow()
+	if !ok {
+		b.errText = "no row selected"
+		return
+	}
+	switch a {
+	case ActionFork, ActionReplay:
+		if row.turnID == "" {
+			b.errText = "fork/replay requires selecting a turn (not a session header)"
+			return
+		}
+	}
+	b.action = a
+	b.closed = true
+}
+
+func (b *SessionsBrowser) currentRow() (sessionsRow, bool) {
+	if b.cursor < 0 || b.cursor >= len(b.rows) {
+		return sessionsRow{}, false
+	}
+	return b.rows[b.cursor], true
+}
+
+func (b *SessionsBrowser) rebuildRows() {
+	b.rows = b.rows[:0]
+	if b.tree == nil {
+		return
+	}
+	b.tree.Walk(func(n *sessions.Node, depth int) {
+		row := sessionsRow{depth: depth, kind: n.Kind}
+		switch n.Kind {
+		case sessions.NodeKindSession:
+			row.sessionID = n.Session.ID
+			label := fmt.Sprintf("● %s", n.Session.ID)
+			if n.Session.ForkParentID != "" {
+				label += " (forked)"
+			}
+			row.label = label
+			if n.Session.Title != "" {
+				row.preview = n.Session.Title
+			}
+		case sessions.NodeKindTurn:
+			row.sessionID = n.Turn.SessionID
+			row.turnID = n.Turn.ID
+			role := n.Turn.Role
+			if role == "" {
+				role = "?"
+			}
+			row.label = fmt.Sprintf("· [%s] %s", role, shortID(n.Turn.ID))
+			row.preview = truncatePreview(n.Turn.Content, 60)
+		}
+		b.rows = append(b.rows, row)
+	})
+}
+
+func truncatePreview(s string, max int) string {
+	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+	if len(s) <= max {
+		return s
+	}
+	if max <= 1 {
+		return s[:max]
+	}
+	return s[:max-1] + "…"
+}
+
+func shortID(id string) string {
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:6] + "…" + id[len(id)-4:]
+}

--- a/internal/tui/sessions_browser_test.go
+++ b/internal/tui/sessions_browser_test.go
@@ -1,0 +1,111 @@
+package tui
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jabreeflor/conduit/internal/sessions"
+)
+
+func newPopulatedStore(t *testing.T) (*sessions.Store, sessions.Turn) {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "sessions")
+	store, err := sessions.NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	sess, err := store.Create()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	a, err := store.Append(sess, sessions.Turn{Role: "user", Content: "hello browser"})
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if _, err := store.Append(sess, sessions.Turn{Role: "assistant", Content: "hi", ParentID: a.ID}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	return store, a
+}
+
+func TestSessionsBrowserViewIncludesSessionRow(t *testing.T) {
+	store, _ := newPopulatedStore(t)
+	tree, err := sessions.BuildTree(store)
+	if err != nil {
+		t.Fatalf("BuildTree: %v", err)
+	}
+	browser := NewSessionsBrowser(tree)
+	out := browser.View()
+	if !strings.Contains(out, "Session Tree Browser") {
+		t.Errorf("missing header in view: %q", out)
+	}
+	if !strings.Contains(out, "user") {
+		t.Errorf("expected turn role label in view: %q", out)
+	}
+}
+
+func TestSessionsBrowserNavigationAndForkAction(t *testing.T) {
+	store, turnA := newPopulatedStore(t)
+	tree, _ := sessions.BuildTree(store)
+	browser := NewSessionsBrowser(tree)
+
+	// Walk down until we land on the user turn.
+	for i := 0; i < 5 && !rowIsTurn(browser, turnA.ID); i++ {
+		next, _ := browser.Update(tea.KeyMsg{Type: tea.KeyDown})
+		browser = next
+	}
+	if !rowIsTurn(browser, turnA.ID) {
+		t.Fatalf("could not navigate to user turn; rows=%d cursor=%d", len(browser.rows), browser.cursor)
+	}
+	// Press 'f' to fork.
+	next, _ := browser.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	browser = next
+	if !browser.IsClosed() {
+		t.Fatal("browser should close after fork action")
+	}
+	sel := browser.Selected()
+	if sel.Action != ActionFork {
+		t.Errorf("action: got %v want ActionFork", sel.Action)
+	}
+	if sel.TurnID != turnA.ID {
+		t.Errorf("turn id: got %q want %q", sel.TurnID, turnA.ID)
+	}
+}
+
+func TestSessionsBrowserQuitDismissesCleanly(t *testing.T) {
+	store, _ := newPopulatedStore(t)
+	tree, _ := sessions.BuildTree(store)
+	browser := NewSessionsBrowser(tree)
+
+	next, _ := browser.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	browser = next
+	if !browser.IsClosed() {
+		t.Fatal("browser should close on q")
+	}
+	if browser.Selected().Action != ActionNone {
+		t.Errorf("expected ActionNone, got %v", browser.Selected().Action)
+	}
+}
+
+func TestSessionsBrowserForkOnSessionRowReportsError(t *testing.T) {
+	store, _ := newPopulatedStore(t)
+	tree, _ := sessions.BuildTree(store)
+	browser := NewSessionsBrowser(tree)
+	// Cursor starts at row 0 = session header; fork should be rejected.
+	next, _ := browser.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	browser = next
+	if browser.IsClosed() {
+		t.Fatal("browser should not close when fork target is a session header")
+	}
+	if browser.errText == "" {
+		t.Errorf("expected an error message, got empty")
+	}
+}
+
+func rowIsTurn(b SessionsBrowser, turnID string) bool {
+	row, ok := b.currentRow()
+	return ok && row.kind == sessions.NodeKindTurn && row.turnID == turnID
+}

--- a/internal/tui/sessions_wiring.go
+++ b/internal/tui/sessions_wiring.go
@@ -1,0 +1,121 @@
+package tui
+
+import (
+	"fmt"
+
+	"github.com/jabreeflor/conduit/internal/sessions"
+)
+
+// AttachSessions injects a sessions.Dispatcher into the model so /sessions
+// slash commands and the ctrl+s browser have something to talk to. Surfaces
+// call this once at boot — the dispatcher is reused across browser opens
+// so list/load are cheap.
+func (m Model) AttachSessions(dispatcher *sessions.Dispatcher) Model {
+	m.sessions = dispatcher
+	return m
+}
+
+// openSessionsBrowser builds a fresh tree from the dispatcher's store and
+// hands it to a new SessionsBrowser instance. We rebuild on every open so
+// new sessions show up without restarting the TUI.
+func (m Model) openSessionsBrowser() Model {
+	if m.sessions == nil || m.sessions.Store == nil {
+		m.messages = append(m.messages, message{
+			role: roleAgent,
+			text: "Session browser unavailable — no session store attached.",
+		})
+		return m.refreshContent()
+	}
+	tree, err := sessions.BuildTree(m.sessions.Store)
+	if err != nil {
+		m.messages = append(m.messages, message{
+			role: roleAgent,
+			text: "Could not load session tree: " + err.Error(),
+		})
+		return m.refreshContent()
+	}
+	browser := NewSessionsBrowser(tree)
+	browser.SetSize(m.width, m.height)
+	m.sessionsBrowser = &browser
+	return m
+}
+
+// handleSessionsSlash parses the /sessions command line and renders the
+// dispatcher's response into the conversation log. A bare "/sessions" or
+// "/sessions list" with no arguments opens the browser instead so users
+// can navigate visually.
+func (m Model) handleSessionsSlash(line string) Model {
+	if m.sessions == nil {
+		m.messages = append(m.messages, message{
+			role: roleAgent,
+			text: "Sessions are not configured for this surface.",
+		})
+		return m.refreshContent()
+	}
+	res, err := m.sessions.DispatchLine(line)
+	if err != nil {
+		m.messages = append(m.messages, message{
+			role: roleAgent,
+			text: fmt.Sprintf("/sessions error: %v", err),
+		})
+		return m.refreshContent()
+	}
+	if res.Output != "" {
+		m.messages = append(m.messages, message{role: roleAgent, text: res.Output})
+	}
+	if res.LoadSessionID != "" {
+		m.activeSessionID = res.LoadSessionID
+	}
+	return m.refreshContent()
+}
+
+// handleSessionsBrowserClose runs when the browser hands focus back. It
+// inspects the chosen action and dispatches it through the same pipeline
+// the slash commands use, so output stays consistent.
+func (m Model) handleSessionsBrowserClose(sel SessionsBrowserSelection) Model {
+	m.sessionsBrowser = nil
+	if m.sessions == nil {
+		return m.refreshContent()
+	}
+	switch sel.Action {
+	case ActionLoad:
+		if sel.SessionID == "" {
+			return m.refreshContent()
+		}
+		res, err := m.sessions.Dispatch([]string{"load", sel.SessionID})
+		return m.appendDispatchResult(res, err)
+	case ActionFork:
+		if sel.TurnID == "" {
+			return m.refreshContent()
+		}
+		res, err := m.sessions.Dispatch([]string{"fork", sel.TurnID})
+		return m.appendDispatchResult(res, err)
+	case ActionReplay:
+		if sel.TurnID == "" {
+			return m.refreshContent()
+		}
+		// No --model override here; the host TUI doesn't yet have a model
+		// picker UI for the browser. Users can run /sessions replay with a
+		// flag from the prompt instead.
+		res, err := m.sessions.Dispatch([]string{"replay", sel.TurnID})
+		return m.appendDispatchResult(res, err)
+	}
+	return m.refreshContent()
+}
+
+func (m Model) appendDispatchResult(res sessions.Result, err error) Model {
+	if err != nil {
+		m.messages = append(m.messages, message{
+			role: roleAgent,
+			text: fmt.Sprintf("/sessions error: %v", err),
+		})
+		return m.refreshContent()
+	}
+	if res.Output != "" {
+		m.messages = append(m.messages, message{role: roleAgent, text: res.Output})
+	}
+	if res.LoadSessionID != "" {
+		m.activeSessionID = res.LoadSessionID
+	}
+	return m.refreshContent()
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -136,6 +136,16 @@ func (m Model) View() string {
 	}
 
 	statusBar := m.renderStatusBar()
+
+	// When the sessions browser is up, render it full-width in place of
+	// the conversation/context row. Status bar and input row stay so the
+	// user can still see model + cost and dismiss with esc/q.
+	if m.sessionsBrowser != nil {
+		browserPanel := styleActivePanel.Render(m.sessionsBrowser.View())
+		inputRow := styleDim.Render(" ↑/↓ navigate  enter:load  f:fork  r:replay  q/esc:close")
+		return lipgloss.JoinVertical(lipgloss.Left, statusBar, browserPanel, inputRow)
+	}
+
 	mainRow := m.renderMainRow()
 	inputRow := m.renderInputRow()
 
@@ -161,9 +171,9 @@ func (m Model) renderMainRow() string {
 }
 
 func (m Model) renderInputRow() string {
-	help := " enter:send  ctrl+p:panel  x:expand  esc:quit"
+	help := " enter:send  ctrl+p:panel  ctrl+s:sessions  x:expand  esc:quit"
 	if m.setup.Phase == "welcome" {
-		help = " l:local setup  a:external api  enter:send  ctrl+p:panel  esc:quit"
+		help = " l:local setup  a:external api  enter:send  ctrl+p:panel  ctrl+s:sessions  esc:quit"
 	}
 	help = styleDim.Render(help)
 	inputBox := stylePanel.Render(m.input.View())


### PR DESCRIPTION
## Summary
- Adds an `internal/sessions` package that persists conversation sessions as JSONL files under `~/.conduit/sessions/`, with parent-child links between turns so any turn can be forked or replayed (PRD §6.13).
- Implements the slash-command surface `/sessions list|fork|replay|load` via a `sessions.Dispatcher`, reused by both the TUI (interactive `/sessions ...`) and a new `conduit sessions` CLI subcommand.
- Adds a TUI session-tree browser (Bubble Tea) with arrow-key navigation, `enter` to load, `f` to fork, `r` to replay, and `q`/`esc` to dismiss; bound to `ctrl+s` from the main chat view.

## Design notes
- **Schema:** each turn is `{id, parent_id, session_id, role, content, model, params, timestamp, metadata}`; close to the PRD's described shape but with `model`/`params` so replays can record the inference parameters they ran with.
- **Fork semantics:** forking copies the prefix of turns up to and including the chosen parent into a new session, then writes the original turn id into the new session's first turn `parent_id`. That single cross-session pointer is enough to rebuild the global fork tree on disk.
- **Replay:** `Replay = Fork + responder.Respond + Append assistant turn`. Live provider integration ships in a follow-up; the dispatcher accepts any `ReplayResponder`, and the CLI/TUI default to no responder rather than crashing when one isn't injected.
- **Tree builder:** `BuildTree` produces a forest where session-headers are roots and forked sessions hang off the source turn, so the same model drives both the TUI browser and any future GUI/web tree views.

## Test plan
- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes (storage round-trip, fork prefix, replay, dispatcher list/fork/replay/load, browser navigation/fork/quit smoke tests)
- [x] `go build ./...` succeeds
- Manual: `conduit sessions list` against an empty `~/.conduit/sessions/` reports no sessions; opening `ctrl+s` in the TUI shows the browser with help text.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)