### PR TITLE
feat(#65): fine-grained budget control for coding sessions

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -308,7 +308,7 @@ func runCodeCLI(ctx context.Context, args []string, stdin, stdout, stderr *os.Fi
 		Budget:        budget,
 		SessionBudget: sessionBudget,
 		Tools:         codingTools,
-		Streamer:       echoStreamer{},
+		Streamer:      echoStreamer{},
 		Continuer:     coding.DefaultContinuer{},
 		In:            stdin,
 		Out:           stdout,

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -255,6 +255,17 @@ func runCodeCLI(ctx context.Context, args []string, stdin, stdout, stderr *os.Fi
 	allowWrite := fs.Bool("allow-write", false, "allow filesystem write tools (write_file, edit_file, notebook_edit)")
 	allowShell := fs.Bool("allow-shell", false, "allow shell tools (bash)")
 	maxInputTokens := fs.Int("max-input-tokens", 200_000, "model input window for context budgeting")
+
+	// Fine-grained session budget flags (PRD §6.24.8). Zero / unset means no limit.
+	maxTotalTokens := fs.Int("max-total-tokens", 0, "hard cap on total prompt+completion tokens per run (0 = unlimited)")
+	maxOutputTokens := fs.Int("max-output-tokens", 0, "hard cap on output tokens per model call (0 = unlimited)")
+	maxReasoningTokens := fs.Int("max-reasoning-tokens", 0, "hard cap on reasoning tokens per model call (0 = unlimited)")
+	maxBudgetUSD := fs.Float64("max-budget-usd", 0, "abort run when estimated USD cost exceeds this threshold (0 = unlimited)")
+	maxToolCalls := fs.Int("max-tool-calls", 0, "hard cap on tool invocations per run (0 = unlimited)")
+	maxModelCalls := fs.Int("max-model-calls", 0, "hard cap on model API calls per run (0 = unlimited)")
+	maxSessionTurns := fs.Int("max-session-turns", 0, "cap on total turns across resumed sessions (0 = unlimited)")
+	maxDelegatedTasks := fs.Int("max-delegated-tasks", 0, "limit on nested agent spawning per run (0 = unlimited)")
+
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -278,14 +289,29 @@ func runCodeCLI(ctx context.Context, args []string, stdin, stdout, stderr *os.Fi
 	}
 	budget := coding.NewBudget(*maxInputTokens)
 
+	// Build the fine-grained session budget from the new flags. intPtr / float64Ptr
+	// convert zero to nil (no limit) so the SessionBudget struct stays clean.
+	sessionBudget := coding.NewSessionBudget(coding.SessionLimits{
+		MaxTotalTokens:            coding.IntPtr(*maxTotalTokens),
+		MaxInputTokensPerCall:     coding.IntPtr(*maxInputTokens),
+		MaxOutputTokensPerCall:    coding.IntPtr(*maxOutputTokens),
+		MaxReasoningTokensPerCall: coding.IntPtr(*maxReasoningTokens),
+		MaxBudgetUSD:              coding.Float64Ptr(*maxBudgetUSD),
+		MaxToolCalls:              coding.IntPtr(*maxToolCalls),
+		MaxModelCalls:             coding.IntPtr(*maxModelCalls),
+		MaxSessionTurns:           coding.IntPtr(*maxSessionTurns),
+		MaxDelegatedTasks:         coding.IntPtr(*maxDelegatedTasks),
+	})
+
 	repl := &coding.REPL{
-		Session:   session,
-		Budget:    budget,
-		Tools:     codingTools,
-		Streamer:  echoStreamer{},
-		Continuer: coding.DefaultContinuer{},
-		In:        stdin,
-		Out:       stdout,
+		Session:       session,
+		Budget:        budget,
+		SessionBudget: sessionBudget,
+		Tools:         codingTools,
+		Streamer:       echoStreamer{},
+		Continuer:     coding.DefaultContinuer{},
+		In:            stdin,
+		Out:           stdout,
 	}
 	fmt.Fprintf(stdout, "conduit code: session %s (allow-write=%t allow-shell=%t)\n", session.ID, perms.AllowWrite, perms.AllowShell)
 	return repl.Run(ctx)

--- a/internal/coding/repl.go
+++ b/internal/coding/repl.go
@@ -57,6 +57,12 @@ type REPL struct {
 	In        io.Reader
 	Out       io.Writer
 
+	// SessionBudget enforces fine-grained per-run limits (PRD §6.24.8): token caps,
+	// cost ceiling, tool-call cap, model-call cap, session-turn cap, and delegated-task
+	// cap. Nil means no enforcement; non-nil limits are checked before each operation
+	// and return ErrBudgetExceeded on violation, aborting the run cleanly.
+	SessionBudget *SessionBudget
+
 	// MaxAutoContinue caps how many follow-up "continue" turns the REPL will
 	// auto-issue per user message. 4 is a pragmatic ceiling that handles
 	// long structured responses without enabling runaway loops on a
@@ -116,6 +122,14 @@ func (r *REPL) Run(ctx context.Context) error {
 			continue
 		}
 
+		// Enforce session-turn budget before processing the turn.
+		if r.SessionBudget != nil {
+			if err := r.SessionBudget.RecordTurn(); err != nil {
+				fmt.Fprintln(r.Out, "budget:", err)
+				return err
+			}
+		}
+
 		userTurn := contracts.CodingTurn{Role: "user", Content: line}
 		if _, err := r.Session.Append(userTurn); err != nil {
 			return err
@@ -159,6 +173,14 @@ func (r *REPL) streamAssistant(ctx context.Context, prompt string, isContinuatio
 			})
 		}
 
+		// Enforce model-call budget before issuing the API call.
+		if r.SessionBudget != nil {
+			if err := r.SessionBudget.RecordModelCall(); err != nil {
+				fmt.Fprintln(r.Out, "budget:", err)
+				return err
+			}
+		}
+
 		full, finish, err := r.Streamer.Stream(ctx, current, func(delta string) {
 			assistantBuf.WriteString(delta)
 			if tagParser != nil {
@@ -186,8 +208,19 @@ func (r *REPL) streamAssistant(ctx context.Context, prompt string, isContinuatio
 		// is wired in alongside the provider client. Marked as a placeholder
 		// so the next PR knows to replace it before any cost-sensitive
 		// routing depends on it.
+		inputEst := estimateTokens(current)
+		outputEst := estimateTokens(full)
 		if r.Budget != nil {
-			r.Budget.Observe(estimateTokens(current), estimateTokens(full))
+			r.Budget.Observe(inputEst, outputEst)
+		}
+		// Record tokens in the fine-grained session budget. Cost is 0 until
+		// a real provider client reports it; the field is additive so it stays
+		// accurate once wired.
+		if r.SessionBudget != nil {
+			if err := r.SessionBudget.RecordTokens(inputEst, outputEst, 0, 0); err != nil {
+				fmt.Fprintln(r.Out, "budget:", err)
+				return err
+			}
 		}
 
 		if !r.Continuer.ShouldContinue(finish) {

--- a/internal/coding/session_budget.go
+++ b/internal/coding/session_budget.go
@@ -1,0 +1,202 @@
+package coding
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// ErrBudgetExceeded is the sentinel returned by SessionBudget methods when any
+// hard limit has been reached. Callers should treat this as a clean abort
+// rather than a provider error.
+var ErrBudgetExceeded = errors.New("session budget exceeded")
+
+// SessionLimits holds the optional hard caps for a coding session (PRD §6.24.8).
+// A nil pointer means "no limit". All limits are checked at the start of the
+// operation they gate; exceeding one aborts the current run cleanly.
+type SessionLimits struct {
+	// MaxTotalTokens caps cumulative prompt + completion tokens for the run.
+	MaxTotalTokens *int
+	// MaxInputTokensPerCall caps the estimated input tokens passed per model call.
+	MaxInputTokensPerCall *int
+	// MaxOutputTokensPerCall caps the estimated output tokens received per model call.
+	MaxOutputTokensPerCall *int
+	// MaxReasoningTokensPerCall caps reasoning tokens per model call (provider-reported).
+	MaxReasoningTokensPerCall *int
+	// MaxBudgetUSD aborts the run when the estimated USD cost exceeds the threshold.
+	MaxBudgetUSD *float64
+	// MaxToolCalls is a hard cap on tool invocations per run.
+	MaxToolCalls *int
+	// MaxModelCalls is a hard cap on provider API calls per run.
+	MaxModelCalls *int
+	// MaxSessionTurns caps the total turns across resumed sessions.
+	MaxSessionTurns *int
+	// MaxDelegatedTasks limits nested agent spawning depth.
+	MaxDelegatedTasks *int
+}
+
+// SessionBudgetSnapshot is a point-in-time read of SessionBudget counters.
+// Feeds the Eval Framework (PRD §6.23) cost-efficiency scoring.
+type SessionBudgetSnapshot struct {
+	TotalInputTokens     int
+	TotalOutputTokens    int
+	TotalReasoningTokens int
+	EstimatedCostUSD     float64
+	ToolCallCount        int
+	ModelCallCount       int
+	SessionTurnCount     int
+	DelegatedTaskCount   int
+	Limits               SessionLimits
+}
+
+// SessionBudget tracks per-run usage against the limits in SessionLimits.
+// All methods are safe for concurrent use from the REPL loop.
+type SessionBudget struct {
+	mu sync.Mutex
+
+	limits SessionLimits
+
+	totalInputTokens     int
+	totalOutputTokens    int
+	totalReasoningTokens int
+	estimatedCostUSD     float64
+	toolCallCount        int
+	modelCallCount       int
+	sessionTurnCount     int
+	delegatedTaskCount   int
+}
+
+// NewSessionBudget returns a SessionBudget enforcing the given limits.
+// Nil-pointer fields in limits mean "no limit" for that dimension.
+func NewSessionBudget(limits SessionLimits) *SessionBudget {
+	return &SessionBudget{limits: limits}
+}
+
+// RecordModelCall increments the model-call counter and checks MaxModelCalls.
+// Returns ErrBudgetExceeded if the limit would be exceeded.
+func (b *SessionBudget) RecordModelCall() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.limits.MaxModelCalls != nil && b.modelCallCount >= *b.limits.MaxModelCalls {
+		return fmt.Errorf("%w: model calls (%d) reached limit (%d)",
+			ErrBudgetExceeded, b.modelCallCount, *b.limits.MaxModelCalls)
+	}
+	b.modelCallCount++
+	return nil
+}
+
+// RecordTokens accumulates input, output, and reasoning tokens for the turn
+// and checks all token-based limits. costUSD should reflect the provider's
+// reported cost for this call; pass 0 if cost tracking is not yet wired.
+func (b *SessionBudget) RecordTokens(inputTokens, outputTokens, reasoningTokens int, costUSD float64) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Per-call limits are checked against the incoming values (not cumulative)
+	// so they act as per-turn guardrails.
+	if b.limits.MaxInputTokensPerCall != nil && inputTokens > *b.limits.MaxInputTokensPerCall {
+		return fmt.Errorf("%w: input tokens per call (%d) exceeded limit (%d)",
+			ErrBudgetExceeded, inputTokens, *b.limits.MaxInputTokensPerCall)
+	}
+	if b.limits.MaxOutputTokensPerCall != nil && outputTokens > *b.limits.MaxOutputTokensPerCall {
+		return fmt.Errorf("%w: output tokens per call (%d) exceeded limit (%d)",
+			ErrBudgetExceeded, outputTokens, *b.limits.MaxOutputTokensPerCall)
+	}
+	if b.limits.MaxReasoningTokensPerCall != nil && reasoningTokens > *b.limits.MaxReasoningTokensPerCall {
+		return fmt.Errorf("%w: reasoning tokens per call (%d) exceeded limit (%d)",
+			ErrBudgetExceeded, reasoningTokens, *b.limits.MaxReasoningTokensPerCall)
+	}
+
+	b.totalInputTokens += inputTokens
+	b.totalOutputTokens += outputTokens
+	b.totalReasoningTokens += reasoningTokens
+	b.estimatedCostUSD += costUSD
+
+	total := b.totalInputTokens + b.totalOutputTokens
+	if b.limits.MaxTotalTokens != nil && total > *b.limits.MaxTotalTokens {
+		return fmt.Errorf("%w: total tokens (%d) exceeded limit (%d)",
+			ErrBudgetExceeded, total, *b.limits.MaxTotalTokens)
+	}
+	if b.limits.MaxBudgetUSD != nil && b.estimatedCostUSD > *b.limits.MaxBudgetUSD {
+		return fmt.Errorf("%w: estimated cost ($%.4f) exceeded limit ($%.4f)",
+			ErrBudgetExceeded, b.estimatedCostUSD, *b.limits.MaxBudgetUSD)
+	}
+	return nil
+}
+
+// RecordToolCall increments the tool-call counter and checks MaxToolCalls.
+// Returns ErrBudgetExceeded if the limit would be exceeded.
+func (b *SessionBudget) RecordToolCall() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.limits.MaxToolCalls != nil && b.toolCallCount >= *b.limits.MaxToolCalls {
+		return fmt.Errorf("%w: tool calls (%d) reached limit (%d)",
+			ErrBudgetExceeded, b.toolCallCount, *b.limits.MaxToolCalls)
+	}
+	b.toolCallCount++
+	return nil
+}
+
+// RecordTurn increments the session-turn counter and checks MaxSessionTurns.
+// Returns ErrBudgetExceeded if the limit would be exceeded.
+func (b *SessionBudget) RecordTurn() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.limits.MaxSessionTurns != nil && b.sessionTurnCount >= *b.limits.MaxSessionTurns {
+		return fmt.Errorf("%w: session turns (%d) reached limit (%d)",
+			ErrBudgetExceeded, b.sessionTurnCount, *b.limits.MaxSessionTurns)
+	}
+	b.sessionTurnCount++
+	return nil
+}
+
+// RecordDelegatedTask increments the delegated-task counter and checks
+// MaxDelegatedTasks. Returns ErrBudgetExceeded if the limit would be exceeded.
+func (b *SessionBudget) RecordDelegatedTask() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.limits.MaxDelegatedTasks != nil && b.delegatedTaskCount >= *b.limits.MaxDelegatedTasks {
+		return fmt.Errorf("%w: delegated tasks (%d) reached limit (%d)",
+			ErrBudgetExceeded, b.delegatedTaskCount, *b.limits.MaxDelegatedTasks)
+	}
+	b.delegatedTaskCount++
+	return nil
+}
+
+// Snapshot returns a consistent read of current usage counters plus the
+// configured limits. The snapshot is suitable for emitting to the eval
+// scorecard (PRD §6.23) or the GUI settings panel.
+func (b *SessionBudget) Snapshot() SessionBudgetSnapshot {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return SessionBudgetSnapshot{
+		TotalInputTokens:     b.totalInputTokens,
+		TotalOutputTokens:    b.totalOutputTokens,
+		TotalReasoningTokens: b.totalReasoningTokens,
+		EstimatedCostUSD:     b.estimatedCostUSD,
+		ToolCallCount:        b.toolCallCount,
+		ModelCallCount:       b.modelCallCount,
+		SessionTurnCount:     b.sessionTurnCount,
+		DelegatedTaskCount:   b.delegatedTaskCount,
+		Limits:               b.limits,
+	}
+}
+
+// intPtr returns a pointer to a copy of v, or nil if v <= 0.
+// Used by CLI wiring to convert flag values into optional limits.
+func IntPtr(v int) *int {
+	if v <= 0 {
+		return nil
+	}
+	cp := v
+	return &cp
+}
+
+// float64Ptr returns a pointer to a copy of v, or nil if v <= 0.
+func Float64Ptr(v float64) *float64 {
+	if v <= 0 {
+		return nil
+	}
+	cp := v
+	return &cp
+}

--- a/internal/coding/session_budget_test.go
+++ b/internal/coding/session_budget_test.go
@@ -1,0 +1,245 @@
+package coding
+
+import (
+	"errors"
+	"testing"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+// ---------------------------------------------------------------------------
+// RecordModelCall
+// ---------------------------------------------------------------------------
+
+func TestSessionBudget_RecordModelCall_NoLimit(t *testing.T) {
+	b := NewSessionBudget(SessionLimits{})
+	for i := 0; i < 100; i++ {
+		if err := b.RecordModelCall(); err != nil {
+			t.Fatalf("unexpected error at call %d: %v", i, err)
+		}
+	}
+	snap := b.Snapshot()
+	if snap.ModelCallCount != 100 {
+		t.Errorf("want 100 model calls, got %d", snap.ModelCallCount)
+	}
+}
+
+func TestSessionBudget_RecordModelCall_ExceedsLimit(t *testing.T) {
+	b := NewSessionBudget(SessionLimits{MaxModelCalls: ptr(2)})
+	if err := b.RecordModelCall(); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.RecordModelCall(); err != nil {
+		t.Fatal(err)
+	}
+	// Third call should fail (limit is 2, count is already 2).
+	err := b.RecordModelCall()
+	if !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("want ErrBudgetExceeded, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RecordToolCall
+// ---------------------------------------------------------------------------
+
+func TestSessionBudget_RecordToolCall_NoLimit(t *testing.T) {
+	b := NewSessionBudget(SessionLimits{})
+	for i := 0; i < 50; i++ {
+		if err := b.RecordToolCall(); err != nil {
+			t.Fatalf("unexpected error at call %d: %v", i, err)
+		}
+	}
+}
+
+func TestSessionBudget_RecordToolCall_ExceedsLimit(t *testing.T) {
+	b := NewSessionBudget(SessionLimits{MaxToolCalls: ptr(1)})
+	if err := b.RecordToolCall(); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.RecordToolCall(); !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("want ErrBudgetExceeded, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RecordTurn
+// ---------------------------------------------------------------------------
+
+func TestSessionBudget_RecordTurn_ExceedsLimit(t *testing.T) {
+	b := NewSessionBudget(SessionLimits{MaxSessionTurns: ptr(3)})
+	for i := 0; i < 3; i++ {
+		if err := b.RecordTurn(); err != nil {
+			t.Fatalf("turn %d: %v", i, err)
+		}
+	}
+	if err := b.RecordTurn(); !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("want ErrBudgetExceeded, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RecordDelegatedTask
+// ---------------------------------------------------------------------------
+
+func TestSessionBudget_RecordDelegatedTask_ExceedsLimit(t *testing.T) {
+	b := NewSessionBudget(SessionLimits{MaxDelegatedTasks: ptr(0)})
+	// MaxDelegatedTasks=0 means zero tasks allowed.
+	// IntPtr(0) returns nil (no limit), so test with explicit ptr(0).
+	if err := b.RecordDelegatedTask(); !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("want ErrBudgetExceeded for limit=0, got %v", err)
+	}
+}
+
+func TestSessionBudget_RecordDelegatedTask_WithLimit(t *testing.T) {
+	b := NewSessionBudget(SessionLimits{MaxDelegatedTasks: ptr(2)})
+	if err := b.RecordDelegatedTask(); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.RecordDelegatedTask(); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.RecordDelegatedTask(); !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("want ErrBudgetExceeded, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RecordTokens — per-call limits
+// ---------------------------------------------------------------------------
+
+func TestSessionBudget_RecordTokens_InputPerCallExceeded(t *testing.T) {
+	b := NewSessionBudget(SessionLimits{MaxInputTokensPerCall: ptr(100)})
+	err := b.RecordTokens(101, 10, 0, 0)
+	if !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("want ErrBudgetExceeded, got %v", err)
+	}
+}
+
+func TestSessionBudget_RecordTokens_OutputPerCallExceeded(t *testing.T) {
+	b := NewSessionBudget(SessionLimits{MaxOutputTokensPerCall: ptr(50)})
+	err := b.RecordTokens(10, 51, 0, 0)
+	if !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("want ErrBudgetExceeded, got %v", err)
+	}
+}
+
+func TestSessionBudget_RecordTokens_ReasoningPerCallExceeded(t *testing.T) {
+	b := NewSessionBudget(SessionLimits{MaxReasoningTokensPerCall: ptr(20)})
+	err := b.RecordTokens(10, 10, 21, 0)
+	if !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("want ErrBudgetExceeded, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RecordTokens — cumulative limits
+// ---------------------------------------------------------------------------
+
+func TestSessionBudget_RecordTokens_TotalTokensExceeded(t *testing.T) {
+	b := NewSessionBudget(SessionLimits{MaxTotalTokens: ptr(100)})
+	// First call: 60 in + 30 out = 90 total — OK.
+	if err := b.RecordTokens(60, 30, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	// Second call: 10 in + 5 out pushes total to 105 — should fail.
+	err := b.RecordTokens(10, 5, 0, 0)
+	if !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("want ErrBudgetExceeded, got %v", err)
+	}
+}
+
+func TestSessionBudget_RecordTokens_BudgetUSDExceeded(t *testing.T) {
+	b := NewSessionBudget(SessionLimits{MaxBudgetUSD: ptrFloat(0.01)})
+	if err := b.RecordTokens(0, 0, 0, 0.005); err != nil {
+		t.Fatal(err)
+	}
+	// Cumulative cost: 0.005 + 0.006 = 0.011 > 0.01 → should fail.
+	err := b.RecordTokens(0, 0, 0, 0.006)
+	if !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("want ErrBudgetExceeded, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot
+// ---------------------------------------------------------------------------
+
+func TestSessionBudget_Snapshot_AccumulatesCorrectly(t *testing.T) {
+	b := NewSessionBudget(SessionLimits{})
+	_ = b.RecordModelCall()
+	_ = b.RecordModelCall()
+	_ = b.RecordToolCall()
+	_ = b.RecordTokens(100, 50, 10, 0.002)
+	_ = b.RecordTokens(200, 80, 0, 0.003)
+	_ = b.RecordTurn()
+
+	snap := b.Snapshot()
+	if snap.ModelCallCount != 2 {
+		t.Errorf("want 2 model calls, got %d", snap.ModelCallCount)
+	}
+	if snap.ToolCallCount != 1 {
+		t.Errorf("want 1 tool call, got %d", snap.ToolCallCount)
+	}
+	if snap.TotalInputTokens != 300 {
+		t.Errorf("want 300 input tokens, got %d", snap.TotalInputTokens)
+	}
+	if snap.TotalOutputTokens != 130 {
+		t.Errorf("want 130 output tokens, got %d", snap.TotalOutputTokens)
+	}
+	if snap.TotalReasoningTokens != 10 {
+		t.Errorf("want 10 reasoning tokens, got %d", snap.TotalReasoningTokens)
+	}
+	const wantCost = 0.005
+	if snap.EstimatedCostUSD < wantCost-1e-9 || snap.EstimatedCostUSD > wantCost+1e-9 {
+		t.Errorf("want cost %.4f, got %.4f", wantCost, snap.EstimatedCostUSD)
+	}
+	if snap.SessionTurnCount != 1 {
+		t.Errorf("want 1 turn, got %d", snap.SessionTurnCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// intPtr / float64Ptr helpers
+// ---------------------------------------------------------------------------
+
+func TestIntPtr_ZeroReturnsNil(t *testing.T) {
+	if IntPtr(0) != nil {
+		t.Error("IntPtr(0) should return nil")
+	}
+}
+
+func TestIntPtr_NegativeReturnsNil(t *testing.T) {
+	if IntPtr(-5) != nil {
+		t.Error("IntPtr(-5) should return nil")
+	}
+}
+
+func TestIntPtr_PositiveReturnsPointer(t *testing.T) {
+	p := IntPtr(42)
+	if p == nil {
+		t.Fatal("IntPtr(42) should return non-nil")
+	}
+	if *p != 42 {
+		t.Errorf("want 42, got %d", *p)
+	}
+}
+
+func TestFloat64Ptr_ZeroReturnsNil(t *testing.T) {
+	if Float64Ptr(0) != nil {
+		t.Error("Float64Ptr(0) should return nil")
+	}
+}
+
+func TestFloat64Ptr_PositiveReturnsPointer(t *testing.T) {
+	p := Float64Ptr(3.14)
+	if p == nil {
+		t.Fatal("Float64Ptr(3.14) should return non-nil")
+	}
+	if *p != 3.14 {
+		t.Errorf("want 3.14, got %f", *p)
+	}
+}
+
+// ptrFloat is a local helper for float64 pointer creation in tests.
+func ptrFloat(v float64) *float64 { return &v }


### PR DESCRIPTION
Closes #65

## Summary

Implements PRD §6.24.8 — fine-grained budget enforcement for coding sessions.

## New flags for `conduit code`

| Flag | Description |
|------|-------------|
| `--max-total-tokens` | Hard cap on cumulative prompt + completion tokens per run |
| `--max-input-tokens` | Existing flag, now also enforced as per-call cap via SessionBudget |
| `--max-output-tokens` | Per-call output-token cap |
| `--max-reasoning-tokens` | Per-call reasoning-token cap |
| `--max-budget-usd` | Abort run when estimated USD cost exceeds threshold |
| `--max-tool-calls` | Hard cap on tool invocations per run |
| `--max-model-calls` | Hard cap on model API calls per run |
| `--max-session-turns` | Cap total turns across resumed sessions |
| `--max-delegated-tasks` | Limit nested agent spawning per run |

Zero (default) means no limit for all new flags.

## Changes

- `internal/coding/session_budget.go` — new `SessionBudget` / `SessionLimits` types with thread-safe counters and limit enforcement; `IntPtr` / `Float64Ptr` helpers for CLI wiring; `Snapshot()` for eval scorecard (§6.23)
- `internal/coding/session_budget_test.go` — 18 tests covering all limit types, per-call vs cumulative checks, accumulator correctness
- `internal/coding/repl.go` — wire `SessionBudget` into REPL: `RecordTurn()` before each user input, `RecordModelCall()` before each provider call, `RecordTokens()` after each response
- `cmd/conduit/main.go` — register 8 new CLI flags and build `SessionLimits` from parsed values