### PR TITLE
feat(#57): multimodal input — images, PDFs, screenshots

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jabreeflor/conduit/internal/localmodel"
 	"github.com/jabreeflor/conduit/internal/mcp"
 	"github.com/jabreeflor/conduit/internal/router"
+	"github.com/jabreeflor/conduit/internal/sandbox"
 	"github.com/jabreeflor/conduit/internal/sessions"
 	"github.com/jabreeflor/conduit/internal/skills"
 	"github.com/jabreeflor/conduit/internal/tools"
@@ -100,6 +101,12 @@ func main() {
 		case "agents", "agents-create", "agents-update", "agents-delete":
 			if err := runAgentsCLI(os.Args[1], os.Args[2:], os.Stdout, os.Stderr); err != nil {
 				fmt.Fprintf(os.Stderr, "conduit %s: %v\n", os.Args[1], err)
+				os.Exit(1)
+			}
+			return
+		case "sandbox":
+			if err := sandbox.RunCLI(context.Background(), os.Args[2:], os.Stdout, os.Stderr); err != nil {
+				fmt.Fprintf(os.Stderr, "conduit sandbox: %v\n", err)
 				os.Exit(1)
 			}
 			return

--- a/internal/multimodal/multimodal.go
+++ b/internal/multimodal/multimodal.go
@@ -1,0 +1,119 @@
+// Package multimodal handles @image and @pdf directive parsing, file loading,
+// and base64 encoding for the TUI input pipeline (PRD §6.22).
+package multimodal
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jabreeflor/conduit/internal/router"
+)
+
+// supportedImageExts is the set of image extensions accepted by @image.
+var supportedImageExts = map[string]string{
+	".png":  "image/png",
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif":  "image/gif",
+	".webp": "image/webp",
+}
+
+// Attachment represents a file that has been parsed from a TUI directive,
+// loaded from disk, and base64-encoded for transmission.
+type Attachment struct {
+	Path      string
+	MediaType string
+	Data      string // base64-encoded file content
+}
+
+// ToInput converts an Attachment to a router.Input for vision-aware routing.
+func (a Attachment) ToInput() router.Input {
+	inputType := router.InputImage
+	if a.MediaType == "application/pdf" {
+		inputType = router.InputPDF
+	}
+	return router.Input{
+		Type:      inputType,
+		Ref:       a.Path,
+		Data:      a.Data,
+		MediaType: a.MediaType,
+	}
+}
+
+// ParseAndLoad extracts @image and @pdf directives from text, loads each
+// referenced file, and returns the cleaned text with directives removed plus
+// the loaded attachments.
+//
+// Directive syntax: @image <path> or @pdf <path> anywhere in the input.
+// Multiple directives in one message are supported.
+func ParseAndLoad(text string) (cleanText string, attachments []Attachment, err error) {
+	tokens := strings.Fields(text)
+	var kept []string
+
+	for i := 0; i < len(tokens); i++ {
+		switch tokens[i] {
+		case "@image", "@pdf":
+			if i+1 >= len(tokens) {
+				return "", nil, fmt.Errorf("%s requires a file path argument", tokens[i])
+			}
+			i++ // consume path token
+			path := tokens[i]
+			att, loadErr := loadFile(tokens[i-1], path)
+			if loadErr != nil {
+				return "", nil, loadErr
+			}
+			attachments = append(attachments, att)
+		default:
+			kept = append(kept, tokens[i])
+		}
+	}
+
+	return strings.Join(kept, " "), attachments, nil
+}
+
+// loadFile reads the file at path, validates its extension against the
+// directive kind, and returns a base64-encoded Attachment.
+func loadFile(directive, path string) (Attachment, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+
+	var mediaType string
+	switch directive {
+	case "@image":
+		mt, ok := supportedImageExts[ext]
+		if !ok {
+			return Attachment{}, fmt.Errorf(
+				"@image: unsupported extension %q (supported: png, jpg, jpeg, gif, webp)", ext,
+			)
+		}
+		mediaType = mt
+	case "@pdf":
+		if ext != ".pdf" {
+			return Attachment{}, fmt.Errorf("@pdf: expected .pdf extension, got %q", ext)
+		}
+		mediaType = "application/pdf"
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Attachment{}, fmt.Errorf("%s: cannot read %q: %w", directive, path, err)
+	}
+
+	return Attachment{
+		Path:      path,
+		MediaType: mediaType,
+		Data:      base64.StdEncoding.EncodeToString(data),
+	}, nil
+}
+
+// AttachmentLabel returns a short display string for use in TUI chips,
+// e.g. "[image: screenshot.png]" or "[pdf: report.pdf]".
+func AttachmentLabel(a Attachment) string {
+	base := filepath.Base(a.Path)
+	if a.MediaType == "application/pdf" {
+		return fmt.Sprintf("[pdf: %s]", base)
+	}
+	return fmt.Sprintf("[image: %s]", base)
+}

--- a/internal/multimodal/multimodal_test.go
+++ b/internal/multimodal/multimodal_test.go
@@ -1,0 +1,183 @@
+package multimodal
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/router"
+)
+
+func TestParseAndLoadImageDirective(t *testing.T) {
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "shot.png")
+	content := []byte("fake-png-bytes")
+	if err := os.WriteFile(imgPath, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	clean, atts, err := ParseAndLoad("@image " + imgPath + " describe this")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if clean != "describe this" {
+		t.Errorf("cleanText = %q, want %q", clean, "describe this")
+	}
+	if len(atts) != 1 {
+		t.Fatalf("attachments = %d, want 1", len(atts))
+	}
+	if atts[0].MediaType != "image/png" {
+		t.Errorf("MediaType = %q, want image/png", atts[0].MediaType)
+	}
+	want := base64.StdEncoding.EncodeToString(content)
+	if atts[0].Data != want {
+		t.Errorf("Data mismatch")
+	}
+}
+
+func TestParseAndLoadPDFDirective(t *testing.T) {
+	dir := t.TempDir()
+	pdfPath := filepath.Join(dir, "report.pdf")
+	if err := os.WriteFile(pdfPath, []byte("%PDF-1.4"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	clean, atts, err := ParseAndLoad("@pdf " + pdfPath + " summarize")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if clean != "summarize" {
+		t.Errorf("cleanText = %q, want summarize", clean)
+	}
+	if len(atts) != 1 {
+		t.Fatalf("attachments = %d, want 1", len(atts))
+	}
+	if atts[0].MediaType != "application/pdf" {
+		t.Errorf("MediaType = %q, want application/pdf", atts[0].MediaType)
+	}
+}
+
+func TestParseAndLoadMultipleImages(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a.png", "b.jpg"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("data"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	text := "@image " + filepath.Join(dir, "a.png") + " @image " + filepath.Join(dir, "b.jpg") + " describe differences"
+	clean, atts, err := ParseAndLoad(text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if clean != "describe differences" {
+		t.Errorf("cleanText = %q, want %q", clean, "describe differences")
+	}
+	if len(atts) != 2 {
+		t.Fatalf("attachments = %d, want 2", len(atts))
+	}
+	if atts[0].MediaType != "image/png" {
+		t.Errorf("first MediaType = %q, want image/png", atts[0].MediaType)
+	}
+	if atts[1].MediaType != "image/jpeg" {
+		t.Errorf("second MediaType = %q, want image/jpeg", atts[1].MediaType)
+	}
+}
+
+func TestParseAndLoadNoDirectives(t *testing.T) {
+	clean, atts, err := ParseAndLoad("just a plain message")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if clean != "just a plain message" {
+		t.Errorf("cleanText = %q, want original text", clean)
+	}
+	if len(atts) != 0 {
+		t.Errorf("attachments = %d, want 0", len(atts))
+	}
+}
+
+func TestParseAndLoadMissingPath(t *testing.T) {
+	_, _, err := ParseAndLoad("@image")
+	if err == nil {
+		t.Fatal("expected error for missing path, got nil")
+	}
+}
+
+func TestParseAndLoadFileNotFound(t *testing.T) {
+	_, _, err := ParseAndLoad("@image /nonexistent/path.png")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestParseAndLoadUnsupportedImageExt(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "file.bmp")
+	if err := os.WriteFile(p, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := ParseAndLoad("@image " + p)
+	if err == nil {
+		t.Fatal("expected error for unsupported extension, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported extension") {
+		t.Errorf("error = %q, want 'unsupported extension'", err.Error())
+	}
+}
+
+func TestParseAndLoadPDFWrongExt(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(p, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := ParseAndLoad("@pdf " + p)
+	if err == nil {
+		t.Fatal("expected error for wrong extension, got nil")
+	}
+}
+
+func TestAttachmentToInput(t *testing.T) {
+	a := Attachment{Path: "/tmp/shot.png", MediaType: "image/png", Data: "abc123"}
+	inp := a.ToInput()
+	if inp.Type != router.InputImage {
+		t.Errorf("Type = %q, want InputImage", inp.Type)
+	}
+	if inp.Ref != "/tmp/shot.png" {
+		t.Errorf("Ref = %q, want /tmp/shot.png", inp.Ref)
+	}
+	if inp.Data != "abc123" {
+		t.Errorf("Data = %q, want abc123", inp.Data)
+	}
+	if inp.MediaType != "image/png" {
+		t.Errorf("MediaType = %q, want image/png", inp.MediaType)
+	}
+}
+
+func TestPDFAttachmentToInput(t *testing.T) {
+	a := Attachment{Path: "/tmp/doc.pdf", MediaType: "application/pdf", Data: "pdfdata"}
+	inp := a.ToInput()
+	if inp.Type != router.InputPDF {
+		t.Errorf("Type = %q, want InputPDF", inp.Type)
+	}
+}
+
+func TestAttachmentLabel(t *testing.T) {
+	cases := []struct {
+		a    Attachment
+		want string
+	}{
+		{Attachment{Path: "/tmp/shot.png", MediaType: "image/png"}, "[image: shot.png]"},
+		{Attachment{Path: "/home/user/docs/report.pdf", MediaType: "application/pdf"}, "[pdf: report.pdf]"},
+		{Attachment{Path: "/tmp/photo.webp", MediaType: "image/webp"}, "[image: photo.webp]"},
+	}
+	for _, tc := range cases {
+		got := AttachmentLabel(tc.a)
+		if got != tc.want {
+			t.Errorf("AttachmentLabel(%q) = %q, want %q", tc.a.Path, got, tc.want)
+		}
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -29,9 +29,11 @@ type Request struct {
 
 // Input is an inference request payload.
 type Input struct {
-	Type InputType
-	Ref  string
-	Text string
+	Type      InputType
+	Ref       string
+	Text      string
+	Data      string // base64-encoded content for image and PDF inputs
+	MediaType string // MIME type, e.g. "image/png", "application/pdf"
 }
 
 // Response is the normalized provider result returned by the router.

--- a/internal/sandbox/active.go
+++ b/internal/sandbox/active.go
@@ -1,0 +1,114 @@
+// active.go — PRD §15.7  Active sandbox pointer
+//
+// The active sandbox is a process-spanning selection: future `conduit` runs
+// open it by default, and the TUI/GUI status bar reflects it. We persist the
+// selection in a single line of text at <root>/sandboxes/.active so it
+// survives across CLI invocations without any external state store.
+//
+// The active pointer is decoupled from any open Workspace handle: switching
+// is just a pointer write — no I/O on the workspace itself — and the on-disk
+// representation can be inspected with `cat`.
+
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// activeFilePath returns the absolute path to the active-pointer file.
+func (m *Manager) activeFilePath() string {
+	return filepath.Join(m.sandboxesPath(), "."+activeFileName)
+}
+
+// Active returns the name of the currently-active sandbox. ErrNoActive is
+// returned when no pointer file exists yet, which lets callers errors.Is-test
+// the "first run / unset" case without parsing strings.
+func (m *Manager) Active() (string, error) {
+	data, err := os.ReadFile(m.activeFilePath())
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", ErrNoActive
+		}
+		return "", fmt.Errorf("read active pointer: %w", err)
+	}
+	name := strings.TrimSpace(string(data))
+	if name == "" {
+		return "", ErrNoActive
+	}
+	if err := validateName(name); err != nil {
+		// A stale pointer file with a bad name is treated as unset rather
+		// than poisoning every CLI call until someone hand-deletes the file.
+		return "", ErrNoActive
+	}
+	return name, nil
+}
+
+// SetActive marks name as the active sandbox. The sandbox must already exist;
+// ErrNotFound is returned otherwise so we never have a pointer to a missing
+// directory.
+func (m *Manager) SetActive(name string) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
+	path := m.pathFor(name)
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("%w: %s", ErrNotFound, name)
+		}
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%w: %s is not a directory", ErrNotFound, name)
+	}
+
+	// Ensure the sandboxes/ dir exists before writing the pointer file —
+	// callers may invoke SetActive before any Create on a fresh root.
+	if err := os.MkdirAll(m.sandboxesPath(), dirPerm); err != nil {
+		return fmt.Errorf("create sandboxes dir: %w", err)
+	}
+
+	// Write atomically: write a tmp file in the same dir, then rename. This
+	// avoids a window where the file exists but is empty (which Active()
+	// already tolerates as "unset", but we can do better).
+	tmp := m.activeFilePath() + ".tmp"
+	if err := os.WriteFile(tmp, []byte(name+"\n"), configFilePerm); err != nil {
+		return fmt.Errorf("write active pointer: %w", err)
+	}
+	if err := os.Rename(tmp, m.activeFilePath()); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename active pointer: %w", err)
+	}
+	return nil
+}
+
+// ClearActive removes the active-pointer file. Calling ClearActive when no
+// pointer exists is a no-op (mirrors Destroy's idempotent friendlier paths).
+func (m *Manager) ClearActive() error {
+	if err := os.Remove(m.activeFilePath()); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("remove active pointer: %w", err)
+	}
+	return nil
+}
+
+// Switch validates the named sandbox exists, opens it, and records it as the
+// active selection in one call. Returns the resolved Workspace handle so the
+// caller can immediately drive a session against it.
+func (m *Manager) Switch(name string) (*Workspace, error) {
+	ws, err := m.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	if err := m.SetActive(name); err != nil {
+		return nil, err
+	}
+	return ws, nil
+}

--- a/internal/sandbox/active_test.go
+++ b/internal/sandbox/active_test.go
@@ -1,0 +1,171 @@
+package sandbox
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestActiveUnsetReturnsErrNoActive(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Active(); !errors.Is(err, ErrNoActive) {
+		t.Fatalf("Active on fresh root err=%v, want ErrNoActive", err)
+	}
+}
+
+func TestSetActiveRequiresExistingSandbox(t *testing.T) {
+	m := newTestManager(t)
+	if err := m.SetActive("ghost"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("SetActive missing err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestSetActiveRejectsInvalidName(t *testing.T) {
+	m := newTestManager(t)
+	if err := m.SetActive("Bad Name"); !errors.Is(err, ErrInvalidName) {
+		t.Fatalf("SetActive bad name err=%v, want ErrInvalidName", err)
+	}
+}
+
+func TestSetActiveAndActiveRoundTrip(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("alpha", CreateOptions{}); err != nil {
+		t.Fatalf("Create alpha: %v", err)
+	}
+	if err := m.SetActive("alpha"); err != nil {
+		t.Fatalf("SetActive alpha: %v", err)
+	}
+	got, err := m.Active()
+	if err != nil {
+		t.Fatalf("Active: %v", err)
+	}
+	if got != "alpha" {
+		t.Fatalf("Active = %q, want alpha", got)
+	}
+}
+
+func TestSetActiveOverwritesPrevious(t *testing.T) {
+	m := newTestManager(t)
+	for _, n := range []string{"alpha", "beta"} {
+		if _, err := m.Create(n, CreateOptions{}); err != nil {
+			t.Fatalf("Create %s: %v", n, err)
+		}
+	}
+	if err := m.SetActive("alpha"); err != nil {
+		t.Fatalf("SetActive alpha: %v", err)
+	}
+	if err := m.SetActive("beta"); err != nil {
+		t.Fatalf("SetActive beta: %v", err)
+	}
+	got, err := m.Active()
+	if err != nil {
+		t.Fatalf("Active: %v", err)
+	}
+	if got != "beta" {
+		t.Fatalf("Active = %q, want beta after switch", got)
+	}
+}
+
+func TestClearActive(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("alpha", CreateOptions{}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := m.SetActive("alpha"); err != nil {
+		t.Fatalf("SetActive: %v", err)
+	}
+	if err := m.ClearActive(); err != nil {
+		t.Fatalf("ClearActive: %v", err)
+	}
+	if _, err := m.Active(); !errors.Is(err, ErrNoActive) {
+		t.Fatalf("Active after Clear err=%v, want ErrNoActive", err)
+	}
+	// Idempotent: clearing again is fine.
+	if err := m.ClearActive(); err != nil {
+		t.Fatalf("ClearActive idempotent: %v", err)
+	}
+}
+
+func TestActiveStaleNameTreatedAsUnset(t *testing.T) {
+	// A pointer file that contains a name we wouldn't accept (e.g. uppercase
+	// or a path traversal attempt) should read as ErrNoActive rather than
+	// poisoning every CLI call.
+	m := newTestManager(t)
+	if err := os.MkdirAll(m.sandboxesPath(), 0o755); err != nil {
+		t.Fatalf("mkdir sandboxes: %v", err)
+	}
+	pointer := filepath.Join(m.sandboxesPath(), ".active")
+	if err := os.WriteFile(pointer, []byte("../etc/passwd\n"), 0o644); err != nil {
+		t.Fatalf("write stale pointer: %v", err)
+	}
+	if _, err := m.Active(); !errors.Is(err, ErrNoActive) {
+		t.Fatalf("Active on stale pointer err=%v, want ErrNoActive", err)
+	}
+}
+
+func TestSwitchOpensAndActivates(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("gamma", CreateOptions{}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	ws, err := m.Switch("gamma")
+	if err != nil {
+		t.Fatalf("Switch: %v", err)
+	}
+	if ws.Name() != "gamma" {
+		t.Fatalf("Switch returned name=%q, want gamma", ws.Name())
+	}
+	got, err := m.Active()
+	if err != nil {
+		t.Fatalf("Active after Switch: %v", err)
+	}
+	if got != "gamma" {
+		t.Fatalf("Active = %q, want gamma", got)
+	}
+}
+
+func TestSwitchMissingReturnsNotFound(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Switch("ghost"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Switch missing err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestDestroyClearsActivePointer(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("doomed", CreateOptions{}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := m.SetActive("doomed"); err != nil {
+		t.Fatalf("SetActive: %v", err)
+	}
+	if err := m.Destroy("doomed"); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if _, err := m.Active(); !errors.Is(err, ErrNoActive) {
+		t.Fatalf("Active after Destroy of active err=%v, want ErrNoActive", err)
+	}
+}
+
+func TestListMarksActiveSandbox(t *testing.T) {
+	m := newTestManager(t)
+	for _, n := range []string{"alpha", "beta", "gamma"} {
+		if _, err := m.Create(n, CreateOptions{}); err != nil {
+			t.Fatalf("Create %s: %v", n, err)
+		}
+	}
+	if err := m.SetActive("beta"); err != nil {
+		t.Fatalf("SetActive: %v", err)
+	}
+	infos, err := m.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, info := range infos {
+		want := info.Name == "beta"
+		if info.Active != want {
+			t.Fatalf("info[%s].Active = %v, want %v", info.Name, info.Active, want)
+		}
+	}
+}

--- a/internal/sandbox/cli.go
+++ b/internal/sandbox/cli.go
@@ -1,0 +1,286 @@
+// cli.go — `conduit sandbox` subcommand surface.
+//
+// Verbs: list / create / switch / clone / destroy (PRD §15.7) plus the
+// already-supported snapshot / rollback verbs from §15.6.
+//
+// The CLI layer is deliberately thin: each verb maps to one Manager call,
+// and human-readable output goes to stdout while diagnostics go to stderr.
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// RunCLI is the entry point wired from cmd/conduit/main.go. It dispatches
+// args[0] to the matching subcommand against a default-rooted Manager.
+func RunCLI(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	return dispatchCLI(ctx, NewManager(""), args, stdout, stderr)
+}
+
+// dispatchCLI is the inner dispatcher that drives RunCLI; it lets tests
+// supply a tempdir-rooted Manager without touching $HOME.
+func dispatchCLI(_ context.Context, mgr *Manager, args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		printUsage(stderr)
+		return flag.ErrHelp
+	}
+
+	switch args[0] {
+	case "list":
+		return runList(mgr, args[1:], stdout, stderr)
+	case "create":
+		return runCreate(mgr, args[1:], stdout, stderr)
+	case "switch":
+		return runSwitch(mgr, args[1:], stdout, stderr)
+	case "clone":
+		return runClone(mgr, args[1:], stdout, stderr)
+	case "destroy":
+		return runDestroy(mgr, args[1:], stdout, stderr)
+	case "active":
+		return runActive(mgr, stdout, stderr)
+	case "-h", "--help", "help":
+		printUsage(stdout)
+		return nil
+	default:
+		fmt.Fprintf(stderr, "unknown sandbox command %q\n\n", args[0])
+		printUsage(stderr)
+		return fmt.Errorf("unknown sandbox command %q", args[0])
+	}
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage: conduit sandbox <command> [flags]")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "commands:")
+	fmt.Fprintln(w, "  list                            list all sandboxes (active row marked with '*')")
+	fmt.Fprintln(w, "  create  <name> [flags]          create a new sandbox")
+	fmt.Fprintln(w, "  switch  <name>                  set the active sandbox")
+	fmt.Fprintln(w, "  clone   <src> <dst> [flags]     duplicate an existing sandbox")
+	fmt.Fprintln(w, "  destroy <name>                  delete a sandbox and all its data")
+	fmt.Fprintln(w, "  active                          print the active sandbox name")
+}
+
+func runList(mgr *Manager, args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("conduit sandbox list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	infos, err := mgr.List()
+	if err != nil {
+		return err
+	}
+	if len(infos) == 0 {
+		fmt.Fprintln(stdout, "no sandboxes found")
+		fmt.Fprintf(stdout, "  root: %s\n", mgr.Root())
+		return nil
+	}
+	fmt.Fprintf(stdout, "%-2s  %-24s  %-19s  %-10s  %-10s  %s\n",
+		"", "NAME", "LAST USED", "QUOTA", "MEMORY", "CPU")
+	for _, info := range infos {
+		marker := "  "
+		if info.Active {
+			marker = "* "
+		}
+		fmt.Fprintf(stdout, "%s  %-24s  %-19s  %-10s  %-10s  %s\n",
+			marker,
+			info.Name,
+			formatTime(info.LastUsedAt),
+			humanBytes(info.QuotaBytes),
+			humanBytes(info.MemoryBytes),
+			formatCPU(info.CPULimit),
+		)
+	}
+	return nil
+}
+
+func runCreate(mgr *Manager, args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("conduit sandbox create", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	quota := fs.Int64("quota-bytes", 0, "disk quota in bytes (default 10 GiB)")
+	memory := fs.Int64("memory-bytes", 0, "process memory limit in bytes (default 4 GiB)")
+	cpu := fs.Float64("cpu-limit", -1, "CPU allowance in fractional cores (0 = unconstrained)")
+	makeActive := fs.Bool("activate", false, "set the new sandbox as active after creation")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: conduit sandbox create <name> [flags]")
+	}
+	name := fs.Arg(0)
+
+	opts := CreateOptions{
+		QuotaBytes:  *quota,
+		MemoryBytes: *memory,
+	}
+	if *cpu >= 0 {
+		opts.CPULimit = *cpu
+	}
+
+	ws, err := mgr.Create(name, opts)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "created sandbox %q at %s\n", ws.Name(), ws.Root())
+
+	if *makeActive {
+		if err := mgr.SetActive(ws.Name()); err != nil {
+			return fmt.Errorf("set active: %w", err)
+		}
+		fmt.Fprintf(stdout, "active sandbox: %s\n", ws.Name())
+	}
+	return nil
+}
+
+func runSwitch(mgr *Manager, args []string, stdout, stderr io.Writer) error {
+	if len(args) != 1 {
+		return errors.New("usage: conduit sandbox switch <name>")
+	}
+	ws, err := mgr.Switch(args[0])
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "switched to sandbox %q\n", ws.Name())
+	return nil
+}
+
+func runClone(mgr *Manager, args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("conduit sandbox clone", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	quota := fs.Int64("quota-bytes", 0, "override disk quota for the clone (default: inherit)")
+	memory := fs.Int64("memory-bytes", 0, "override memory limit for the clone (default: inherit)")
+	cpu := fs.Float64("cpu-limit", 0, "override CPU allowance for the clone (default: inherit)")
+	makeActive := fs.Bool("activate", false, "set the clone as active after cloning")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 2 {
+		return errors.New("usage: conduit sandbox clone <src> <dst> [flags]")
+	}
+
+	opts := CloneOptions{
+		QuotaBytes:  *quota,
+		MemoryBytes: *memory,
+		CPULimit:    *cpu,
+	}
+	ws, err := mgr.Clone(fs.Arg(0), fs.Arg(1), opts)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "cloned %q -> %q (%s)\n", fs.Arg(0), ws.Name(), ws.Root())
+
+	if *makeActive {
+		if err := mgr.SetActive(ws.Name()); err != nil {
+			return fmt.Errorf("set active: %w", err)
+		}
+		fmt.Fprintf(stdout, "active sandbox: %s\n", ws.Name())
+	}
+	return nil
+}
+
+func runDestroy(mgr *Manager, args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("conduit sandbox destroy", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	force := fs.Bool("force", false, "skip the safety prompt (no-op when stdin is non-interactive)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: conduit sandbox destroy <name> [--force]")
+	}
+	name := fs.Arg(0)
+
+	if !*force && isInteractive() {
+		fmt.Fprintf(stderr, "destroy sandbox %q? [y/N]: ", name)
+		var resp string
+		fmt.Fscanln(os.Stdin, &resp)
+		resp = strings.TrimSpace(strings.ToLower(resp))
+		if resp != "y" && resp != "yes" {
+			fmt.Fprintln(stdout, "aborted")
+			return nil
+		}
+	}
+
+	if err := mgr.Destroy(name); err != nil {
+		return err
+	}
+	// Clear the active pointer if we just destroyed it so the user is not
+	// left with a dangling reference.
+	if active, err := mgr.Active(); err == nil && active == name {
+		_ = mgr.ClearActive()
+	}
+	fmt.Fprintf(stdout, "destroyed sandbox %q\n", name)
+	return nil
+}
+
+func runActive(mgr *Manager, stdout, stderr io.Writer) error {
+	name, err := mgr.Active()
+	if err != nil {
+		if errors.Is(err, ErrNoActive) {
+			fmt.Fprintln(stdout, "no active sandbox")
+			return nil
+		}
+		// ErrNotFound here means the active pointer is dangling.
+		if errors.Is(err, ErrNotFound) {
+			fmt.Fprintf(stderr, "active sandbox %q no longer exists; use `conduit sandbox switch` to pick another\n", name)
+			return err
+		}
+		return err
+	}
+	fmt.Fprintln(stdout, name)
+	return nil
+}
+
+// formatTime renders t in a compact human form. The zero value renders as
+// "—" so listings stay aligned.
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return "—"
+	}
+	return t.Local().Format("2006-01-02 15:04")
+}
+
+// humanBytes renders n as a short binary-prefixed string. 0 renders as "—"
+// so unset limits read clearly in tabular output.
+func humanBytes(n int64) string {
+	if n <= 0 {
+		return "—"
+	}
+	const unit = int64(1024)
+	if n < unit {
+		return fmt.Sprintf("%dB", n)
+	}
+	div, exp := unit, 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f%ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+// formatCPU renders cpu as fractional cores. 0 renders as "—" to mean
+// "unconstrained" so the user can see at a glance which sandboxes are capped.
+func formatCPU(cpu float64) string {
+	if cpu <= 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%.2f", cpu)
+}
+
+// isInteractive returns true when stdin is attached to a terminal. We use
+// stat() instead of x/term so the package keeps zero deps.
+func isInteractive() bool {
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}

--- a/internal/sandbox/cli_test.go
+++ b/internal/sandbox/cli_test.go
@@ -1,0 +1,234 @@
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// runCLI dispatches args against m and asserts success, returning stdout.
+func runCLI(t *testing.T, m *Manager, args ...string) string {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	if err := dispatchCLI(context.Background(), m, args, &stdout, &stderr); err != nil {
+		t.Fatalf("CLI %v failed: %v\nstderr=%s", args, err, stderr.String())
+	}
+	return stdout.String()
+}
+
+// runCLIErr dispatches args against m and returns (stdout, stderr, err)
+// without asserting success.
+func runCLIErr(t *testing.T, m *Manager, args ...string) (string, string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	err := dispatchCLI(context.Background(), m, args, &stdout, &stderr)
+	return stdout.String(), stderr.String(), err
+}
+
+func TestCLINoArgsPrintsUsage(t *testing.T) {
+	m := newTestManager(t)
+	_, stderr, err := runCLIErr(t, m)
+	if err == nil {
+		t.Fatal("dispatchCLI with no args should return an error")
+	}
+	if !strings.Contains(stderr, "usage:") {
+		t.Fatalf("usage missing from stderr: %q", stderr)
+	}
+}
+
+func TestCLIUnknownVerb(t *testing.T) {
+	m := newTestManager(t)
+	_, _, err := runCLIErr(t, m, "frobnicate")
+	if err == nil {
+		t.Fatal("unknown verb should error")
+	}
+}
+
+func TestCLICreateListSwitchActiveDestroyRoundTrip(t *testing.T) {
+	m := newTestManager(t)
+
+	// Empty list shows the empty-state message.
+	out := runCLI(t, m, "list")
+	if !strings.Contains(out, "no sandboxes") {
+		t.Errorf("empty list missing empty-state message: %q", out)
+	}
+
+	// Create.
+	out = runCLI(t, m, "create", "alpha")
+	if !strings.Contains(out, "created sandbox") || !strings.Contains(out, "alpha") {
+		t.Errorf("create output: %q", out)
+	}
+
+	// active reads back as none (we did not pass --activate).
+	out = runCLI(t, m, "active")
+	if !strings.Contains(out, "no active sandbox") {
+		t.Errorf("active = %q, want 'no active sandbox'", out)
+	}
+
+	// switch.
+	out = runCLI(t, m, "switch", "alpha")
+	if !strings.Contains(out, "switched to sandbox") {
+		t.Errorf("switch output: %q", out)
+	}
+
+	// active reads back as alpha.
+	out = runCLI(t, m, "active")
+	if strings.TrimSpace(out) != "alpha" {
+		t.Errorf("active = %q, want alpha", strings.TrimSpace(out))
+	}
+
+	// list now marks alpha with '*'.
+	out = runCLI(t, m, "list")
+	if !strings.Contains(out, "*") {
+		t.Errorf("list missing active marker: %q", out)
+	}
+
+	// destroy --force (flag must precede positional with stdlib flag pkg).
+	out = runCLI(t, m, "destroy", "--force", "alpha")
+	if !strings.Contains(out, "destroyed sandbox") {
+		t.Errorf("destroy output: %q", out)
+	}
+
+	// active reads back as none.
+	out = runCLI(t, m, "active")
+	if !strings.Contains(out, "no active sandbox") {
+		t.Errorf("active after destroy = %q", out)
+	}
+}
+
+func TestCLICreateActivate(t *testing.T) {
+	m := newTestManager(t)
+	out := runCLI(t, m, "create", "--activate", "alpha")
+	if !strings.Contains(out, "active sandbox: alpha") {
+		t.Fatalf("--activate output: %q", out)
+	}
+	out = runCLI(t, m, "active")
+	if strings.TrimSpace(out) != "alpha" {
+		t.Fatalf("active = %q, want alpha", strings.TrimSpace(out))
+	}
+}
+
+func TestCLICreateAcceptsResourceFlags(t *testing.T) {
+	m := newTestManager(t)
+	runCLI(t, m,
+		"create",
+		"--quota-bytes", "1048576",
+		"--memory-bytes", "524288",
+		"--cpu-limit", "2.5",
+		"alpha",
+	)
+	ws, err := m.Open("alpha")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if ws.Quota() != 1<<20 || ws.MemoryLimit() != 1<<19 || ws.CPULimit() != 2.5 {
+		t.Fatalf("limits: q=%d m=%d c=%f", ws.Quota(), ws.MemoryLimit(), ws.CPULimit())
+	}
+}
+
+func TestCLICreateRequiresName(t *testing.T) {
+	m := newTestManager(t)
+	if _, _, err := runCLIErr(t, m, "create"); err == nil {
+		t.Fatal("create with no name should error")
+	}
+}
+
+func TestCLISwitchMissingErrors(t *testing.T) {
+	m := newTestManager(t)
+	if _, _, err := runCLIErr(t, m, "switch", "ghost"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("switch missing err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestCLICloneViaCLI(t *testing.T) {
+	m := newTestManager(t)
+	runCLI(t, m, "create", "src")
+
+	// Plant a payload so we can verify the clone surfaces it.
+	srcWS, err := m.Open("src")
+	if err != nil {
+		t.Fatalf("Open src: %v", err)
+	}
+	writeFile(t, srcWS.Path(SubdirWorkspace)+"/data.txt", []byte("payload"))
+
+	out := runCLI(t, m, "clone", "src", "dst")
+	if !strings.Contains(out, "cloned") {
+		t.Fatalf("clone output: %q", out)
+	}
+
+	dstWS, err := m.Open("dst")
+	if err != nil {
+		t.Fatalf("Open dst: %v", err)
+	}
+	got, err := os.ReadFile(dstWS.Path(SubdirWorkspace) + "/data.txt")
+	if err != nil {
+		t.Fatalf("read clone payload: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("clone payload = %q, want payload", got)
+	}
+}
+
+func TestCLIClonePropagatesOverrides(t *testing.T) {
+	m := newTestManager(t)
+	runCLI(t, m, "create", "--memory-bytes", "1073741824", "src")
+	runCLI(t, m, "clone", "--memory-bytes", "536870912", "src", "dst")
+	ws, err := m.Open("dst")
+	if err != nil {
+		t.Fatalf("Open dst: %v", err)
+	}
+	if ws.MemoryLimit() != 1<<29 {
+		t.Fatalf("clone MemoryLimit = %d, want %d", ws.MemoryLimit(), 1<<29)
+	}
+}
+
+func TestCLIDestroyClearsActive(t *testing.T) {
+	m := newTestManager(t)
+	runCLI(t, m, "create", "--activate", "x")
+	runCLI(t, m, "destroy", "--force", "x")
+	out := runCLI(t, m, "active")
+	if !strings.Contains(out, "no active sandbox") {
+		t.Fatalf("active after destroy = %q", out)
+	}
+}
+
+func TestCLIHelpVerbsPrintUsage(t *testing.T) {
+	m := newTestManager(t)
+	for _, verb := range []string{"help", "--help", "-h"} {
+		out := runCLI(t, m, verb)
+		if !strings.Contains(out, "usage:") {
+			t.Fatalf("%s output missing usage: %q", verb, out)
+		}
+	}
+}
+
+func TestHumanBytesEdges(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "—"},
+		{-1, "—"},
+		{500, "500B"},
+		{1 << 10, "1.0KiB"},
+		{1 << 20, "1.0MiB"},
+		{1 << 30, "1.0GiB"},
+	}
+	for _, c := range cases {
+		if got := humanBytes(c.in); got != c.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFormatCPUEdges(t *testing.T) {
+	if got := formatCPU(0); got != "—" {
+		t.Errorf("formatCPU(0) = %q, want —", got)
+	}
+	if got := formatCPU(2.5); !strings.HasPrefix(got, "2.5") {
+		t.Errorf("formatCPU(2.5) = %q, want starts with 2.5", got)
+	}
+}

--- a/internal/sandbox/clone.go
+++ b/internal/sandbox/clone.go
@@ -1,0 +1,153 @@
+// clone.go — PRD §15.7  Sandbox cloning
+//
+// Clone copies workspace/, home/, cache/, and logs/ from a source sandbox to
+// a fresh destination sandbox. snapshots/ and tmp/ are intentionally not
+// cloned: snapshots are point-in-time records of the source, and tmp/ is by
+// definition session-scoped scratch space.
+//
+// Clone reuses hardlinkTree (snapshot.go) so the on-disk cost is O(file count)
+// rather than O(bytes). The two trees stay independent for *future* writes
+// because file-system COW (APFS / btrfs) breaks the link on first write, and
+// because Conduit always writes via O_TRUNC + create-then-rename rather than
+// in-place — which preserves source bytes even on filesystems without COW.
+
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// CloneOptions controls Clone. A zero CloneOptions inherits the source's
+// disk quota and resource limits.
+type CloneOptions struct {
+	// QuotaBytes overrides the source's disk quota when > 0.
+	QuotaBytes int64
+	// MemoryBytes overrides the source's memory ceiling when > 0.
+	MemoryBytes int64
+	// CPULimit overrides the source's CPU allowance when > 0.
+	CPULimit float64
+}
+
+// cloneSubdirs is the set of subdirs Clone copies. snapshots/ and tmp/ are
+// intentionally omitted — see file-level docstring.
+var cloneSubdirs = []Subdir{
+	SubdirWorkspace,
+	SubdirHome,
+	SubdirCache,
+	SubdirLogs,
+}
+
+// Clone creates a new sandbox at dst by hardlink-copying the workspace data
+// from src. The destination must not already exist; the source must.
+//
+// On any partial failure the destination is removed in full so the caller
+// never sees a half-built sandbox.
+func (m *Manager) Clone(src, dst string, opts CloneOptions) (*Workspace, error) {
+	if err := validateName(src); err != nil {
+		return nil, fmt.Errorf("source: %w", err)
+	}
+	if err := validateName(dst); err != nil {
+		return nil, fmt.Errorf("destination: %w", err)
+	}
+	if src == dst {
+		return nil, fmt.Errorf("source and destination must differ: both %q", src)
+	}
+
+	srcPath := m.pathFor(src)
+	srcInfo, err := os.Stat(srcPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("%w: %s", ErrNotFound, src)
+		}
+		return nil, fmt.Errorf("stat source %s: %w", srcPath, err)
+	}
+	if !srcInfo.IsDir() {
+		return nil, fmt.Errorf("%w: %s is not a directory", ErrNotFound, src)
+	}
+
+	dstPath := m.pathFor(dst)
+	if _, err := os.Stat(dstPath); err == nil {
+		return nil, fmt.Errorf("%w: %s", ErrAlreadyExists, dst)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("stat destination %s: %w", dstPath, err)
+	}
+
+	srcCfg, err := readConfig(srcPath)
+	if err != nil {
+		return nil, fmt.Errorf("read source config: %w", err)
+	}
+
+	// Lock the source so a session-scoped operation (EndSession / Cleanup)
+	// can't race the clone mid-walk and leave half-deleted tmp inside the
+	// hardlinked snapshot. We grab the lock through a temporary handle.
+	srcWS := &Workspace{path: srcPath, name: src, cfg: srcCfg}
+	release, err := srcWS.acquireLock()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	if err := os.MkdirAll(dstPath, dirPerm); err != nil {
+		return nil, fmt.Errorf("create destination dir: %w", err)
+	}
+
+	// Pre-create the layout, including the subdirs we don't clone, so the
+	// destination passes the same shape invariants as a freshly Create()d
+	// workspace.
+	for _, sub := range allSubdirs {
+		if err := os.MkdirAll(filepath.Join(dstPath, string(sub)), dirPerm); err != nil {
+			_ = os.RemoveAll(dstPath)
+			return nil, fmt.Errorf("create %s in destination: %w", sub, err)
+		}
+	}
+
+	for _, sub := range cloneSubdirs {
+		if _, _, err := hardlinkTree(srcWS.Path(sub), filepath.Join(dstPath, string(sub))); err != nil {
+			_ = os.RemoveAll(dstPath)
+			return nil, fmt.Errorf("clone %s: %w", sub, err)
+		}
+	}
+
+	now := time.Now().UTC()
+	dstCfg := workspaceConfig{
+		Name:        dst,
+		CreatedAt:   now,
+		LastUsedAt:  now,
+		QuotaBytes:  pickInt64(opts.QuotaBytes, srcCfg.QuotaBytes, DefaultQuotaBytes),
+		MemoryBytes: pickInt64(opts.MemoryBytes, srcCfg.MemoryBytes, DefaultMemoryBytes),
+		CPULimit:    pickFloat(opts.CPULimit, srcCfg.CPULimit, DefaultCPULimit),
+	}
+	if err := writeConfig(dstPath, dstCfg); err != nil {
+		_ = os.RemoveAll(dstPath)
+		return nil, err
+	}
+
+	return &Workspace{path: dstPath, name: dst, cfg: dstCfg}, nil
+}
+
+// pickInt64 returns the first positive value among override, inherited, fallback.
+func pickInt64(override, inherited, fallback int64) int64 {
+	if override > 0 {
+		return override
+	}
+	if inherited > 0 {
+		return inherited
+	}
+	return fallback
+}
+
+// pickFloat is the float64 analogue of pickInt64 for CPU shares.
+func pickFloat(override, inherited, fallback float64) float64 {
+	if override > 0 {
+		return override
+	}
+	if inherited > 0 {
+		return inherited
+	}
+	return fallback
+}

--- a/internal/sandbox/clone_test.go
+++ b/internal/sandbox/clone_test.go
@@ -1,0 +1,244 @@
+package sandbox
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCloneCopiesWorkspaceHomeCacheAndLogs(t *testing.T) {
+	m := newTestManager(t)
+	src, err := m.Create("src", CreateOptions{
+		QuotaBytes:  3 << 30,
+		MemoryBytes: 2 << 30,
+		CPULimit:    1.0,
+	})
+	if err != nil {
+		t.Fatalf("Create src: %v", err)
+	}
+
+	// Seed source files in workspace/, home/, cache/, logs/.
+	writeFile(t, filepath.Join(src.Path(SubdirWorkspace), "code.go"), []byte("package main\n"))
+	writeFile(t, filepath.Join(src.Path(SubdirWorkspace), "nested", "x"), []byte("nested"))
+	writeFile(t, filepath.Join(src.Path(SubdirHome), ".bashrc"), []byte("export X=1\n"))
+	writeFile(t, filepath.Join(src.Path(SubdirCache), "blob"), []byte("cached"))
+	writeFile(t, filepath.Join(src.Path(SubdirLogs), "session.log"), []byte("log line\n"))
+	// snapshots/ and tmp/ should be skipped during clone.
+	writeFile(t, filepath.Join(src.Path(SubdirSnapshots), "leaked.txt"), []byte("snap"))
+	writeFile(t, filepath.Join(src.Path(SubdirTmp), "scratch"), []byte("tmp"))
+
+	dst, err := m.Clone("src", "dst", CloneOptions{})
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	if dst.Name() != "dst" {
+		t.Fatalf("dst.Name = %q", dst.Name())
+	}
+
+	for _, rel := range []struct{ sub, name string }{
+		{string(SubdirWorkspace), "code.go"},
+		{string(SubdirWorkspace), filepath.Join("nested", "x")},
+		{string(SubdirHome), ".bashrc"},
+		{string(SubdirCache), "blob"},
+		{string(SubdirLogs), "session.log"},
+	} {
+		path := filepath.Join(dst.Root(), rel.sub, rel.name)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected %s to exist in clone: %v", path, err)
+		}
+	}
+
+	for _, sub := range []Subdir{SubdirSnapshots, SubdirTmp} {
+		entries, err := os.ReadDir(dst.Path(sub))
+		if err != nil {
+			t.Fatalf("read %s: %v", sub, err)
+		}
+		if len(entries) != 0 {
+			t.Errorf("%s should be empty in clone, got %d entries", sub, len(entries))
+		}
+	}
+
+	// Limits inherited from source.
+	if dst.Quota() != 3<<30 {
+		t.Errorf("clone Quota = %d, want %d", dst.Quota(), 3<<30)
+	}
+	if dst.MemoryLimit() != 2<<30 {
+		t.Errorf("clone MemoryLimit = %d, want %d", dst.MemoryLimit(), 2<<30)
+	}
+	if dst.CPULimit() != 1.0 {
+		t.Errorf("clone CPULimit = %f, want 1.0", dst.CPULimit())
+	}
+}
+
+func TestCloneOverridesLimits(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("base", CreateOptions{
+		QuotaBytes:  3 << 30,
+		MemoryBytes: 2 << 30,
+		CPULimit:    1.0,
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	dst, err := m.Clone("base", "narrow", CloneOptions{
+		QuotaBytes:  1 << 30,
+		MemoryBytes: 512 << 20,
+		CPULimit:    0.25,
+	})
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	if dst.Quota() != 1<<30 || dst.MemoryLimit() != 512<<20 || dst.CPULimit() != 0.25 {
+		t.Errorf("override mismatch: q=%d m=%d c=%f", dst.Quota(), dst.MemoryLimit(), dst.CPULimit())
+	}
+}
+
+func TestCloneRejectsBadAndConflictingNames(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("orig", CreateOptions{}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := m.Clone("Bad", "copy", CloneOptions{}); !errors.Is(err, ErrInvalidName) {
+		t.Fatalf("clone bad src err=%v, want ErrInvalidName", err)
+	}
+	if _, err := m.Clone("orig", "Bad Copy", CloneOptions{}); !errors.Is(err, ErrInvalidName) {
+		t.Fatalf("clone bad dst err=%v, want ErrInvalidName", err)
+	}
+	if _, err := m.Clone("orig", "orig", CloneOptions{}); err == nil {
+		t.Fatalf("clone src==dst should error")
+	}
+}
+
+func TestCloneSourceMissing(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Clone("missing", "copy", CloneOptions{}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("clone missing src err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestCloneDestExists(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("a", CreateOptions{}); err != nil {
+		t.Fatalf("Create a: %v", err)
+	}
+	if _, err := m.Create("b", CreateOptions{}); err != nil {
+		t.Fatalf("Create b: %v", err)
+	}
+	if _, err := m.Clone("a", "b", CloneOptions{}); !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("clone existing dst err=%v, want ErrAlreadyExists", err)
+	}
+}
+
+func TestCloneIndependentOfSourceWrites(t *testing.T) {
+	// After cloning, modifications to the source tree must not surface in
+	// the destination — even though hardlinks share inodes — because
+	// Conduit always writes via create-then-rename, which breaks the link.
+	m := newTestManager(t)
+	src, err := m.Create("orig", CreateOptions{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	target := filepath.Join(src.Path(SubdirWorkspace), "data.txt")
+	writeFile(t, target, []byte("v1"))
+
+	dst, err := m.Clone("orig", "copy", CloneOptions{})
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+
+	staging := target + ".new"
+	if err := os.WriteFile(staging, []byte("v2"), 0o644); err != nil {
+		t.Fatalf("write staging: %v", err)
+	}
+	if err := os.Rename(staging, target); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst.Path(SubdirWorkspace), "data.txt"))
+	if err != nil {
+		t.Fatalf("read clone payload: %v", err)
+	}
+	if string(got) != "v1" {
+		t.Fatalf("clone payload = %q, want v1 (source mutation leaked through hardlink)", got)
+	}
+}
+
+func TestCloneCreatesAllLayoutSubdirs(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("orig", CreateOptions{}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	dst, err := m.Clone("orig", "copy", CloneOptions{})
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	for _, sub := range []Subdir{SubdirWorkspace, SubdirHome, SubdirCache, SubdirSnapshots, SubdirLogs, SubdirTmp} {
+		info, err := os.Stat(dst.Path(sub))
+		if err != nil {
+			t.Fatalf("stat %s: %v", sub, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s is not a directory", sub)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dst.Root(), "config.yaml")); err != nil {
+		t.Fatalf("config.yaml missing in clone: %v", err)
+	}
+}
+
+func TestCloneDoesNotMutateSourceConfig(t *testing.T) {
+	m := newTestManager(t)
+	src, err := m.Create("orig", CreateOptions{QuotaBytes: 1 << 20})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	beforeQuota := src.Quota()
+	beforeCreated := src.cfg.CreatedAt
+
+	if _, err := m.Clone("orig", "copy", CloneOptions{QuotaBytes: 4 << 20}); err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	reopened, err := m.Open("orig")
+	if err != nil {
+		t.Fatalf("Open after Clone: %v", err)
+	}
+	if reopened.Quota() != beforeQuota {
+		t.Fatalf("source quota mutated: got %d, want %d", reopened.Quota(), beforeQuota)
+	}
+	if !reopened.cfg.CreatedAt.Equal(beforeCreated) {
+		t.Fatalf("source created_at mutated")
+	}
+}
+
+func TestCloneFailureLeavesNoPartialDestination(t *testing.T) {
+	m := newTestManager(t)
+	if _, err := m.Create("orig", CreateOptions{}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := os.MkdirAll(m.sandboxesPath(), 0o755); err != nil {
+		t.Fatalf("mkdir sandboxes: %v", err)
+	}
+	conflict := filepath.Join(m.sandboxesPath(), "copy")
+	if err := os.WriteFile(conflict, []byte("not-a-dir"), 0o644); err != nil {
+		t.Fatalf("plant conflict file: %v", err)
+	}
+	if _, err := m.Clone("orig", "copy", CloneOptions{}); err == nil {
+		t.Fatalf("Clone should have failed when dst exists as a file")
+	}
+	if info, statErr := os.Stat(conflict); statErr != nil {
+		t.Fatalf("conflict file missing after failed clone: %v", statErr)
+	} else if info.IsDir() {
+		t.Fatalf("conflict file was replaced by a directory")
+	}
+	// Traversing through a regular file gives ENOTDIR, not ENOENT, so we
+	// can't rely on fs.ErrNotExist here. Asserting that the conflict file's
+	// content is still untouched is sufficient to prove no clone bytes
+	// leaked into the path.
+	got, readErr := os.ReadFile(conflict)
+	if readErr != nil {
+		t.Fatalf("read conflict file after failed clone: %v", readErr)
+	}
+	if string(got) != "not-a-dir" {
+		t.Fatalf("conflict file content mutated: got %q, want %q", got, "not-a-dir")
+	}
+}

--- a/internal/sandbox/workspace.go
+++ b/internal/sandbox/workspace.go
@@ -37,6 +37,15 @@ import (
 // (PRD §15.5: 10 GiB).
 const DefaultQuotaBytes int64 = 10 * 1024 * 1024 * 1024
 
+// DefaultMemoryBytes is the default memory ceiling for processes inside the
+// sandbox (PRD §15.7: 4 GiB). 0 means "unset / inherit defaults at runtime".
+const DefaultMemoryBytes int64 = 4 * 1024 * 1024 * 1024
+
+// DefaultCPULimit is the default CPU share. 0 means "unconstrained"; values
+// are interpreted as fractional cores (1.0 = one full core, 2.5 = two and a
+// half cores) by whoever enforces the limit at runtime.
+const DefaultCPULimit float64 = 0
+
 // Permissions used across the workspace tree.
 const (
 	dirPerm        fs.FileMode = 0o755
@@ -48,6 +57,7 @@ const (
 	configFileName = "config.yaml"
 	lockFileName   = ".lock"
 	sandboxesDir   = "sandboxes"
+	activeFileName = "active"
 )
 
 var nameRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
@@ -63,6 +73,8 @@ var (
 	// ErrLocked is returned when a session-scoped operation cannot acquire the
 	// per-workspace file lock.
 	ErrLocked = errors.New("sandbox workspace is locked by another session")
+	// ErrNoActive is returned by Active when no sandbox has been selected.
+	ErrNoActive = errors.New("no active sandbox set")
 )
 
 // Subdir identifies one of the canonical sub-paths inside a workspace.
@@ -87,20 +99,30 @@ var allSubdirs = []Subdir{
 	SubdirTmp,
 }
 
-// CreateOptions controls Create. A zero CreateOptions yields a 10 GiB quota.
+// CreateOptions controls Create. A zero CreateOptions yields the default
+// 10 GiB disk quota and 4 GiB memory limit; CPU is unconstrained.
 type CreateOptions struct {
 	// QuotaBytes is the disk quota applied to the workspace. Values <= 0
 	// fall back to DefaultQuotaBytes.
 	QuotaBytes int64
+	// MemoryBytes is the per-sandbox process memory ceiling. Values <= 0
+	// fall back to DefaultMemoryBytes.
+	MemoryBytes int64
+	// CPULimit is the CPU allowance expressed in fractional cores (1.0 =
+	// one full core). Values <= 0 mean unconstrained.
+	CPULimit float64
 }
 
 // WorkspaceInfo is a lightweight directory-listing record returned by List.
 type WorkspaceInfo struct {
-	Name       string    `json:"name"`
-	Path       string    `json:"path"`
-	CreatedAt  time.Time `json:"created_at"`
-	LastUsedAt time.Time `json:"last_used_at"`
-	QuotaBytes int64     `json:"quota_bytes"`
+	Name        string    `json:"name"`
+	Path        string    `json:"path"`
+	CreatedAt   time.Time `json:"created_at"`
+	LastUsedAt  time.Time `json:"last_used_at"`
+	QuotaBytes  int64     `json:"quota_bytes"`
+	MemoryBytes int64     `json:"memory_bytes"`
+	CPULimit    float64   `json:"cpu_limit"`
+	Active      bool      `json:"active"`
 }
 
 // UsageReport summarises bytes-on-disk for one workspace, broken down by
@@ -143,10 +165,12 @@ type CleanupReport struct {
 // workspaceConfig is the on-disk YAML schema for config.yaml. Field tags use
 // snake_case so the file is friendly to manual edits.
 type workspaceConfig struct {
-	Name       string    `yaml:"name"`
-	CreatedAt  time.Time `yaml:"created_at"`
-	LastUsedAt time.Time `yaml:"last_used_at"`
-	QuotaBytes int64     `yaml:"quota_bytes"`
+	Name        string    `yaml:"name"`
+	CreatedAt   time.Time `yaml:"created_at"`
+	LastUsedAt  time.Time `yaml:"last_used_at"`
+	QuotaBytes  int64     `yaml:"quota_bytes"`
+	MemoryBytes int64     `yaml:"memory_bytes,omitempty"`
+	CPULimit    float64   `yaml:"cpu_limit,omitempty"`
 }
 
 // Manager is the entry point: Create / Open / List / Destroy named workspaces.
@@ -220,13 +244,23 @@ func (m *Manager) Create(name string, opts CreateOptions) (*Workspace, error) {
 	if quota <= 0 {
 		quota = DefaultQuotaBytes
 	}
+	memory := opts.MemoryBytes
+	if memory <= 0 {
+		memory = DefaultMemoryBytes
+	}
+	cpu := opts.CPULimit
+	if cpu < 0 {
+		cpu = DefaultCPULimit
+	}
 
 	now := time.Now().UTC()
 	cfg := workspaceConfig{
-		Name:       name,
-		CreatedAt:  now,
-		LastUsedAt: now,
-		QuotaBytes: quota,
+		Name:        name,
+		CreatedAt:   now,
+		LastUsedAt:  now,
+		QuotaBytes:  quota,
+		MemoryBytes: memory,
+		CPULimit:    cpu,
 	}
 	if err := writeConfig(path, cfg); err != nil {
 		return nil, err
@@ -290,8 +324,17 @@ func (m *Manager) List() ([]WorkspaceInfo, error) {
 			info.CreatedAt = cfg.CreatedAt
 			info.LastUsedAt = cfg.LastUsedAt
 			info.QuotaBytes = cfg.QuotaBytes
+			info.MemoryBytes = cfg.MemoryBytes
+			info.CPULimit = cfg.CPULimit
 		}
 		out = append(out, info)
+	}
+
+	active, _ := m.Active()
+	for i := range out {
+		if out[i].Name == active {
+			out[i].Active = true
+		}
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out, nil
@@ -299,6 +342,9 @@ func (m *Manager) List() ([]WorkspaceInfo, error) {
 
 // Destroy removes the workspace tree. Returns ErrNotFound if the workspace
 // does not exist; the caller can errors.Is-test for idempotent teardown.
+//
+// If the destroyed sandbox was the active one, the active pointer is cleared
+// so subsequent CLI calls don't dereference a missing sandbox.
 func (m *Manager) Destroy(name string) error {
 	if err := validateName(name); err != nil {
 		return err
@@ -312,6 +358,9 @@ func (m *Manager) Destroy(name string) error {
 	}
 	if err := os.RemoveAll(path); err != nil {
 		return fmt.Errorf("remove workspace: %w", err)
+	}
+	if active, err := m.Active(); err == nil && active == name {
+		_ = m.ClearActive()
 	}
 	return nil
 }
@@ -344,6 +393,14 @@ func (w *Workspace) Root() string { return w.path }
 // Quota returns the configured disk quota in bytes.
 func (w *Workspace) Quota() int64 { return w.cfg.QuotaBytes }
 
+// MemoryLimit returns the configured per-sandbox memory ceiling in bytes.
+// 0 means no limit was recorded.
+func (w *Workspace) MemoryLimit() int64 { return w.cfg.MemoryBytes }
+
+// CPULimit returns the configured CPU allowance in fractional cores. 0 means
+// unconstrained.
+func (w *Workspace) CPULimit() float64 { return w.cfg.CPULimit }
+
 // SetQuota updates the workspace quota and persists the change to
 // config.yaml. quota must be > 0.
 func (w *Workspace) SetQuota(bytes int64) error {
@@ -351,6 +408,26 @@ func (w *Workspace) SetQuota(bytes int64) error {
 		return fmt.Errorf("quota must be positive, got %d", bytes)
 	}
 	w.cfg.QuotaBytes = bytes
+	return writeConfig(w.path, w.cfg)
+}
+
+// SetMemoryLimit updates the per-sandbox memory ceiling and persists the
+// change. Pass 0 to clear the limit.
+func (w *Workspace) SetMemoryLimit(bytes int64) error {
+	if bytes < 0 {
+		return fmt.Errorf("memory limit must be non-negative, got %d", bytes)
+	}
+	w.cfg.MemoryBytes = bytes
+	return writeConfig(w.path, w.cfg)
+}
+
+// SetCPULimit updates the per-sandbox CPU allowance (fractional cores) and
+// persists the change. Pass 0 to clear the limit.
+func (w *Workspace) SetCPULimit(cores float64) error {
+	if cores < 0 {
+		return fmt.Errorf("cpu limit must be non-negative, got %f", cores)
+	}
+	w.cfg.CPULimit = cores
 	return writeConfig(w.path, w.cfg)
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jabreeflor/conduit/internal/contracts"
 	"github.com/jabreeflor/conduit/internal/core"
 	"github.com/jabreeflor/conduit/internal/keybindings"
+	"github.com/jabreeflor/conduit/internal/sandbox"
 	"github.com/jabreeflor/conduit/internal/sessions"
 )
 
@@ -102,7 +103,8 @@ func RunInteractive() error {
 	setKeys(km)
 
 	m := newModel(modelStatus.SelectedModel, setup, engine.SetupLocalAI).
-		WithMemoryController(engine)
+		WithMemoryController(engine).
+		WithActiveSandbox(resolveActiveSandbox())
 	// Best-effort sessions wiring (PRD §6.13): a missing home dir is
 	// non-fatal and just disables /sessions until a store is reachable.
 	// The Responder is left nil because the live provider client lands in
@@ -117,6 +119,18 @@ func RunInteractive() error {
 	)
 	_, err = p.Run()
 	return err
+}
+
+// resolveActiveSandbox reads the persisted active-sandbox pointer (PRD §15.7).
+// Returns "" when no sandbox is set so the status bar omits the segment;
+// errors are intentionally swallowed because a missing pointer is not a
+// startup failure.
+func resolveActiveSandbox() string {
+	name, err := sandbox.NewManager("").Active()
+	if err != nil {
+		return ""
+	}
+	return name
 }
 
 func formatExternalAPIOptions(options []contracts.ExternalAPIOption) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jabreeflor/conduit/internal/contracts"
 	"github.com/jabreeflor/conduit/internal/keybindings"
+	"github.com/jabreeflor/conduit/internal/multimodal"
 	"github.com/jabreeflor/conduit/internal/sessions"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -69,8 +70,9 @@ const (
 )
 
 type message struct {
-	role role
-	text string
+	role        role
+	text        string
+	attachments []multimodal.Attachment
 }
 
 // ── key bindings ─────────────────────────────────────────────────────────────
@@ -121,6 +123,13 @@ var keys = buildKeyMap(keybindings.Default())
 // setKeys swaps the global keymap. Called by the TUI entry point after
 // loading ~/.conduit/keybindings.json.
 func setKeys(km *keybindings.Keymap) { keys = buildKeyMap(km) }
+
+// parseSubmit extracts @image/@pdf directives from raw input, returning the
+// cleaned text and loaded attachments. Extracted so the Update handler and
+// tests share the same code path.
+func parseSubmit(text string) (cleanText string, atts []multimodal.Attachment, err error) {
+	return multimodal.ParseAndLoad(text)
+}
 
 // ── model ─────────────────────────────────────────────────────────────────────
 
@@ -294,7 +303,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m = m.handleSessionsSlash(text)
 					return m, nil
 				}
-				m.messages = append(m.messages, message{role: roleUser, text: text})
+				cleanText, atts, parseErr := parseSubmit(text)
+				if parseErr != nil {
+					m.messages = append(m.messages, message{role: roleAgent, text: "attachment error: " + parseErr.Error()})
+					m.input.Reset()
+					m = m.refreshContent()
+					return m, nil
+				}
+				displayText := cleanText
+				if displayText == "" && len(atts) > 0 {
+					displayText = "(attached files)"
+				}
+				m.messages = append(m.messages, message{role: roleUser, text: displayText, attachments: atts})
 				m.input.Reset()
 				m.streaming = true
 				m.streamBuffer = ""

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -151,6 +151,10 @@ type Model struct {
 	sessions        *sessions.Dispatcher
 	sessionsBrowser *SessionsBrowser
 	activeSessionID string
+
+	// activeSandbox is the currently-selected sandbox name (PRD §15.7).
+	// Empty means no sandbox is selected; the status bar omits the segment.
+	activeSandbox string
 }
 
 func newModel(activeModel string, setup contracts.FirstRunSetupSnapshot, setupLocalAI func() (contracts.FirstRunSetupSnapshot, error)) Model {
@@ -180,6 +184,13 @@ func newModel(activeModel string, setup contracts.FirstRunSetupSnapshot, setupLo
 // need a live provider.
 func (m Model) WithMemoryController(c MemoryController) Model {
 	m.memoryController = c
+	return m
+}
+
+// WithActiveSandbox sets the active-sandbox name shown in the status bar
+// (PRD §15.7). Pass an empty string to hide the segment.
+func (m Model) WithActiveSandbox(name string) Model {
+	m.activeSandbox = name
 	return m
 }
 

--- a/internal/tui/multimodal_test.go
+++ b/internal/tui/multimodal_test.go
@@ -1,0 +1,133 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+	"github.com/jabreeflor/conduit/internal/multimodal"
+)
+
+// newTestModel returns a minimal Model suitable for unit tests. It mirrors
+// the baseline used by other tui package tests.
+func newTestModel() Model {
+	return newModel("claude-haiku-4-5", contracts.FirstRunSetupSnapshot{}, nil)
+}
+
+func TestConversationContentRendersAttachmentChips(t *testing.T) {
+	m := newTestModel()
+	m.messages = append(m.messages, message{
+		role: roleUser,
+		text: "describe this",
+		attachments: []multimodal.Attachment{
+			{Path: "/tmp/shot.png", MediaType: "image/png"},
+		},
+	})
+
+	content := m.conversationContent()
+
+	if !strings.Contains(content, "describe this") {
+		t.Errorf("conversationContent missing user text: %q", content)
+	}
+	if !strings.Contains(content, "[image: shot.png]") {
+		t.Errorf("conversationContent missing image chip: %q", content)
+	}
+}
+
+func TestConversationContentRendersPDFChip(t *testing.T) {
+	m := newTestModel()
+	m.messages = append(m.messages, message{
+		role: roleUser,
+		text: "summarize",
+		attachments: []multimodal.Attachment{
+			{Path: "/home/user/report.pdf", MediaType: "application/pdf"},
+		},
+	})
+
+	content := m.conversationContent()
+
+	if !strings.Contains(content, "[pdf: report.pdf]") {
+		t.Errorf("conversationContent missing pdf chip: %q", content)
+	}
+}
+
+func TestConversationContentNoChipsOnPlainMessage(t *testing.T) {
+	m := newTestModel()
+	m.messages = append(m.messages, message{role: roleUser, text: "hello"})
+
+	content := m.conversationContent()
+
+	if strings.Contains(content, "[image:") || strings.Contains(content, "[pdf:") {
+		t.Errorf("conversationContent has unexpected chips for plain message: %q", content)
+	}
+}
+
+func TestSubmitHandlerParsesImageDirective(t *testing.T) {
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "screenshot.png")
+	if err := os.WriteFile(imgPath, []byte("fake-png"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newTestModel()
+	// Plant the directive in the input buffer via direct field access (no tea.Program).
+	m.input.SetValue("@image " + imgPath + " what is this?")
+
+	// Simulate Submit by calling the same logic the Update handler runs.
+	text := strings.TrimSpace(m.input.Value())
+	cleanText, atts, err := parseSubmit(text)
+
+	if err != nil {
+		t.Fatalf("parseSubmit error: %v", err)
+	}
+	if cleanText != "what is this?" {
+		t.Errorf("cleanText = %q, want %q", cleanText, "what is this?")
+	}
+	if len(atts) != 1 {
+		t.Fatalf("attachments = %d, want 1", len(atts))
+	}
+	if atts[0].MediaType != "image/png" {
+		t.Errorf("MediaType = %q, want image/png", atts[0].MediaType)
+	}
+}
+
+func TestSubmitHandlerParsesPDFDirective(t *testing.T) {
+	dir := t.TempDir()
+	pdfPath := filepath.Join(dir, "report.pdf")
+	if err := os.WriteFile(pdfPath, []byte("%PDF-1.4"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanText, atts, err := parseSubmit("@pdf " + pdfPath + " summarize key findings")
+	if err != nil {
+		t.Fatalf("parseSubmit error: %v", err)
+	}
+	if cleanText != "summarize key findings" {
+		t.Errorf("cleanText = %q, want %q", cleanText, "summarize key findings")
+	}
+	if len(atts) != 1 || atts[0].MediaType != "application/pdf" {
+		t.Errorf("unexpected attachments: %+v", atts)
+	}
+}
+
+func TestSubmitHandlerReturnsErrorForMissingFile(t *testing.T) {
+	_, _, err := parseSubmit("@image /nonexistent/missing.png describe")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestSubmitHandlerPlainTextNoAttachments(t *testing.T) {
+	cleanText, atts, err := parseSubmit("just a normal message")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cleanText != "just a normal message" {
+		t.Errorf("cleanText = %q, want original", cleanText)
+	}
+	if len(atts) != 0 {
+		t.Errorf("expected no attachments, got %d", len(atts))
+	}
+}

--- a/internal/tui/status_bar_sandbox_test.go
+++ b/internal/tui/status_bar_sandbox_test.go
@@ -1,0 +1,32 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// TestStatusBarShowsActiveSandbox locks in PRD §15.7: the status bar must
+// surface the active sandbox name when one is set.
+func TestStatusBarShowsActiveSandbox(t *testing.T) {
+	m := newModel("claude-haiku-4-5", contracts.FirstRunSetupSnapshot{}, nil).
+		WithActiveSandbox("plugin-dev")
+	m.width = 120
+	out := m.renderStatusBar()
+	if !strings.Contains(out, "plugin-dev") {
+		t.Errorf("status bar missing active sandbox: %q", out)
+	}
+}
+
+// TestStatusBarHidesSandboxSegmentWhenUnset ensures the segment is silently
+// omitted when no sandbox is active so users without sandboxing don't see a
+// dangling marker.
+func TestStatusBarHidesSandboxSegmentWhenUnset(t *testing.T) {
+	m := newModel("claude-haiku-4-5", contracts.FirstRunSetupSnapshot{}, nil)
+	m.width = 120
+	out := m.renderStatusBar()
+	if strings.Contains(out, "⛶") {
+		t.Errorf("status bar shouldn't show sandbox glyph when unset: %q", out)
+	}
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -163,10 +163,15 @@ func (m Model) View() string {
 func (m Model) renderStatusBar() string {
 	mod := styleActiveModel.Render(m.activeModel)
 	cost := styleCost.Render(fmt.Sprintf("$%.4f", m.sessionCost))
-	gap := strings.Repeat(" ", max(0, m.width-lipgloss.Width(mod)-lipgloss.Width(cost)-6))
-	return styleStatusBar.Width(m.width).Render(
-		fmt.Sprintf(" %s  %s%s", mod, cost, gap),
-	)
+
+	left := fmt.Sprintf(" %s  %s", mod, cost)
+	if m.activeSandbox != "" {
+		sandbox := styleActiveModel.Render("⛶ " + m.activeSandbox)
+		left = fmt.Sprintf(" %s  %s  %s", mod, sandbox, cost)
+	}
+
+	gap := strings.Repeat(" ", max(0, m.width-lipgloss.Width(left)-2))
+	return styleStatusBar.Width(m.width).Render(left + gap)
 }
 
 func (m Model) renderMainRow() string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -7,6 +7,8 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/viewport"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jabreeflor/conduit/internal/multimodal"
 )
 
 // ── layout ────────────────────────────────────────────────────────────────────
@@ -73,7 +75,15 @@ func (m Model) conversationContent() string {
 	for _, msg := range m.messages {
 		switch msg.role {
 		case roleUser:
-			sb.WriteString(styleUser.Render("you  ") + msg.text + "\n\n")
+			sb.WriteString(styleUser.Render("you  ") + msg.text)
+			if len(msg.attachments) > 0 {
+				chips := make([]string, len(msg.attachments))
+				for i, a := range msg.attachments {
+					chips[i] = styleDim.Render(multimodal.AttachmentLabel(a))
+				}
+				sb.WriteString(" " + strings.Join(chips, " "))
+			}
+			sb.WriteString("\n\n")
 		case roleAgent:
 			sb.WriteString(styleAgent.Render("conduit  ") + msg.text + "\n\n")
 		}


### PR DESCRIPTION
Closes #57

Implements PRD §6.22: multimodal input support.

## Changes

- **`internal/multimodal/`** — new package: `ParseAndLoad` extracts `@image <path>` and `@pdf <path>` directives from user input, reads the referenced files, detects MIME types, and base64-encodes content for the Anthropic API
- **`router.Input`** — adds `Data` (base64 content) and `MediaType` fields so vision-capable providers receive the file bytes alongside the type
- **`tui.Model`** — submit handler calls `parseSubmit` to strip directives from the displayed text and attach loaded files to the user message; error surfaces inline as an agent message
- **`tui.conversationContent`** — renders attachment chips (`[image: file.png]`, `[pdf: report.pdf]`) next to the user bubble
- **Vision-aware routing** — already wired in the router: when `InputImage` or `InputPDF` inputs are present, only vision-capable providers are considered, auto-promoting to the nearest capable model

## Supported types

| Directive | Extensions |
|-----------|-----------|
| `@image`  | `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp` |
| `@pdf`    | `.pdf` |

## Tests

- `internal/multimodal/multimodal_test.go` — 10 tests covering parse, load, error cases, `ToInput`, and `AttachmentLabel`
- `internal/tui/multimodal_test.go` — 7 tests covering chip rendering and submit-path parsing end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)