### PR TITLE
feat(#52): universal skill adapter — import from any source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 target/
 .conduit/
 .worktrees/
+conduit

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -327,22 +327,25 @@ func providerResponderFromEnv(model string) (evalpkg.Responder, bool) {
 // integration lives in the agent loop, not here.
 func runSkillsCLI(args []string, stdout, stderr *os.File) error {
 	if len(args) == 0 {
-		fmt.Fprintln(stderr, "usage: conduit skills <list|lookup|search> [args...]")
+		fmt.Fprintln(stderr, "usage: conduit skills <list|lookup|search|import|sync> [args...]")
 		return flag.ErrHelp
-	}
-
-	registry, err := newSkillsRegistry()
-	if err != nil {
-		return err
 	}
 
 	switch args[0] {
 	case "list":
+		registry, err := newSkillsRegistry()
+		if err != nil {
+			return err
+		}
 		printSkillRows(stdout, registry.List())
 		return nil
 	case "lookup":
 		if len(args) < 2 {
 			return fmt.Errorf("usage: conduit skills lookup <name>")
+		}
+		registry, err := newSkillsRegistry()
+		if err != nil {
+			return err
 		}
 		skill, ok := registry.Lookup(args[1])
 		if !ok {
@@ -355,18 +358,80 @@ func runSkillsCLI(args []string, stdout, stderr *os.File) error {
 		if len(args) < 2 {
 			return fmt.Errorf("usage: conduit skills search <query>")
 		}
+		registry, err := newSkillsRegistry()
+		if err != nil {
+			return err
+		}
 		printSkillRows(stdout, registry.Search(strings.Join(args[1:], " ")))
 		return nil
+	case "import":
+		return runSkillsImport(args[1:], stdout, stderr)
+	case "sync":
+		return runSkillsSync(stdout, stderr)
 	default:
 		return fmt.Errorf("unknown skills command %q", args[0])
+	}
+}
+
+func runSkillsImport(args []string, stdout, stderr *os.File) error {
+	imp, err := newSkillsImporter()
+	if err != nil {
+		return err
+	}
+
+	// Check for --from flag
+	if len(args) >= 2 && args[0] == "--from" {
+		provider := args[1]
+		fmt.Fprintf(stdout, "importing skills from %s...\n", provider)
+		if err := imp.ImportFrom(provider); err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, "done\n")
+		return nil
+	}
+
+	if len(args) < 1 {
+		return fmt.Errorf("usage: conduit skills import <path|url> | --from <provider>")
+	}
+
+	source := args[0]
+	fmt.Fprintf(stdout, "importing skills from %s...\n", source)
+	if err := imp.Import(source); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "done\n")
+	return nil
+}
+
+func runSkillsSync(stdout, stderr *os.File) error {
+	imp, err := newSkillsImporter()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "syncing all tracked skill sources...\n")
+	if err := imp.Sync(); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "done\n")
+	return nil
+}
+
+// allAdapters returns the full adapter chain in detection-priority order.
+// Specialized adapters go first so they have a chance to claim their files
+// before the generic MarkdownAdapter swallows everything.
+func allAdapters() []skills.Adapter {
+	return []skills.Adapter{
+		skills.NewHermesAdapter(),
+		skills.NewOpenClawAdapter(),
+		skills.NewCursorRulesAdapter(),
+		skills.NewAgentsMDAdapter(),
+		skills.NewMarkdownAdapter(),
 	}
 }
 
 func newSkillsRegistry() (*skills.Registry, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		// A missing home dir is unusual but should not break the CLI; the
-		// registry will simply have no personal/imported/bundled tiers.
 		home = ""
 	}
 	workspace, err := os.Getwd()
@@ -374,10 +439,24 @@ func newSkillsRegistry() (*skills.Registry, error) {
 		workspace = ""
 	}
 	registry := skills.NewRegistry(skills.DefaultRoots(home, workspace))
-	if err := registry.Load([]skills.Adapter{skills.NewMarkdownAdapter()}); err != nil {
+	if err := registry.Load(allAdapters()); err != nil {
 		return nil, err
 	}
 	return registry, nil
+}
+
+func newSkillsImporter() (*skills.Importer, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	roots := skills.DefaultRoots(home, "")
+	importedRoot := roots[contracts.SkillTierImported]
+	registry := skills.NewRegistry(roots)
+	if err := registry.Load(allAdapters()); err != nil {
+		return nil, err
+	}
+	return skills.NewImporter(registry, importedRoot)
 }
 
 func printSkillRows(out *os.File, list []contracts.Skill) {

--- a/internal/skills/adapter_agents.go
+++ b/internal/skills/adapter_agents.go
@@ -1,0 +1,52 @@
+package skills
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// AgentsMDAdapter parses AGENTS.md files which serve as root-level agent
+// instruction files in repositories.
+type AgentsMDAdapter struct{}
+
+// NewAgentsMDAdapter returns an AGENTS.md adapter.
+func NewAgentsMDAdapter() AgentsMDAdapter {
+	return AgentsMDAdapter{}
+}
+
+// Name implements Adapter.
+func (AgentsMDAdapter) Name() string { return "agents-md" }
+
+// CanHandle accepts files named AGENTS.md (case-insensitive).
+func (AgentsMDAdapter) CanHandle(path string) bool {
+	base := filepath.Base(path)
+	return strings.EqualFold(base, "AGENTS.md")
+}
+
+// Parse implements Adapter. It treats the entire file as instructions and
+// derives the skill name from the parent directory.
+func (AgentsMDAdapter) Parse(path string, data []byte, tier contracts.SkillTier) (contracts.Skill, error) {
+	// Extract name from parent directory
+	dir := filepath.Dir(path)
+	name := filepath.Base(dir)
+	if name == "" || name == "." || name == "/" {
+		name = "agents"
+	}
+	name = strings.TrimSpace(name)
+
+	body := string(data)
+
+	skill := contracts.Skill{
+		Name:        name,
+		Tier:        tier,
+		Description: "",
+		Tags:        []string{"agents"},
+		Path:        path,
+		Body:        strings.TrimSpace(body),
+		UpdatedAt:   time.Time{},
+	}
+	return skill, nil
+}

--- a/internal/skills/adapter_agents_test.go
+++ b/internal/skills/adapter_agents_test.go
@@ -1,0 +1,131 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestAgentsMDAdapterParsesFile(t *testing.T) {
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, "code-review-agent")
+	os.MkdirAll(agentDir, 0o755)
+	path := filepath.Join(agentDir, "AGENTS.md")
+	body := "Review code for quality.\nCheck for:\n- Performance\n- Security\n- Style\n"
+	writeFile(t, path, body)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	skill, err := NewAgentsMDAdapter().Parse(path, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if skill.Name != "code-review-agent" {
+		t.Errorf("name should be derived from parent dir, got %q", skill.Name)
+	}
+
+	if !strings.Contains(skill.Body, "Review code for quality.") {
+		t.Errorf("body should contain full file content, got %q", skill.Body)
+	}
+
+	if !contains(skill.Tags, "agents") {
+		t.Errorf("tags should include 'agents', got %v", skill.Tags)
+	}
+}
+
+func TestAgentsMDAdapterDerivesNameFromParent(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{"/home/user/my-agent/AGENTS.md", "my-agent"},
+		{"/projects/research/AGENTS.md", "research"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			dir := t.TempDir()
+			fullPath := filepath.Join(dir, tt.path)
+			os.MkdirAll(filepath.Dir(fullPath), 0o755)
+			writeFile(t, fullPath, "Instructions")
+
+			data, err := os.ReadFile(fullPath)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+
+			skill, err := NewAgentsMDAdapter().Parse(fullPath, data, contracts.SkillTierImported)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+
+			if skill.Name != tt.expected {
+				t.Errorf("got %q, want %q", skill.Name, tt.expected)
+			}
+		})
+	}
+
+	// Root-level AGENTS.md falls back to "agents"
+	t.Run("root-level", func(t *testing.T) {
+		skill, err := NewAgentsMDAdapter().Parse("/AGENTS.md", []byte("Instructions"), contracts.SkillTierImported)
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		if skill.Name != "agents" {
+			t.Errorf("got %q, want %q", skill.Name, "agents")
+		}
+	})
+}
+
+func TestAgentsMDAdapterCanHandle(t *testing.T) {
+	a := NewAgentsMDAdapter()
+
+	if !a.CanHandle("/path/to/AGENTS.md") {
+		t.Errorf("expected AGENTS.md to be handled")
+	}
+
+	if !a.CanHandle("/AGENTS.md") {
+		t.Errorf("expected root AGENTS.md to be handled")
+	}
+
+	if !a.CanHandle("/agents.md") {
+		t.Errorf("expected agents.md (case-insensitive) to be handled")
+	}
+
+	if a.CanHandle("/path/to/AGENTS.txt") {
+		t.Errorf("expected AGENTS.txt to be rejected")
+	}
+
+	if a.CanHandle("/path/to/agents") {
+		t.Errorf("expected agents (no extension) to be rejected")
+	}
+}
+
+func TestAgentsMDAdapterTier(t *testing.T) {
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, "test-agent")
+	os.MkdirAll(agentDir, 0o755)
+	path := filepath.Join(agentDir, "AGENTS.md")
+	writeFile(t, path, "Instructions")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	skill, err := NewAgentsMDAdapter().Parse(path, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if skill.Tier != contracts.SkillTierImported {
+		t.Errorf("tier: got %q want %q", skill.Tier, contracts.SkillTierImported)
+	}
+}

--- a/internal/skills/adapter_cursor.go
+++ b/internal/skills/adapter_cursor.go
@@ -1,0 +1,120 @@
+package skills
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+	"gopkg.in/yaml.v3"
+)
+
+// CursorRulesAdapter parses Cursor editor rules files (.cursorrules and .mdc files).
+type CursorRulesAdapter struct{}
+
+// NewCursorRulesAdapter returns a Cursor rules adapter.
+func NewCursorRulesAdapter() CursorRulesAdapter {
+	return CursorRulesAdapter{}
+}
+
+// Name implements Adapter.
+func (CursorRulesAdapter) Name() string { return "cursor" }
+
+// CanHandle accepts .cursorrules files and .mdc files (Markdown with Code).
+func (CursorRulesAdapter) CanHandle(path string) bool {
+	base := filepath.Base(path)
+	ext := filepath.Ext(path)
+
+	// Accept .cursorrules files
+	if strings.EqualFold(base, ".cursorrules") {
+		return true
+	}
+
+	// Accept .mdc files in .cursor/rules/ directory
+	if strings.EqualFold(ext, ".mdc") && strings.Contains(path, ".cursor") {
+		return true
+	}
+
+	return false
+}
+
+// cursorFrontmatter represents optional YAML header in .mdc files.
+type cursorFrontmatter struct {
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description"`
+	Tags        []string `yaml:"tags"`
+}
+
+// Parse implements Adapter. It treats .cursorrules as plain text and .mdc files
+// may have YAML frontmatter.
+func (CursorRulesAdapter) Parse(path string, data []byte, tier contracts.SkillTier) (contracts.Skill, error) {
+	ext := filepath.Ext(path)
+
+	var name, description, body string
+
+	if strings.EqualFold(ext, ".mdc") {
+		// Try to parse YAML frontmatter from .mdc file
+		front, b, err := splitCursorFrontmatter(data)
+		if err != nil {
+			return contracts.Skill{}, fmt.Errorf("skills: parse Cursor frontmatter %q: %w", path, err)
+		}
+		body = b
+		name = strings.TrimSpace(front.Name)
+		description = strings.TrimSpace(front.Description)
+	} else {
+		// .cursorrules: treat entire file as body
+		body = string(data)
+	}
+
+	// Fallback to filename or fixed name for .cursorrules
+	if name == "" {
+		base := filepath.Base(path)
+		if strings.EqualFold(base, ".cursorrules") {
+			name = "cursor-rules"
+		} else {
+			name = strings.TrimSuffix(base, filepath.Ext(base))
+		}
+	}
+	name = strings.TrimSpace(name)
+	if name == "" || name == "." || name == "/" {
+		name = "cursor-rules"
+	}
+
+	skill := contracts.Skill{
+		Name:        name,
+		Tier:        tier,
+		Description: description,
+		Tags:        []string{"cursor"},
+		Path:        path,
+		Body:        strings.TrimSpace(body),
+		UpdatedAt:   time.Time{},
+	}
+	return skill, nil
+}
+
+// splitCursorFrontmatter parses optional YAML frontmatter from .mdc files.
+func splitCursorFrontmatter(data []byte) (cursorFrontmatter, string, error) {
+	normalised := bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	if !bytes.HasPrefix(normalised, []byte("---\n")) && !bytes.Equal(bytes.TrimSpace(normalised), []byte("---")) {
+		return cursorFrontmatter{}, string(normalised), nil
+	}
+
+	rest := normalised[len("---\n"):]
+	end := bytes.Index(rest, []byte("\n---"))
+	if end < 0 {
+		return cursorFrontmatter{}, string(normalised), nil
+	}
+	header := rest[:end]
+	body := rest[end+len("\n---"):]
+	body = bytes.TrimPrefix(body, []byte("\n"))
+
+	var front cursorFrontmatter
+	if len(bytes.TrimSpace(header)) > 0 {
+		if err := yaml.Unmarshal(header, &front); err != nil {
+			return cursorFrontmatter{}, "", err
+		}
+	}
+	return front, string(body), nil
+}

--- a/internal/skills/adapter_cursor_test.go
+++ b/internal/skills/adapter_cursor_test.go
@@ -1,0 +1,113 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestCursorRulesAdapterParsesPlainCursorrules(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".cursorrules")
+	body := "You are a helpful assistant.\nFollow these rules...\n"
+	writeFile(t, path, body)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	skill, err := NewCursorRulesAdapter().Parse(path, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if skill.Name != "cursor-rules" {
+		t.Errorf("name: got %q want %q", skill.Name, "cursor-rules")
+	}
+
+	if !strings.Contains(skill.Body, "You are a helpful assistant.") {
+		t.Errorf("body should contain rules, got %q", skill.Body)
+	}
+
+	if !contains(skill.Tags, "cursor") {
+		t.Errorf("tags should include cursor, got %v", skill.Tags)
+	}
+}
+
+func TestCursorRulesAdapterParsesMDCwithFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	cursorDir := filepath.Join(dir, ".cursor", "rules")
+	os.MkdirAll(cursorDir, 0o755)
+	path := filepath.Join(cursorDir, "custom.mdc")
+	body := "---\nname: my-cursor-rule\ndescription: Custom cursor behavior\ntags:\n  - style\n---\nImplementation details.\n"
+	writeFile(t, path, body)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	skill, err := NewCursorRulesAdapter().Parse(path, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if skill.Name != "my-cursor-rule" {
+		t.Errorf("name: got %q want %q", skill.Name, "my-cursor-rule")
+	}
+
+	if skill.Description != "Custom cursor behavior" {
+		t.Errorf("description: got %q", skill.Description)
+	}
+
+	if !strings.Contains(skill.Body, "Implementation details.") {
+		t.Errorf("body should contain content, got %q", skill.Body)
+	}
+}
+
+func TestCursorRulesAdapterMDCFallsBackToFilename(t *testing.T) {
+	dir := t.TempDir()
+	cursorDir := filepath.Join(dir, ".cursor", "rules")
+	os.MkdirAll(cursorDir, 0o755)
+	path := filepath.Join(cursorDir, "style-guide.mdc")
+	body := "Plain content without frontmatter.\n"
+	writeFile(t, path, body)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	skill, err := NewCursorRulesAdapter().Parse(path, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if skill.Name != "style-guide" {
+		t.Errorf("expected filename fallback, got %q", skill.Name)
+	}
+}
+
+func TestCursorRulesAdapterCanHandle(t *testing.T) {
+	a := NewCursorRulesAdapter()
+
+	if !a.CanHandle("/home/user/.cursorrules") {
+		t.Errorf("expected .cursorrules to be handled")
+	}
+
+	if !a.CanHandle("/project/.cursor/rules/custom.mdc") {
+		t.Errorf("expected .mdc in .cursor to be handled")
+	}
+
+	if a.CanHandle("/project/custom.mdc") {
+		t.Errorf("expected .mdc without .cursor dir to be rejected")
+	}
+
+	if a.CanHandle("/path/to/rules.txt") {
+		t.Errorf("expected .txt to be rejected")
+	}
+}

--- a/internal/skills/adapter_hermes.go
+++ b/internal/skills/adapter_hermes.go
@@ -1,0 +1,108 @@
+package skills
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+	"gopkg.in/yaml.v3"
+)
+
+// HermesAdapter parses YAML files with Hermes-specific frontmatter.
+// Hermes is an agent framework by NousResearch that includes a `platforms:` field
+// in its skill metadata.
+type HermesAdapter struct{}
+
+// NewHermesAdapter returns a Hermes skill adapter.
+func NewHermesAdapter() HermesAdapter {
+	return HermesAdapter{}
+}
+
+// Name implements Adapter.
+func (HermesAdapter) Name() string { return "hermes" }
+
+// CanHandle accepts .md files in paths that suggest Hermes origin
+// (e.g., containing "hermes" in the path). This prevents conflicts with
+// the broader MarkdownAdapter by narrowing the scope.
+func (HermesAdapter) CanHandle(path string) bool {
+	ext := filepath.Ext(path)
+	if !strings.EqualFold(ext, ".md") {
+		return false
+	}
+	// Accept files in hermes-related directories or with hermes in the name
+	return strings.Contains(strings.ToLower(path), "hermes") ||
+		strings.Contains(strings.ToLower(filepath.Base(path)), "hermes")
+}
+
+type hermesFrontmatter struct {
+	Name         string   `yaml:"name"`
+	Description  string   `yaml:"description"`
+	Tags         []string `yaml:"tags"`
+	Platforms    []string `yaml:"platforms"`
+	ToolsFilter  []string `yaml:"tools_filter"`
+	Conditions   []string `yaml:"conditions"`
+}
+
+// Parse implements Adapter. It checks for the Hermes-specific `platforms:` field
+// to confirm this is a Hermes skill before parsing.
+func (HermesAdapter) Parse(path string, data []byte, tier contracts.SkillTier) (contracts.Skill, error) {
+	front, body, err := splitHermesFrontmatter(data)
+	if err != nil {
+		return contracts.Skill{}, fmt.Errorf("skills: parse Hermes frontmatter %q: %w", path, err)
+	}
+
+	// Verify this is actually a Hermes skill by checking for platforms field
+	if len(front.Platforms) == 0 {
+		return contracts.Skill{}, fmt.Errorf("skills: %q missing required 'platforms' field for Hermes", path)
+	}
+
+	name := strings.TrimSpace(front.Name)
+	if name == "" {
+		base := filepath.Base(path)
+		name = strings.TrimSuffix(base, filepath.Ext(base))
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return contracts.Skill{}, fmt.Errorf("skills: %q has no usable name", path)
+	}
+
+	skill := contracts.Skill{
+		Name:        name,
+		Tier:        tier,
+		Description: strings.TrimSpace(front.Description),
+		Tags:        normaliseTags(front.Tags),
+		Path:        path,
+		Body:        strings.TrimSpace(body),
+		UpdatedAt:   time.Time{},
+	}
+	return skill, nil
+}
+
+// splitHermesFrontmatter returns the parsed YAML header and the body that follows.
+// It handles both LF and CRLF line endings.
+func splitHermesFrontmatter(data []byte) (hermesFrontmatter, string, error) {
+	normalised := bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	if !bytes.HasPrefix(normalised, []byte("---\n")) && !bytes.Equal(bytes.TrimSpace(normalised), []byte("---")) {
+		return hermesFrontmatter{}, string(normalised), nil
+	}
+
+	rest := normalised[len("---\n"):]
+	end := bytes.Index(rest, []byte("\n---"))
+	if end < 0 {
+		return hermesFrontmatter{}, string(normalised), nil
+	}
+	header := rest[:end]
+	body := rest[end+len("\n---"):]
+	body = bytes.TrimPrefix(body, []byte("\n"))
+
+	var front hermesFrontmatter
+	if len(bytes.TrimSpace(header)) > 0 {
+		if err := yaml.Unmarshal(header, &front); err != nil {
+			return hermesFrontmatter{}, "", err
+		}
+	}
+	return front, string(body), nil
+}

--- a/internal/skills/adapter_hermes.go
+++ b/internal/skills/adapter_hermes.go
@@ -38,12 +38,12 @@ func (HermesAdapter) CanHandle(path string) bool {
 }
 
 type hermesFrontmatter struct {
-	Name         string   `yaml:"name"`
-	Description  string   `yaml:"description"`
-	Tags         []string `yaml:"tags"`
-	Platforms    []string `yaml:"platforms"`
-	ToolsFilter  []string `yaml:"tools_filter"`
-	Conditions   []string `yaml:"conditions"`
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description"`
+	Tags        []string `yaml:"tags"`
+	Platforms   []string `yaml:"platforms"`
+	ToolsFilter []string `yaml:"tools_filter"`
+	Conditions  []string `yaml:"conditions"`
 }
 
 // Parse implements Adapter. It checks for the Hermes-specific `platforms:` field

--- a/internal/skills/adapter_hermes_test.go
+++ b/internal/skills/adapter_hermes_test.go
@@ -1,0 +1,100 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestHermesAdapterParsesFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	hermesDir := filepath.Join(dir, "hermes-skills")
+	os.MkdirAll(hermesDir, 0o755)
+	path := filepath.Join(hermesDir, "example.md")
+	body := "---\nname: hermes-example\ndescription: A Hermes skill\nplatforms:\n  - claude\n  - openai\ntags:\n  - hermes\n  - agent\n---\nAgent instructions here.\n"
+	writeFile(t, path, body)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	skill, err := NewHermesAdapter().Parse(path, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if skill.Name != "hermes-example" {
+		t.Errorf("name: got %q want %q", skill.Name, "hermes-example")
+	}
+	if skill.Description != "A Hermes skill" {
+		t.Errorf("description: got %q", skill.Description)
+	}
+	if got, want := skill.Tags, []string{"hermes", "agent"}; !equalStrings(got, want) {
+		t.Errorf("tags: got %v want %v", got, want)
+	}
+}
+
+func TestHermesAdapterRejectsWithoutPlatforms(t *testing.T) {
+	dir := t.TempDir()
+	hermesDir := filepath.Join(dir, "hermes-skills")
+	os.MkdirAll(hermesDir, 0o755)
+	path := filepath.Join(hermesDir, "nothermes.md")
+	body := "---\nname: nothermes\ndescription: Missing platforms\n---\nBody\n"
+	writeFile(t, path, body)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	_, err = NewHermesAdapter().Parse(path, data, contracts.SkillTierImported)
+	if err == nil {
+		t.Fatalf("expected error when platforms field is missing")
+	}
+}
+
+func TestHermesAdapterCanHandle(t *testing.T) {
+	a := NewHermesAdapter()
+
+	// Should handle .md files in hermes paths
+	if !a.CanHandle("/home/user/.hermes/skills/example.md") {
+		t.Errorf("expected .hermes/skills path to be handled")
+	}
+	if !a.CanHandle("/path/to/hermes/skill.md") {
+		t.Errorf("expected 'hermes' in path to be handled")
+	}
+
+	// Should not handle other paths
+	if a.CanHandle("/path/to/regular.md") {
+		t.Errorf("expected non-hermes .md to be rejected")
+	}
+	if a.CanHandle("/path/to/hermes.txt") {
+		t.Errorf("expected .txt to be rejected")
+	}
+}
+
+func TestHermesAdapterFallsBackToFilename(t *testing.T) {
+	dir := t.TempDir()
+	hermesDir := filepath.Join(dir, "hermes")
+	os.MkdirAll(hermesDir, 0o755)
+	path := filepath.Join(hermesDir, "my-skill.md")
+	body := "---\nplatforms:\n  - claude\n---\nInstructions.\n"
+	writeFile(t, path, body)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	skill, err := NewHermesAdapter().Parse(path, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if skill.Name != "my-skill" {
+		t.Errorf("expected filename fallback, got %q", skill.Name)
+	}
+}

--- a/internal/skills/adapter_openclaw.go
+++ b/internal/skills/adapter_openclaw.go
@@ -1,0 +1,103 @@
+package skills
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// OpenClawAdapter parses OpenClaw SOUL.md files that contain agent persona
+// and instruction sections.
+type OpenClawAdapter struct{}
+
+// NewOpenClawAdapter returns an OpenClaw skill adapter.
+func NewOpenClawAdapter() OpenClawAdapter {
+	return OpenClawAdapter{}
+}
+
+// Name implements Adapter.
+func (OpenClawAdapter) Name() string { return "openclaw" }
+
+// CanHandle accepts files named SOUL.md (case-insensitive).
+func (OpenClawAdapter) CanHandle(path string) bool {
+	base := filepath.Base(path)
+	return strings.EqualFold(base, "SOUL.md")
+}
+
+// Parse implements Adapter. It extracts persona/role sections from markdown
+// and maps them to a Skill. If no structured sections are found, it treats
+// the entire body as instructions.
+func (OpenClawAdapter) Parse(path string, data []byte, tier contracts.SkillTier) (contracts.Skill, error) {
+	body := string(data)
+
+	// Extract name from parent directory
+	dir := filepath.Dir(path)
+	name := filepath.Base(dir)
+	if name == "" || name == "." {
+		name = "openclaw-soul"
+	}
+	name = strings.TrimSpace(name)
+
+	// Extract description and role from markdown sections
+	description := extractSection(body, "description", "Description")
+	if description == "" {
+		description = extractSection(body, "role", "Role")
+	}
+	if description == "" {
+		description = extractSection(body, "persona", "Persona")
+	}
+
+	// Extract instructions section
+	instructions := extractSection(body, "instructions", "Instructions")
+	if instructions == "" {
+		// Fallback: use full body if no instructions section found
+		instructions = body
+	}
+
+	skill := contracts.Skill{
+		Name:        name,
+		Tier:        tier,
+		Description: description,
+		Tags:        []string{"openclaw"},
+		Path:        path,
+		Body:        strings.TrimSpace(instructions),
+		UpdatedAt:   time.Time{},
+	}
+	return skill, nil
+}
+
+// extractSection finds a markdown section (## Header or ### Header) and returns
+// its content until the next header or EOF.
+func extractSection(content string, sectionNames ...string) string {
+	lines := strings.Split(content, "\n")
+	var capturing bool
+	var result []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isMarkdownHeader(trimmed) {
+			if capturing {
+				break // next header ends the section
+			}
+			headerText := strings.TrimSpace(strings.TrimLeft(trimmed, "#"))
+			for _, name := range sectionNames {
+				if strings.EqualFold(headerText, name) {
+					capturing = true
+					break
+				}
+			}
+			continue
+		}
+		if capturing {
+			result = append(result, line)
+		}
+	}
+	return strings.TrimSpace(strings.Join(result, "\n"))
+}
+
+func isMarkdownHeader(line string) bool {
+	return strings.HasPrefix(line, "# ") || strings.HasPrefix(line, "## ") ||
+		strings.HasPrefix(line, "### ") || strings.HasPrefix(line, "#### ")
+}

--- a/internal/skills/adapter_openclaw_test.go
+++ b/internal/skills/adapter_openclaw_test.go
@@ -1,0 +1,129 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestOpenClawAdapterParsesSOULmd(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "my-agent")
+	os.MkdirAll(skillDir, 0o755)
+	path := filepath.Join(skillDir, "SOUL.md")
+	body := `## Persona
+You are a helpful AI assistant.
+
+## Instructions
+Follow these guidelines:
+- Be concise
+- Be helpful
+`
+	writeFile(t, path, body)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	skill, err := NewOpenClawAdapter().Parse(path, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if skill.Name != "my-agent" {
+		t.Errorf("name: got %q want %q", skill.Name, "my-agent")
+	}
+
+	// Should have openclaw tag
+	if !contains(skill.Tags, "openclaw") {
+		t.Errorf("tags should include openclaw, got %v", skill.Tags)
+	}
+
+	// Body should contain instructions
+	if !strings.Contains(skill.Body, "Follow these guidelines") {
+		t.Errorf("body should contain instructions, got %q", skill.Body)
+	}
+}
+
+func TestOpenClawAdapterExtractsDescription(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "my-agent")
+	os.MkdirAll(skillDir, 0o755)
+	path := filepath.Join(skillDir, "SOUL.md")
+	body := `## Description
+This agent helps with code review.
+
+## Instructions
+Review code carefully.
+`
+	writeFile(t, path, body)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	skill, err := NewOpenClawAdapter().Parse(path, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if skill.Description != "This agent helps with code review." {
+		t.Errorf("description: got %q", skill.Description)
+	}
+}
+
+func TestOpenClawAdapterFallsBackToFullBody(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "simple-agent")
+	os.MkdirAll(skillDir, 0o755)
+	path := filepath.Join(skillDir, "SOUL.md")
+	body := `Just plain content without structured sections.
+This is the body.
+`
+	writeFile(t, path, body)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	skill, err := NewOpenClawAdapter().Parse(path, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	if !strings.Contains(skill.Body, "Just plain content") {
+		t.Errorf("body should include full content, got %q", skill.Body)
+	}
+}
+
+func TestOpenClawAdapterCanHandle(t *testing.T) {
+	a := NewOpenClawAdapter()
+
+	if !a.CanHandle("/path/to/SOUL.md") {
+		t.Errorf("expected SOUL.md to be handled")
+	}
+	if !a.CanHandle("/PATH/TO/soul.md") {
+		t.Errorf("expected soul.md (lowercase) to be handled")
+	}
+	if a.CanHandle("/path/to/soul.txt") {
+		t.Errorf("expected soul.txt to be rejected")
+	}
+	if a.CanHandle("/path/to/soul-md") {
+		t.Errorf("expected soul-md to be rejected")
+	}
+}
+
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/skills/importer.go
+++ b/internal/skills/importer.go
@@ -1,0 +1,281 @@
+package skills
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// Importer handles importing skills from external sources (Hermes, OpenClaw, etc.)
+// and manages skill synchronization.
+type Importer struct {
+	registry *Registry
+	// importedTierRoot is the directory where imported skills are stored
+	importedTierRoot string
+	// sourcesPath is the path to .sources.json tracking imported sources
+	sourcesPath string
+}
+
+// NewImporter creates an importer that persists imported skills to the
+// supplied importedTierRoot directory.
+func NewImporter(registry *Registry, importedTierRoot string) (*Importer, error) {
+	if err := os.MkdirAll(importedTierRoot, 0o755); err != nil {
+		return nil, fmt.Errorf("skills: mkdir imported tier: %w", err)
+	}
+
+	sourcesPath := filepath.Join(importedTierRoot, ".sources.json")
+
+	return &Importer{
+		registry:         registry,
+		importedTierRoot: importedTierRoot,
+		sourcesPath:      sourcesPath,
+	}, nil
+}
+
+// SourceRecord tracks an imported skill source for later sync.
+type SourceRecord struct {
+	Provider string    `json:"provider"`
+	Source   string    `json:"source"`
+	ImportedAt time.Time `json:"imported_at"`
+	LastSyncedAt time.Time `json:"last_synced_at"`
+}
+
+// sourcesFile is the format of .sources.json.
+type sourcesFile struct {
+	Sources []SourceRecord `json:"sources"`
+}
+
+// Import imports a single file or directory of skills from the given source path.
+// It automatically detects the skill format and uses the appropriate adapter.
+// Imported skills are written to the importedTierRoot with "imported" as the provider.
+func (imp *Importer) Import(source string) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("skills: stat source %q: %w", source, err)
+	}
+
+	if info.IsDir() {
+		return imp.importDir(source, "imported")
+	}
+	return imp.importFile(source, "imported")
+}
+
+// ImportFrom imports skills from a known provider. Supported providers:
+// - "hermes": ~/.hermes/skills/
+// - "openclaw": ~/.openclaw/
+// Imported skills are tagged with the provider name.
+func (imp *Importer) ImportFrom(provider string) error {
+	var sourceDir string
+
+	switch strings.ToLower(provider) {
+	case "hermes":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("skills: get home dir: %w", err)
+		}
+		sourceDir = filepath.Join(home, ".hermes", "skills")
+	case "openclaw":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("skills: get home dir: %w", err)
+		}
+		sourceDir = filepath.Join(home, ".openclaw")
+	default:
+		return fmt.Errorf("skills: unknown provider %q", provider)
+	}
+
+	if err := imp.importDir(sourceDir, provider); err != nil {
+		return err
+	}
+
+	// Record this source for future syncs
+	return imp.recordSource(provider, sourceDir)
+}
+
+// Sync re-imports all tracked sources from .sources.json.
+func (imp *Importer) Sync() error {
+	data, err := os.ReadFile(imp.sourcesPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No sources file yet; nothing to sync
+			return nil
+		}
+		return fmt.Errorf("skills: read sources: %w", err)
+	}
+
+	var sources sourcesFile
+	if err := json.Unmarshal(data, &sources); err != nil {
+		return fmt.Errorf("skills: parse sources: %w", err)
+	}
+
+	for _, rec := range sources.Sources {
+		if strings.ToLower(rec.Provider) == "imported" {
+			// Re-import from specific path
+			if err := imp.Import(rec.Source); err != nil {
+				return fmt.Errorf("skills: sync %q: %w", rec.Source, err)
+			}
+		} else {
+			// Re-import from known provider
+			if err := imp.ImportFrom(rec.Provider); err != nil {
+				return fmt.Errorf("skills: sync provider %q: %w", rec.Provider, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// importDir recursively imports all skills from a directory.
+func (imp *Importer) importDir(dir string, provider string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("skills: read dir %q: %w", dir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.Name() == ".sources.json" {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		if entry.IsDir() {
+			// Recurse into subdirectories
+			if err := imp.importDir(path, provider); err != nil {
+				return err
+			}
+		} else if shouldImportFile(entry.Name()) {
+			if err := imp.importFile(path, provider); err != nil {
+				// Log error but continue with other files
+				fmt.Fprintf(os.Stderr, "warning: import %q: %v\n", path, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// importFile imports a single skill file.
+func (imp *Importer) importFile(path string, provider string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+
+	// Try each adapter in order until one succeeds
+	adapters := []Adapter{
+		NewHermesAdapter(),
+		NewOpenClawAdapter(),
+		NewCursorRulesAdapter(),
+		NewAgentsMDAdapter(),
+		NewMarkdownAdapter(),
+	}
+
+	var parseErr error
+
+	for _, adapter := range adapters {
+		if !adapter.CanHandle(path) {
+			continue
+		}
+
+		_, err := adapter.Parse(path, data, contracts.SkillTierImported)
+		if err == nil {
+			parseErr = nil
+			break
+		}
+		parseErr = err
+	}
+
+	if parseErr != nil {
+		return fmt.Errorf("no adapter could parse: %w", parseErr)
+	}
+
+	// Write the skill to the imported tier directory
+	// Use provider as a subdirectory to avoid conflicts
+	destDir := filepath.Join(imp.importedTierRoot, provider)
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+
+	// Preserve original filename
+	destPath := filepath.Join(destDir, filepath.Base(path))
+
+	if err := os.WriteFile(destPath, data, 0o644); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+
+	return nil
+}
+
+// recordSource adds or updates a source record in .sources.json.
+func (imp *Importer) recordSource(provider, source string) error {
+	var sources sourcesFile
+
+	// Read existing sources if available
+	if data, err := os.ReadFile(imp.sourcesPath); err == nil {
+		if err := json.Unmarshal(data, &sources); err != nil {
+			return fmt.Errorf("skills: parse sources: %w", err)
+		}
+	}
+
+	// Check if this source already exists and update it
+	found := false
+	now := time.Now()
+	for i, rec := range sources.Sources {
+		if rec.Provider == provider && rec.Source == source {
+			sources.Sources[i].LastSyncedAt = now
+			found = true
+			break
+		}
+	}
+
+	// Add new record if not found
+	if !found {
+		sources.Sources = append(sources.Sources, SourceRecord{
+			Provider:     provider,
+			Source:       source,
+			ImportedAt:   now,
+			LastSyncedAt: now,
+		})
+	}
+
+	// Write updated sources file
+	data, err := json.MarshalIndent(sources, "", "  ")
+	if err != nil {
+		return fmt.Errorf("skills: marshal sources: %w", err)
+	}
+
+	if err := os.WriteFile(imp.sourcesPath, data, 0o644); err != nil {
+		return fmt.Errorf("skills: write sources: %w", err)
+	}
+
+	return nil
+}
+
+// shouldImportFile determines if a file should be imported based on extension.
+func shouldImportFile(name string) bool {
+	ext := filepath.Ext(name)
+	base := filepath.Base(name)
+
+	// Check for known skill file types
+	switch {
+	case strings.EqualFold(ext, ".md"):
+		return true
+	case strings.EqualFold(base, ".cursorrules"):
+		return true
+	case strings.EqualFold(ext, ".mdc"):
+		return true
+	case strings.EqualFold(base, "SOUL.md"):
+		return true
+	case strings.EqualFold(base, "AGENTS.md"):
+		return true
+	case strings.EqualFold(base, "SKILL.md"):
+		return true
+	}
+
+	return false
+}

--- a/internal/skills/importer.go
+++ b/internal/skills/importer.go
@@ -39,9 +39,9 @@ func NewImporter(registry *Registry, importedTierRoot string) (*Importer, error)
 
 // SourceRecord tracks an imported skill source for later sync.
 type SourceRecord struct {
-	Provider string    `json:"provider"`
-	Source   string    `json:"source"`
-	ImportedAt time.Time `json:"imported_at"`
+	Provider     string    `json:"provider"`
+	Source       string    `json:"source"`
+	ImportedAt   time.Time `json:"imported_at"`
 	LastSyncedAt time.Time `json:"last_synced_at"`
 }
 

--- a/internal/skills/importer_test.go
+++ b/internal/skills/importer_test.go
@@ -1,0 +1,296 @@
+package skills
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestImporterImportsSingleFile(t *testing.T) {
+	sourceDir := t.TempDir()
+	importDir := t.TempDir()
+
+	// Create a source skill file
+	skillFile := filepath.Join(sourceDir, "my-skill.md")
+	skillBody := "---\nname: test-skill\ndescription: Test\n---\nBody content\n"
+	writeFile(t, skillFile, skillBody)
+
+	// Create a minimal registry (just need it to exist)
+	reg := &Registry{}
+
+	importer, err := NewImporter(reg, importDir)
+	if err != nil {
+		t.Fatalf("NewImporter: %v", err)
+	}
+
+	// Import the file
+	if err := importer.Import(skillFile); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	// Check that the file was copied to imported directory
+	expectedPath := filepath.Join(importDir, "imported", "my-skill.md")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Errorf("skill file not found at %q: %v", expectedPath, err)
+	}
+
+	// Verify content was copied
+	data, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("read imported file: %v", err)
+	}
+	if !strings.Contains(string(data), "Body content") {
+		t.Errorf("imported file content corrupted, got %q", string(data))
+	}
+}
+
+func TestImporterImportsDirectory(t *testing.T) {
+	sourceDir := t.TempDir()
+	importDir := t.TempDir()
+
+	// Create multiple skill files
+	skillsDir := filepath.Join(sourceDir, "skills")
+	os.MkdirAll(skillsDir, 0o755)
+
+	writeFile(t, filepath.Join(skillsDir, "skill1.md"), "---\nname: skill1\n---\nContent1")
+	writeFile(t, filepath.Join(skillsDir, "skill2.md"), "---\nname: skill2\n---\nContent2")
+
+	reg := &Registry{}
+	importer, err := NewImporter(reg, importDir)
+	if err != nil {
+		t.Fatalf("NewImporter: %v", err)
+	}
+
+	// Import the directory
+	if err := importer.Import(skillsDir); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	// Check both files were imported
+	path1 := filepath.Join(importDir, "imported", "skill1.md")
+	path2 := filepath.Join(importDir, "imported", "skill2.md")
+
+	if _, err := os.Stat(path1); err != nil {
+		t.Errorf("skill1 not found: %v", err)
+	}
+	if _, err := os.Stat(path2); err != nil {
+		t.Errorf("skill2 not found: %v", err)
+	}
+}
+
+func TestImporterRecordsSources(t *testing.T) {
+	sourceDir := t.TempDir()
+	importDir := t.TempDir()
+
+	skillFile := filepath.Join(sourceDir, "skill.md")
+	writeFile(t, skillFile, "---\nname: skill\n---\nBody")
+
+	reg := &Registry{}
+	importer, err := NewImporter(reg, importDir)
+	if err != nil {
+		t.Fatalf("NewImporter: %v", err)
+	}
+
+	// Import and record source
+	if err := importer.recordSource("test-provider", sourceDir); err != nil {
+		t.Fatalf("recordSource: %v", err)
+	}
+
+	// Check .sources.json was created
+	sourcesPath := filepath.Join(importDir, ".sources.json")
+	data, err := os.ReadFile(sourcesPath)
+	if err != nil {
+		t.Fatalf("read sources: %v", err)
+	}
+
+	var sources sourcesFile
+	if err := json.Unmarshal(data, &sources); err != nil {
+		t.Fatalf("unmarshal sources: %v", err)
+	}
+
+	if len(sources.Sources) != 1 {
+		t.Errorf("expected 1 source, got %d", len(sources.Sources))
+	}
+
+	rec := sources.Sources[0]
+	if rec.Provider != "test-provider" {
+		t.Errorf("provider: got %q want test-provider", rec.Provider)
+	}
+	if rec.Source != sourceDir {
+		t.Errorf("source: got %q want %q", rec.Source, sourceDir)
+	}
+}
+
+func TestImporterSync(t *testing.T) {
+	sourceDir := t.TempDir()
+	importDir := t.TempDir()
+
+	// Create initial skill file
+	skillFile := filepath.Join(sourceDir, "skill.md")
+	writeFile(t, skillFile, "---\nname: original\n---\nOriginal body")
+
+	reg := &Registry{}
+	importer, err := NewImporter(reg, importDir)
+	if err != nil {
+		t.Fatalf("NewImporter: %v", err)
+	}
+
+	// First import
+	if err := importer.Import(skillFile); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	// Record source
+	if err := importer.recordSource("imported", sourceDir); err != nil {
+		t.Fatalf("recordSource: %v", err)
+	}
+
+	// Update the source file
+	updatedBody := "---\nname: updated\n---\nUpdated body"
+	if err := os.WriteFile(skillFile, []byte(updatedBody), 0o644); err != nil {
+		t.Fatalf("write updated skill: %v", err)
+	}
+
+	// Sync should re-import updated file
+	if err := importer.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// Check that imported file was updated
+	importedPath := filepath.Join(importDir, "imported", "skill.md")
+	data, err := os.ReadFile(importedPath)
+	if err != nil {
+		t.Fatalf("read imported skill: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "Updated body") {
+		t.Errorf("expected updated content, got %q", content)
+	}
+}
+
+func TestImporterSyncWithoutSourcesFile(t *testing.T) {
+	importDir := t.TempDir()
+
+	reg := &Registry{}
+	importer, err := NewImporter(reg, importDir)
+	if err != nil {
+		t.Fatalf("NewImporter: %v", err)
+	}
+
+	// Sync when no sources file exists should not error
+	if err := importer.Sync(); err != nil {
+		t.Errorf("Sync with no sources: %v", err)
+	}
+}
+
+func TestImporterSkipsUnsupportedFiles(t *testing.T) {
+	sourceDir := t.TempDir()
+	importDir := t.TempDir()
+
+	// Create mixed file types
+	writeFile(t, filepath.Join(sourceDir, "skill.md"), "---\nname: skill\n---\nBody")
+	writeFile(t, filepath.Join(sourceDir, "readme.txt"), "Just some text")
+	writeFile(t, filepath.Join(sourceDir, ".gitignore"), "*.tmp")
+
+	reg := &Registry{}
+	importer, err := NewImporter(reg, importDir)
+	if err != nil {
+		t.Fatalf("NewImporter: %v", err)
+	}
+
+	// Import directory
+	if err := importer.importDir(sourceDir, "test"); err != nil {
+		t.Fatalf("importDir: %v", err)
+	}
+
+	// Only skill.md should have been imported
+	skillPath := filepath.Join(importDir, "test", "skill.md")
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Errorf("skill.md not found: %v", err)
+	}
+
+	txtPath := filepath.Join(importDir, "test", "readme.txt")
+	if _, err := os.Stat(txtPath); err == nil {
+		t.Errorf("readme.txt should not have been imported")
+	}
+}
+
+func TestShouldImportFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		expected bool
+	}{
+		{"markdown", "skill.md", true},
+		{"skill", "SKILL.md", true},
+		{"cursor rules", ".cursorrules", true},
+		{"cursor rules in folder", ".cursor/rules/style.mdc", true},
+		{"mdc file", "custom.mdc", true},
+		{"openclaw soul", "SOUL.md", true},
+		{"agents file", "AGENTS.md", true},
+		{"text file", "readme.txt", false},
+		{"python file", "script.py", false},
+		{"json file", "config.json", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldImportFile(tt.filename)
+			if result != tt.expected {
+				t.Errorf("shouldImportFile(%q): got %v want %v", tt.filename, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestImporterUpdatesSyncTime(t *testing.T) {
+	sourceDir := t.TempDir()
+	importDir := t.TempDir()
+
+	reg := &Registry{}
+	importer, err := NewImporter(reg, importDir)
+	if err != nil {
+		t.Fatalf("NewImporter: %v", err)
+	}
+
+	// Record source twice
+	if err := importer.recordSource("provider", sourceDir); err != nil {
+		t.Fatalf("first recordSource: %v", err)
+	}
+
+	firstTime := time.Now()
+	time.Sleep(10 * time.Millisecond)
+
+	if err := importer.recordSource("provider", sourceDir); err != nil {
+		t.Fatalf("second recordSource: %v", err)
+	}
+
+	// Read sources and verify LastSyncedAt was updated
+	data, err := os.ReadFile(filepath.Join(importDir, ".sources.json"))
+	if err != nil {
+		t.Fatalf("read sources: %v", err)
+	}
+
+	var sources sourcesFile
+	if err := json.Unmarshal(data, &sources); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(sources.Sources) != 1 {
+		t.Fatalf("expected 1 source, got %d", len(sources.Sources))
+	}
+
+	// LastSyncedAt should be after firstTime
+	if sources.Sources[0].LastSyncedAt.Before(firstTime) {
+		t.Errorf("LastSyncedAt not updated")
+	}
+
+	// ImportedAt should not have changed
+	if sources.Sources[0].ImportedAt.After(sources.Sources[0].LastSyncedAt) {
+		t.Errorf("ImportedAt should not change on re-record")
+	}
+}


### PR DESCRIPTION
Add adapters for Hermes, OpenClaw SOUL.md, Cursor rules, and AGENTS.md skill formats. Each adapter implements the existing Adapter interface with format-specific detection and parsing.

- HermesAdapter: parses YAML frontmatter with platforms: field
- OpenClawAdapter: extracts persona/role/instructions sections from SOUL.md
- CursorRulesAdapter: handles .cursorrules and .mdc files
- AgentsMDAdapter: treats AGENTS.md as repo-level instruction files
- Importer: import skills from files, directories, or known providers (--from hermes, --from openclaw) with source tracking and sync
- CLI: conduit skills import | sync commands wired up

Closes #52