### PR TITLE
feat(#141): web search tool (cached / live / disabled)

### DIFF
--- a/internal/coding/tier.go
+++ b/internal/coding/tier.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jabreeflor/conduit/internal/contracts"
 	"github.com/jabreeflor/conduit/internal/tools"
+	"github.com/jabreeflor/conduit/internal/tools/websearch"
 )
 
 // TieredTool wraps a tools.Tool with the coding tier that controls whether
@@ -45,28 +46,30 @@ func RegisterCodingTools(base []TieredTool, perms contracts.CodingPermissions) [
 	return out
 }
 
-// DefaultCodingTools returns the PRD §6.24.4 coding tool set as stubs.
-// Real runners arrive in follow-up PRs; the stub layer exists so the tier
-// gating, REPL wiring, and pipeline integration can be exercised end-to-end
-// without blocking on per-tool implementation work.
+// DefaultCodingTools returns the PRD §6.24.4 coding tool set.
+// web_search is fully implemented (PRD §6.25.7); remaining tools are stubs
+// whose real runners arrive in follow-up PRs.
 func DefaultCodingTools() []TieredTool {
-	always := []string{
+	alwaysStubs := []string{
 		"list_dir",
 		"read_file",
 		"glob_search",
 		"grep_search",
 		"web_fetch",
-		"web_search",
 		"tool_search",
 		"sleep",
 	}
 	requiresWrite := []string{"write_file", "edit_file", "notebook_edit"}
 	requiresShell := []string{"bash"}
 
-	out := make([]TieredTool, 0, len(always)+len(requiresWrite)+len(requiresShell))
-	for _, name := range always {
+	out := make([]TieredTool, 0, len(alwaysStubs)+1+len(requiresWrite)+len(requiresShell))
+	for _, name := range alwaysStubs {
 		out = append(out, newStubTool(name, contracts.CodingTierAlways))
 	}
+	out = append(out, TieredTool{
+		Tool: websearch.New(websearch.DefaultConfig()),
+		Tier: contracts.CodingTierAlways,
+	})
 	for _, name := range requiresWrite {
 		out = append(out, newStubTool(name, contracts.CodingTierRequiresWrite))
 	}
@@ -74,6 +77,19 @@ func DefaultCodingTools() []TieredTool {
 		out = append(out, newStubTool(name, contracts.CodingTierRequiresShell))
 	}
 	return out
+}
+
+// DefaultCodingToolsWithConfig returns DefaultCodingTools with the web_search
+// tool configured from cfg instead of the package defaults.
+func DefaultCodingToolsWithConfig(wsCfg websearch.Config) []TieredTool {
+	tools := DefaultCodingTools()
+	for i, t := range tools {
+		if t.Tool.Name == "web_search" {
+			tools[i].Tool = websearch.New(wsCfg)
+			break
+		}
+	}
+	return tools
 }
 
 func newStubTool(name string, tier contracts.CodingTier) TieredTool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,18 @@ type Config struct {
 	Costs       CostConfig                     `yaml:"costs"`
 	Credentials map[string]ProviderCredentials `yaml:"credentials"`
 	ComputerUse ComputerUseConfig              `yaml:"computer_use"`
+	WebSearch   WebSearchConfig                `yaml:"web_search"`
+}
+
+// WebSearchConfig controls the built-in web search tool (PRD §6.25.7).
+type WebSearchConfig struct {
+	// Mode is "cached" (default), "live", or "disabled".
+	Mode string `yaml:"mode"`
+	// CacheDir overrides the default ~/.conduit/cache/websearch/ path.
+	CacheDir string `yaml:"cache_dir,omitempty"`
+	// BodyLimit caps response body bytes retained per result. Zero means the
+	// package default (8192).
+	BodyLimit int `yaml:"body_limit,omitempty"`
 }
 
 // ComputerUseConfig controls the open-codex-computer-use MCP integration

--- a/internal/tools/websearch/websearch.go
+++ b/internal/tools/websearch/websearch.go
@@ -1,0 +1,296 @@
+// Package websearch implements the built-in web search tool (PRD §6.25.7).
+//
+// Three operating modes:
+//   - Cached (default): results are fetched once and stored in
+//     ~/.conduit/cache/websearch/ keyed by SHA256 of the URL.
+//   - Live: every call fetches fresh content from the network.
+//   - Disabled: every call returns an error — useful for offline sessions.
+//
+// Only GET, HEAD, and OPTIONS HTTP methods are permitted. POST, PUT, and
+// DELETE are blocked unconditionally.
+package websearch
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/tools"
+)
+
+// Mode controls whether results come from the local cache, the live network,
+// or are disabled entirely.
+type Mode string
+
+const (
+	ModeCached   Mode = "cached"
+	ModeLive     Mode = "live"
+	ModeDisabled Mode = "disabled"
+)
+
+// Config holds the web search tool's runtime configuration.
+type Config struct {
+	// Mode is "cached" (default), "live", or "disabled".
+	Mode Mode
+	// CacheDir overrides the default ~/.conduit/cache/websearch/ location.
+	CacheDir string
+	// BodyLimit caps the number of bytes kept from the response body.
+	// Zero means the package default (8192).
+	BodyLimit int
+}
+
+// Result is the structured output from one web search call.
+type Result struct {
+	URL     string `json:"url"`
+	Title   string `json:"title"`
+	Snippet string `json:"snippet"`
+	Body    string `json:"body"`
+}
+
+// input is the JSON schema for the tool's call arguments.
+type input struct {
+	URL    string `json:"url"`
+	Method string `json:"method,omitempty"`
+}
+
+const (
+	defaultBodyLimit  = 8192
+	snippetLimit      = 500
+	cacheFileExt      = ".json"
+	httpClientTimeout = 15 * time.Second
+)
+
+// blockedMethods are HTTP methods the tool refuses to issue.
+var blockedMethods = map[string]bool{
+	http.MethodPost:   true,
+	http.MethodPut:    true,
+	http.MethodDelete: true,
+	http.MethodPatch:  true,
+}
+
+// New returns a tools.Tool backed by the web search implementation.
+// cfg is applied as-is; call DefaultConfig() to obtain a config with
+// sensible defaults already set.
+func New(cfg Config) tools.Tool {
+	ws := &webSearch{cfg: applyDefaults(cfg)}
+	return tools.Tool{
+		Name:        "web_search",
+		Description: "Fetch content from a URL. Cached mode returns stored results; live always fetches fresh; disabled returns an error. Only GET, HEAD, and OPTIONS are permitted.",
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"url": map[string]any{
+					"type":        "string",
+					"description": "The URL to fetch.",
+				},
+				"method": map[string]any{
+					"type":        "string",
+					"description": "HTTP method: GET (default), HEAD, or OPTIONS.",
+					"enum":        []string{"GET", "HEAD", "OPTIONS"},
+				},
+			},
+			"required": []string{"url"},
+		},
+		Run: ws.run,
+	}
+}
+
+// DefaultConfig returns a Config with the package defaults applied.
+func DefaultConfig() Config {
+	return applyDefaults(Config{})
+}
+
+func applyDefaults(cfg Config) Config {
+	if cfg.Mode == "" {
+		cfg.Mode = ModeCached
+	}
+	if cfg.BodyLimit == 0 {
+		cfg.BodyLimit = defaultBodyLimit
+	}
+	if cfg.CacheDir == "" {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			cfg.CacheDir = filepath.Join(home, ".conduit", "cache", "websearch")
+		}
+	}
+	return cfg
+}
+
+type webSearch struct {
+	cfg Config
+}
+
+func (ws *webSearch) run(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+	var in input
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return tools.Result{IsError: true, Text: fmt.Sprintf("invalid input: %v", err)}, nil
+	}
+	if in.URL == "" {
+		return tools.Result{IsError: true, Text: "url is required"}, nil
+	}
+	if in.Method == "" {
+		in.Method = http.MethodGet
+	}
+	in.Method = strings.ToUpper(in.Method)
+
+	if blockedMethods[in.Method] {
+		return tools.Result{IsError: true, Text: fmt.Sprintf("method %s is not permitted; only GET, HEAD, and OPTIONS are allowed", in.Method)}, nil
+	}
+
+	if ws.cfg.Mode == ModeDisabled {
+		return tools.Result{IsError: true, Text: "web search is disabled"}, nil
+	}
+
+	if ws.cfg.Mode == ModeCached {
+		if cached, ok := ws.loadCache(in.URL); ok {
+			return resultToToolResult(cached), nil
+		}
+	}
+
+	fetched, err := ws.fetch(ctx, in.URL, in.Method)
+	if err != nil {
+		return tools.Result{IsError: true, Text: fmt.Sprintf("fetch error: %v", err)}, nil
+	}
+
+	if ws.cfg.Mode == ModeCached {
+		_ = ws.saveCache(in.URL, fetched)
+	}
+
+	return resultToToolResult(fetched), nil
+}
+
+func (ws *webSearch) fetch(ctx context.Context, rawURL, method string) (Result, error) {
+	if _, err := url.ParseRequestURI(rawURL); err != nil {
+		return Result{}, fmt.Errorf("invalid URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, nil)
+	if err != nil {
+		return Result{}, err
+	}
+	req.Header.Set("User-Agent", "conduit-web-search/1.0")
+
+	client := &http.Client{Timeout: httpClientTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return Result{}, err
+	}
+	defer resp.Body.Close()
+
+	var bodyBytes []byte
+	if method != http.MethodHead && method != http.MethodOptions {
+		limited := io.LimitReader(resp.Body, int64(ws.cfg.BodyLimit))
+		bodyBytes, err = io.ReadAll(limited)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+
+	body := string(bodyBytes)
+	title := extractTitle(body)
+	snippet := extractSnippet(body)
+
+	return Result{
+		URL:     rawURL,
+		Title:   title,
+		Snippet: snippet,
+		Body:    body,
+	}, nil
+}
+
+// cacheKey returns the SHA256 hex of the URL, used as the cache filename.
+func cacheKey(rawURL string) string {
+	sum := sha256.Sum256([]byte(rawURL))
+	return fmt.Sprintf("%x", sum)
+}
+
+func (ws *webSearch) loadCache(rawURL string) (Result, bool) {
+	if ws.cfg.CacheDir == "" {
+		return Result{}, false
+	}
+	path := filepath.Join(ws.cfg.CacheDir, cacheKey(rawURL)+cacheFileExt)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return Result{}, false
+	}
+	if err != nil {
+		return Result{}, false
+	}
+	var r Result
+	if err := json.Unmarshal(data, &r); err != nil {
+		return Result{}, false
+	}
+	return r, true
+}
+
+func (ws *webSearch) saveCache(rawURL string, r Result) error {
+	if ws.cfg.CacheDir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(ws.cfg.CacheDir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(ws.cfg.CacheDir, cacheKey(rawURL)+cacheFileExt)
+	return os.WriteFile(path, data, 0o644)
+}
+
+func resultToToolResult(r Result) tools.Result {
+	parts := []string{}
+	if r.Title != "" {
+		parts = append(parts, "Title: "+r.Title)
+	}
+	if r.URL != "" {
+		parts = append(parts, "URL: "+r.URL)
+	}
+	if r.Snippet != "" {
+		parts = append(parts, "Snippet: "+r.Snippet)
+	}
+	if r.Body != "" {
+		parts = append(parts, "\n"+r.Body)
+	}
+	return tools.Result{
+		Text: strings.Join(parts, "\n"),
+		Data: map[string]any{
+			"url":     r.URL,
+			"title":   r.Title,
+			"snippet": r.Snippet,
+			"body":    r.Body,
+		},
+	}
+}
+
+var titleRegexp = regexp.MustCompile(`(?i)<title[^>]*>([^<]+)</title>`)
+
+func extractTitle(body string) string {
+	if m := titleRegexp.FindStringSubmatch(body); len(m) > 1 {
+		return strings.TrimSpace(m[1])
+	}
+	return ""
+}
+
+var tagRegexp = regexp.MustCompile(`<[^>]+>`)
+
+func extractSnippet(body string) string {
+	text := tagRegexp.ReplaceAllString(body, " ")
+	// Collapse runs of whitespace.
+	fields := strings.Fields(text)
+	joined := strings.Join(fields, " ")
+	if len(joined) > snippetLimit {
+		return joined[:snippetLimit]
+	}
+	return joined
+}

--- a/internal/tools/websearch/websearch_test.go
+++ b/internal/tools/websearch/websearch_test.go
@@ -1,0 +1,219 @@
+package websearch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNew_returnsToolWithCorrectName(t *testing.T) {
+	tool := New(DefaultConfig())
+	if tool.Name != "web_search" {
+		t.Fatalf("Name = %q, want web_search", tool.Name)
+	}
+}
+
+func TestRun_disabledMode(t *testing.T) {
+	tool := New(Config{Mode: ModeDisabled})
+	raw, _ := json.Marshal(map[string]string{"url": "http://example.com"})
+	result, err := tool.Run(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected IsError=true for disabled mode")
+	}
+	if result.Text != "web search is disabled" {
+		t.Fatalf("Text = %q, want disabled message", result.Text)
+	}
+}
+
+func TestRun_blocksPostMethod(t *testing.T) {
+	tool := New(Config{Mode: ModeLive})
+	raw, _ := json.Marshal(map[string]string{"url": "http://example.com", "method": "POST"})
+	result, err := tool.Run(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected IsError=true for blocked method")
+	}
+}
+
+func TestRun_blocksDeleteMethod(t *testing.T) {
+	tool := New(Config{Mode: ModeLive})
+	raw, _ := json.Marshal(map[string]string{"url": "http://example.com", "method": "DELETE"})
+	result, err := tool.Run(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected IsError=true for DELETE method")
+	}
+}
+
+func TestRun_blocksPutMethod(t *testing.T) {
+	tool := New(Config{Mode: ModeLive})
+	raw, _ := json.Marshal(map[string]string{"url": "http://example.com", "method": "PUT"})
+	result, err := tool.Run(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected IsError=true for PUT method")
+	}
+}
+
+func TestRun_liveMode_fetchesAndReturnsTitle(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, "<html><head><title>Hello World</title></head><body>Some content here</body></html>")
+	}))
+	defer srv.Close()
+
+	tool := New(Config{Mode: ModeLive})
+	raw, _ := json.Marshal(map[string]string{"url": srv.URL})
+	result, err := tool.Run(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", result.Text)
+	}
+	if !strContains(result.Text, "Hello World") {
+		t.Fatalf("Text = %q, expected title 'Hello World'", result.Text)
+	}
+}
+
+func TestRun_cachedMode_storesAndReloadsResult(t *testing.T) {
+	cacheDir := t.TempDir()
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, "<html><head><title>Cached Page</title></head><body>body text</body></html>")
+	}))
+	defer srv.Close()
+
+	cfg := Config{Mode: ModeCached, CacheDir: cacheDir}
+	tool := New(cfg)
+	raw, _ := json.Marshal(map[string]string{"url": srv.URL})
+
+	// First call — should hit the server and cache.
+	r1, err := tool.Run(context.Background(), raw)
+	if err != nil || r1.IsError {
+		t.Fatalf("first call failed: err=%v text=%s", err, r1.Text)
+	}
+
+	// Second call — should return from cache without hitting the server.
+	r2, err := tool.Run(context.Background(), raw)
+	if err != nil || r2.IsError {
+		t.Fatalf("second call failed: err=%v text=%s", err, r2.Text)
+	}
+	if callCount != 1 {
+		t.Fatalf("server callCount = %d, want 1 (second call should use cache)", callCount)
+	}
+	if r1.Text != r2.Text {
+		t.Fatal("cached result text differs from live result")
+	}
+}
+
+func TestRun_cachedMode_cacheFileHasExpectedKey(t *testing.T) {
+	cacheDir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "<html><head><title>T</title></head><body>B</body></html>")
+	}))
+	defer srv.Close()
+
+	cfg := Config{Mode: ModeCached, CacheDir: cacheDir}
+	tool := New(cfg)
+	raw, _ := json.Marshal(map[string]string{"url": srv.URL})
+	if _, err := tool.Run(context.Background(), raw); err != nil {
+		t.Fatal(err)
+	}
+
+	key := cacheKey(srv.URL)
+	path := filepath.Join(cacheDir, key+cacheFileExt)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("cache file not found at %s: %v", path, err)
+	}
+}
+
+func TestRun_missingURL_returnsError(t *testing.T) {
+	tool := New(Config{Mode: ModeLive})
+	raw, _ := json.Marshal(map[string]string{})
+	result, err := tool.Run(context.Background(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("expected IsError=true when url is missing")
+	}
+}
+
+func TestRun_resultDataContainsURLField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "<html><head><title>T</title></head><body>B</body></html>")
+	}))
+	defer srv.Close()
+
+	tool := New(Config{Mode: ModeLive})
+	raw, _ := json.Marshal(map[string]string{"url": srv.URL})
+	result, err := tool.Run(context.Background(), raw)
+	if err != nil || result.IsError {
+		t.Fatalf("unexpected failure: err=%v text=%s", err, result.Text)
+	}
+	if result.Data["url"] != srv.URL {
+		t.Fatalf("Data[url] = %v, want %s", result.Data["url"], srv.URL)
+	}
+}
+
+func TestExtractTitle(t *testing.T) {
+	cases := []struct {
+		body  string
+		title string
+	}{
+		{`<html><head><title>Hello</title></head></html>`, "Hello"},
+		{`<TITLE>Upper Case</TITLE>`, "Upper Case"},
+		{`<title>  Spaced  </title>`, "Spaced"},
+		{`no title here`, ""},
+	}
+	for _, c := range cases {
+		if got := extractTitle(c.body); got != c.title {
+			t.Errorf("extractTitle(%q) = %q, want %q", c.body, got, c.title)
+		}
+	}
+}
+
+func TestCacheKey_deterministicAndDistinct(t *testing.T) {
+	k1 := cacheKey("https://example.com/a")
+	k2 := cacheKey("https://example.com/a")
+	k3 := cacheKey("https://example.com/b")
+	if k1 != k2 {
+		t.Fatal("same URL produced different cache keys")
+	}
+	if k1 == k3 {
+		t.Fatal("different URLs produced the same cache key")
+	}
+}
+
+func strContains(s, sub string) bool {
+	if len(sub) == 0 {
+		return true
+	}
+	if len(s) < len(sub) {
+		return false
+	}
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Implements the first-party web search tool (PRD §6.25.7) with three operating modes:

- **Cached** (default): fetches and stores results in `~/.conduit/cache/websearch/` keyed by SHA256 of the URL; subsequent calls for the same URL return the cached result without a network round-trip
- **Live**: always fetches fresh content from the network
- **Disabled**: returns an error — useful for isolated or offline sessions

Only GET, HEAD, and OPTIONS HTTP methods are permitted. POST, PUT, DELETE, and PATCH are blocked unconditionally.

Closes #141

## Changes

- `internal/tools/websearch/` — new package: `WebSearchTool`, `Mode` enum, SHA256 cache, config, HTML title/snippet extraction
- `internal/config/config.go` — added `WebSearchConfig` (mode, cache_dir, body_limit) to root `Config`
- `internal/coding/tier.go` — replaced the `web_search` stub with the real tool; added `DefaultCodingToolsWithConfig` for callers that want to pass a custom `websearch.Config`
- 12 tests covering: disabled mode, blocked methods (POST/PUT/DELETE), live fetch, cache hit/miss, SHA256 cache key, missing URL error, result Data shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)