### PR TITLE
feat(#64): custom agent profiles

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -97,6 +97,12 @@ func main() {
 				os.Exit(1)
 			}
 			return
+		case "agents", "agents-create", "agents-update", "agents-delete":
+			if err := runAgentsCLI(os.Args[1], os.Args[2:], os.Stdout, os.Stderr); err != nil {
+				fmt.Fprintf(os.Stderr, "conduit %s: %v\n", os.Args[1], err)
+				os.Exit(1)
+			}
+			return
 		}
 	}
 
@@ -414,5 +420,188 @@ func runSessionsCLI(args []string, stdout, stderr *os.File) error {
 		return err
 	}
 	sessions.WriteResult(stdout, res)
+	return nil
+}
+
+// runAgentsCLI handles the four agent-profile commands:
+//
+//	conduit agents                     — list all resolved profiles
+//	conduit agents-create [flags]      — create a new profile
+//	conduit agents-update [flags]      — update an existing profile
+//	conduit agents-delete <name>       — delete a profile
+//
+// Profile directories follow the same two-level hierarchy as config:
+// ~/.conduit/agents/ (user-global) and .conduit/agents/ (project-local).
+// Project profiles override user profiles by name.
+func runAgentsCLI(cmd string, args []string, stdout, stderr *os.File) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home dir: %w", err)
+	}
+	workspace, err := os.Getwd()
+	if err != nil {
+		workspace = ""
+	}
+	userDir, projectDir := coding.DefaultAgentProfileDirs(home, workspace)
+
+	switch cmd {
+	case "agents":
+		return runAgentsList(userDir, projectDir, stdout, stderr)
+	case "agents-create":
+		return runAgentsCreate(args, userDir, projectDir, stdout, stderr)
+	case "agents-update":
+		return runAgentsUpdate(args, userDir, projectDir, stdout, stderr)
+	case "agents-delete":
+		return runAgentsDelete(args, userDir, projectDir, stdout, stderr)
+	default:
+		return fmt.Errorf("unknown agents command %q", cmd)
+	}
+}
+
+func runAgentsList(userDir, projectDir string, stdout, stderr *os.File) error {
+	profiles, err := coding.LoadProfiles(userDir, projectDir)
+	if err != nil {
+		return err
+	}
+	if len(profiles) == 0 {
+		fmt.Fprintln(stderr, "no agent profiles found")
+		fmt.Fprintf(stderr, "  user profiles:    %s\n", userDir)
+		fmt.Fprintf(stderr, "  project profiles: %s\n", projectDir)
+		return nil
+	}
+	for _, p := range profiles {
+		fmt.Fprintf(stdout, "%s\t[%s]\t%s\n", p.Name, p.Source, truncate(p.Description, 60))
+	}
+	return nil
+}
+
+func runAgentsCreate(args []string, userDir, projectDir string, stdout, stderr *os.File) error {
+	fs := flag.NewFlagSet("conduit agents-create", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	name := fs.String("name", "", "agent name (required)")
+	description := fs.String("description", "", "what this agent does")
+	model := fs.String("model", "", "model override (e.g. claude-sonnet-4-6)")
+	toolsFlag := fs.String("tools", "", "comma-separated tool allowlist")
+	initialPrompt := fs.String("initial-prompt", "", "system prompt prefix")
+	project := fs.Bool("project", false, "write to project dir (.conduit/agents/) instead of user dir")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *name == "" {
+		return fmt.Errorf("--name is required")
+	}
+
+	targetDir := userDir
+	if *project {
+		targetDir = projectDir
+	}
+
+	var tools []string
+	if *toolsFlag != "" {
+		for _, t := range strings.Split(*toolsFlag, ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				tools = append(tools, t)
+			}
+		}
+	}
+
+	p := coding.AgentProfile{
+		Name:          *name,
+		Description:   *description,
+		Model:         *model,
+		Tools:         tools,
+		InitialPrompt: *initialPrompt,
+	}
+	if err := coding.WriteProfile(targetDir, p); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "created agent profile %q in %s\n", p.Name, targetDir)
+	return nil
+}
+
+func runAgentsUpdate(args []string, userDir, projectDir string, stdout, stderr *os.File) error {
+	fs := flag.NewFlagSet("conduit agents-update", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	name := fs.String("name", "", "agent name to update (required)")
+	description := fs.String("description", "", "new description")
+	model := fs.String("model", "", "new model override")
+	toolsFlag := fs.String("tools", "", "new comma-separated tool allowlist")
+	initialPrompt := fs.String("initial-prompt", "", "new system prompt prefix")
+	project := fs.Bool("project", false, "update in project dir; default is user dir")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *name == "" {
+		return fmt.Errorf("--name is required")
+	}
+
+	// Load existing profiles so we can merge rather than overwrite with zeros.
+	profiles, err := coding.LoadProfiles(userDir, projectDir)
+	if err != nil {
+		return err
+	}
+	var existing *coding.AgentProfile
+	for i := range profiles {
+		if profiles[i].Name == *name {
+			existing = &profiles[i]
+			break
+		}
+	}
+	if existing == nil {
+		return fmt.Errorf("agent profile %q not found", *name)
+	}
+
+	if *description != "" {
+		existing.Description = *description
+	}
+	if *model != "" {
+		existing.Model = *model
+	}
+	if *toolsFlag != "" {
+		var tools []string
+		for _, t := range strings.Split(*toolsFlag, ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				tools = append(tools, t)
+			}
+		}
+		existing.Tools = tools
+	}
+	if *initialPrompt != "" {
+		existing.InitialPrompt = *initialPrompt
+	}
+
+	targetDir := userDir
+	if *project {
+		targetDir = projectDir
+	}
+	if err := coding.WriteProfile(targetDir, *existing); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "updated agent profile %q in %s\n", *name, targetDir)
+	return nil
+}
+
+func runAgentsDelete(args []string, userDir, projectDir string, stdout, stderr *os.File) error {
+	fs := flag.NewFlagSet("conduit agents-delete", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	project := fs.Bool("project", false, "delete from project dir; default is user dir")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if len(fs.Args()) == 0 {
+		return fmt.Errorf("usage: conduit agents-delete [--project] <name>")
+	}
+	name := fs.Args()[0]
+
+	targetDir := userDir
+	if *project {
+		targetDir = projectDir
+	}
+	if err := coding.DeleteProfile(targetDir, name); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "deleted agent profile %q from %s\n", name, targetDir)
 	return nil
 }

--- a/internal/coding/profiles.go
+++ b/internal/coding/profiles.go
@@ -1,0 +1,267 @@
+// Package coding contains the coding agent REPL and related types.
+package coding
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// AgentProfileSource identifies whether a profile came from the user-global
+// or project-local directory. Project profiles shadow user profiles of the
+// same name.
+type AgentProfileSource string
+
+const (
+	AgentProfileSourceUser    AgentProfileSource = "user"
+	AgentProfileSourceProject AgentProfileSource = "project"
+)
+
+// AgentProfile is a named agent persona loaded from a markdown file with
+// YAML frontmatter. Profiles live at ~/.conduit/agents/*.md (user-global)
+// and .conduit/agents/*.md (project-local). Project profiles override user
+// profiles by name.
+type AgentProfile struct {
+	// Name is the unique identifier. Derived from frontmatter; falls back
+	// to the filename stem when the frontmatter field is absent.
+	Name string
+
+	// Description explains what the agent does (frontmatter or body text).
+	Description string
+
+	// Model overrides the active provider model for this agent. Empty means
+	// use the session default.
+	Model string
+
+	// Tools is the explicit allowlist of tool names for this agent. Nil means
+	// inherit all tools registered for the session.
+	Tools []string
+
+	// InitialPrompt is prepended to the first user turn as a system prefix.
+	InitialPrompt string
+
+	// Source records whether this profile came from the user or project dir.
+	Source AgentProfileSource
+
+	// Path is the absolute filesystem path of the source .md file.
+	Path string
+}
+
+// profileFrontmatter is the YAML header parsed from an agent profile .md file.
+type profileFrontmatter struct {
+	Name          string   `yaml:"name"`
+	Description   string   `yaml:"description"`
+	Model         string   `yaml:"model"`
+	Tools         []string `yaml:"tools"`
+	InitialPrompt string   `yaml:"initialPrompt"`
+}
+
+// DefaultAgentProfileDirs returns the canonical user and project agent
+// profile directories for the given home and workspace paths.
+func DefaultAgentProfileDirs(home, workspace string) (userDir, projectDir string) {
+	if home != "" {
+		userDir = filepath.Join(home, ".conduit", "agents")
+	}
+	if workspace != "" {
+		projectDir = filepath.Join(workspace, ".conduit", "agents")
+	}
+	return userDir, projectDir
+}
+
+// LoadProfiles reads all *.md agent profiles from userDir and projectDir.
+// Project profiles override user profiles with the same name. Either
+// directory may be absent; missing directories are silently skipped.
+func LoadProfiles(userDir, projectDir string) ([]AgentProfile, error) {
+	byName := make(map[string]AgentProfile)
+
+	for _, entry := range []struct {
+		dir    string
+		source AgentProfileSource
+	}{
+		{userDir, AgentProfileSourceUser},
+		{projectDir, AgentProfileSourceProject},
+	} {
+		if entry.dir == "" {
+			continue
+		}
+		profiles, err := loadProfileDir(entry.dir, entry.source)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range profiles {
+			byName[p.Name] = p
+		}
+	}
+
+	out := make([]AgentProfile, 0, len(byName))
+	for _, p := range byName {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// loadProfileDir reads every *.md file in dir and parses it as an AgentProfile.
+func loadProfileDir(dir string, source AgentProfileSource) ([]AgentProfile, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("agents: stat %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("agents: read dir %q: %w", dir, err)
+	}
+
+	var profiles []AgentProfile
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if !strings.EqualFold(filepath.Ext(e.Name()), ".md") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("agents: read %q: %w", path, err)
+		}
+		p, err := parseProfile(path, data, source)
+		if err != nil {
+			// Skip unparseable files rather than aborting the sweep.
+			continue
+		}
+		profiles = append(profiles, p)
+	}
+	return profiles, nil
+}
+
+// parseProfile converts raw .md bytes into an AgentProfile.
+func parseProfile(path string, data []byte, source AgentProfileSource) (AgentProfile, error) {
+	front, body, err := splitProfileFrontmatter(data)
+	if err != nil {
+		return AgentProfile{}, fmt.Errorf("agents: parse %q: %w", path, err)
+	}
+
+	name := strings.TrimSpace(front.Name)
+	if name == "" {
+		base := filepath.Base(path)
+		name = strings.TrimSuffix(base, filepath.Ext(base))
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return AgentProfile{}, fmt.Errorf("agents: %q has no usable name", path)
+	}
+
+	desc := strings.TrimSpace(front.Description)
+	if desc == "" {
+		desc = strings.TrimSpace(body)
+	}
+
+	return AgentProfile{
+		Name:          name,
+		Description:   desc,
+		Model:         strings.TrimSpace(front.Model),
+		Tools:         front.Tools,
+		InitialPrompt: strings.TrimSpace(front.InitialPrompt),
+		Source:        source,
+		Path:          path,
+	}, nil
+}
+
+// splitProfileFrontmatter extracts the YAML header and body from a .md file.
+// Returns zero-value frontmatter and the raw content when no --- fence is found.
+func splitProfileFrontmatter(data []byte) (profileFrontmatter, string, error) {
+	normalised := bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	if !bytes.HasPrefix(normalised, []byte("---\n")) {
+		return profileFrontmatter{}, string(normalised), nil
+	}
+
+	rest := normalised[len("---\n"):]
+	end := bytes.Index(rest, []byte("\n---"))
+	if end < 0 {
+		return profileFrontmatter{}, string(normalised), nil
+	}
+	header := rest[:end]
+	body := rest[end+len("\n---"):]
+	body = bytes.TrimPrefix(body, []byte("\n"))
+
+	var front profileFrontmatter
+	if len(bytes.TrimSpace(header)) > 0 {
+		if err := yaml.Unmarshal(header, &front); err != nil {
+			return profileFrontmatter{}, "", err
+		}
+	}
+	return front, string(body), nil
+}
+
+// WriteProfile serialises an AgentProfile to a .md file in the target directory,
+// creating the directory if needed. The filename is derived from the profile name.
+func WriteProfile(dir string, p AgentProfile) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("agents: mkdir %q: %w", dir, err)
+	}
+
+	front := profileFrontmatter{
+		Name:          p.Name,
+		Description:   p.Description,
+		Model:         p.Model,
+		Tools:         p.Tools,
+		InitialPrompt: p.InitialPrompt,
+	}
+	frontBytes, err := yaml.Marshal(front)
+	if err != nil {
+		return fmt.Errorf("agents: marshal frontmatter: %w", err)
+	}
+
+	content := "---\n" + string(frontBytes) + "---\n"
+
+	filename := sanitiseProfileName(p.Name) + ".md"
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("agents: write %q: %w", path, err)
+	}
+	return nil
+}
+
+// DeleteProfile removes the .md file for the named profile from dir.
+// Returns an error if the file does not exist.
+func DeleteProfile(dir, name string) error {
+	filename := sanitiseProfileName(name) + ".md"
+	path := filepath.Join(dir, filename)
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("agents: profile %q not found in %s", name, dir)
+		}
+		return fmt.Errorf("agents: delete %q: %w", path, err)
+	}
+	return nil
+}
+
+// sanitiseProfileName converts a profile name to a safe filename stem.
+func sanitiseProfileName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			b.WriteRune(r)
+		case r == ' ' || r == '_':
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}

--- a/internal/coding/profiles_test.go
+++ b/internal/coding/profiles_test.go
@@ -1,0 +1,246 @@
+package coding_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/coding"
+)
+
+// writeFile is a test helper that writes content to path, creating parent dirs.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %q: %v", path, err)
+	}
+}
+
+const validProfile = `---
+name: test-agent
+description: A test coding agent
+model: claude-sonnet-4-6
+tools:
+  - bash
+  - edit
+initialPrompt: |
+  You are a focused coding assistant.
+---
+Additional body text.
+`
+
+func TestAgentProfileLoad_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "test-agent.md"), validProfile)
+
+	profiles, err := coding.LoadProfiles(dir, "")
+	if err != nil {
+		t.Fatalf("LoadProfiles: %v", err)
+	}
+	if len(profiles) != 1 {
+		t.Fatalf("want 1 profile, got %d", len(profiles))
+	}
+	p := profiles[0]
+	if p.Name != "test-agent" {
+		t.Errorf("Name = %q, want %q", p.Name, "test-agent")
+	}
+	if p.Description != "A test coding agent" {
+		t.Errorf("Description = %q, want %q", p.Description, "A test coding agent")
+	}
+	if p.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model = %q, want %q", p.Model, "claude-sonnet-4-6")
+	}
+	if len(p.Tools) != 2 || p.Tools[0] != "bash" || p.Tools[1] != "edit" {
+		t.Errorf("Tools = %v, want [bash edit]", p.Tools)
+	}
+	if p.Source != coding.AgentProfileSourceUser {
+		t.Errorf("Source = %q, want %q", p.Source, coding.AgentProfileSourceUser)
+	}
+}
+
+func TestAgentProfileLoad_FallbackNameFromFilename(t *testing.T) {
+	dir := t.TempDir()
+	// No frontmatter name — should fall back to filename stem.
+	writeFile(t, filepath.Join(dir, "my-agent.md"), "---\ndescription: no name field\n---\n")
+
+	profiles, err := coding.LoadProfiles(dir, "")
+	if err != nil {
+		t.Fatalf("LoadProfiles: %v", err)
+	}
+	if len(profiles) != 1 {
+		t.Fatalf("want 1 profile, got %d", len(profiles))
+	}
+	if profiles[0].Name != "my-agent" {
+		t.Errorf("Name = %q, want %q", profiles[0].Name, "my-agent")
+	}
+}
+
+func TestAgentProfileLoad_NoFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "plain.md"), "Just plain markdown body text.\n")
+
+	profiles, err := coding.LoadProfiles(dir, "")
+	if err != nil {
+		t.Fatalf("LoadProfiles: %v", err)
+	}
+	if len(profiles) != 1 {
+		t.Fatalf("want 1 profile, got %d", len(profiles))
+	}
+	p := profiles[0]
+	if p.Name != "plain" {
+		t.Errorf("Name = %q, want %q", p.Name, "plain")
+	}
+	if p.Description != "Just plain markdown body text." {
+		t.Errorf("Description = %q", p.Description)
+	}
+}
+
+func TestAgentProfileLoad_ProjectOverridesUser(t *testing.T) {
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	// User has a profile with model=claude-haiku-4-5.
+	writeFile(t, filepath.Join(userDir, "reviewer.md"), `---
+name: reviewer
+model: claude-haiku-4-5
+description: user version
+---
+`)
+	// Project overrides same name with model=claude-opus-4-7.
+	writeFile(t, filepath.Join(projectDir, "reviewer.md"), `---
+name: reviewer
+model: claude-opus-4-7
+description: project version
+---
+`)
+
+	profiles, err := coding.LoadProfiles(userDir, projectDir)
+	if err != nil {
+		t.Fatalf("LoadProfiles: %v", err)
+	}
+	if len(profiles) != 1 {
+		t.Fatalf("want 1 profile (project wins), got %d", len(profiles))
+	}
+	p := profiles[0]
+	if p.Model != "claude-opus-4-7" {
+		t.Errorf("Model = %q, want project override %q", p.Model, "claude-opus-4-7")
+	}
+	if p.Source != coding.AgentProfileSourceProject {
+		t.Errorf("Source = %q, want %q", p.Source, coding.AgentProfileSourceProject)
+	}
+}
+
+func TestAgentProfileLoad_UserAndProjectCoexist(t *testing.T) {
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	writeFile(t, filepath.Join(userDir, "agent-a.md"), "---\nname: agent-a\n---\n")
+	writeFile(t, filepath.Join(projectDir, "agent-b.md"), "---\nname: agent-b\n---\n")
+
+	profiles, err := coding.LoadProfiles(userDir, projectDir)
+	if err != nil {
+		t.Fatalf("LoadProfiles: %v", err)
+	}
+	if len(profiles) != 2 {
+		t.Fatalf("want 2 profiles, got %d", len(profiles))
+	}
+	// Results are alphabetical.
+	if profiles[0].Name != "agent-a" || profiles[1].Name != "agent-b" {
+		t.Errorf("unexpected order: %q %q", profiles[0].Name, profiles[1].Name)
+	}
+}
+
+func TestAgentProfileLoad_MissingDirs(t *testing.T) {
+	profiles, err := coding.LoadProfiles("/no/such/user/dir", "/no/such/project/dir")
+	if err != nil {
+		t.Fatalf("LoadProfiles with missing dirs should not error: %v", err)
+	}
+	if len(profiles) != 0 {
+		t.Errorf("want 0 profiles from missing dirs, got %d", len(profiles))
+	}
+}
+
+func TestAgentProfileLoad_EmptyDirs(t *testing.T) {
+	userDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	profiles, err := coding.LoadProfiles(userDir, projectDir)
+	if err != nil {
+		t.Fatalf("LoadProfiles: %v", err)
+	}
+	if len(profiles) != 0 {
+		t.Errorf("want 0 profiles from empty dirs, got %d", len(profiles))
+	}
+}
+
+func TestAgentProfileLoad_NonMdFilesIgnored(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "agent.md"), "---\nname: good-agent\n---\n")
+	writeFile(t, filepath.Join(dir, "config.yaml"), "name: not-an-agent\n")
+	writeFile(t, filepath.Join(dir, "README.txt"), "some text")
+
+	profiles, err := coding.LoadProfiles(dir, "")
+	if err != nil {
+		t.Fatalf("LoadProfiles: %v", err)
+	}
+	if len(profiles) != 1 {
+		t.Fatalf("want 1 profile (only .md), got %d", len(profiles))
+	}
+}
+
+func TestWriteAndDeleteProfile(t *testing.T) {
+	dir := t.TempDir()
+	p := coding.AgentProfile{
+		Name:          "write-test",
+		Description:   "A roundtrip test agent",
+		Model:         "claude-sonnet-4-6",
+		Tools:         []string{"read", "bash"},
+		InitialPrompt: "Be concise.",
+	}
+
+	if err := coding.WriteProfile(dir, p); err != nil {
+		t.Fatalf("WriteProfile: %v", err)
+	}
+
+	// Reload and verify.
+	profiles, err := coding.LoadProfiles(dir, "")
+	if err != nil {
+		t.Fatalf("LoadProfiles after write: %v", err)
+	}
+	if len(profiles) != 1 {
+		t.Fatalf("want 1 profile, got %d", len(profiles))
+	}
+	got := profiles[0]
+	if got.Name != p.Name {
+		t.Errorf("Name = %q, want %q", got.Name, p.Name)
+	}
+	if got.Model != p.Model {
+		t.Errorf("Model = %q, want %q", got.Model, p.Model)
+	}
+	if got.InitialPrompt != p.InitialPrompt {
+		t.Errorf("InitialPrompt = %q, want %q", got.InitialPrompt, p.InitialPrompt)
+	}
+
+	// Delete and verify gone.
+	if err := coding.DeleteProfile(dir, p.Name); err != nil {
+		t.Fatalf("DeleteProfile: %v", err)
+	}
+	profiles, err = coding.LoadProfiles(dir, "")
+	if err != nil {
+		t.Fatalf("LoadProfiles after delete: %v", err)
+	}
+	if len(profiles) != 0 {
+		t.Errorf("want 0 profiles after delete, got %d", len(profiles))
+	}
+}
+
+func TestDeleteProfile_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	err := coding.DeleteProfile(dir, "nonexistent")
+	if err == nil {
+		t.Error("DeleteProfile of nonexistent profile should return error")
+	}
+}


### PR DESCRIPTION
## Summary

Implements custom agent profiles as defined in PRD §6.24.7.

- `internal/coding/profiles.go` — `AgentProfile` struct, two-level loader (user-global + project-local), write/delete helpers
- `internal/coding/profiles_test.go` — 10 unit tests covering load, override, write/delete, and edge cases
- `cmd/conduit/main.go` — four new CLI subcommands wired into the existing switch dispatcher

## Profile format

Markdown files with YAML frontmatter at `~/.conduit/agents/*.md` (user) or `.conduit/agents/*.md` (project). Project profiles override user profiles by name.

```markdown
---
name: my-agent
description: A helpful coding agent
model: claude-sonnet-4-6
tools:
  - bash
  - edit
  - read
initialPrompt: |
  You are a focused coding assistant. Keep responses concise.
---
Additional description body (optional).
```

## CLI commands

| Command | Description |
|---|---|
| `conduit agents` | List all resolved profiles (user + project, project wins) |
| `conduit agents-create --name <n> [--model <m>] [--tools <t1,t2>] [--initial-prompt <p>] [--project]` | Create a new profile |
| `conduit agents-update --name <n> [flags] [--project]` | Update an existing profile |
| `conduit agents-delete [--project] <name>` | Delete a profile |

## Test coverage

- Loading a valid profile from a `.md` file
- Fallback name from filename stem when frontmatter `name` is absent
- Profiles with no frontmatter (body becomes description)
- Project profile overrides user profile of same name
- User and project profiles with different names coexist
- Missing directories are silently skipped (no error)
- Empty directories return zero profiles
- Non-`.md` files in the agents directory are ignored
- `WriteProfile` + `LoadProfiles` round-trip
- `DeleteProfile` returns an error when profile is not found

Closes #64