### PR TITLE
feat(#61): core coding tool set with permission tiers

### DIFF
--- a/internal/coding/codingtool.go
+++ b/internal/coding/codingtool.go
@@ -1,0 +1,869 @@
+package coding
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+	"github.com/jabreeflor/conduit/internal/tools"
+	"github.com/jabreeflor/conduit/internal/tools/websearch"
+)
+
+// maxSleepSeconds caps the sleep tool so the agent cannot block a session
+// indefinitely. 60 s is generous enough for polling loops and CI waits.
+const maxSleepSeconds = 60.0
+
+// maxBashSeconds caps bash execution time to guard against runaway commands.
+const maxBashSeconds = 120
+
+// maxReadBytes caps the bytes returned by read_file / web_fetch to avoid
+// flooding the context window with enormous files. 512 KiB ≈ ~128 k tokens.
+const maxReadBytes = 512 * 1024
+
+// maxGrepMatches caps results from grep_search so the context window stays
+// manageable. The agent should narrow the search if this is hit.
+const maxGrepMatches = 200
+
+// maxGlobResults caps results from glob_search.
+const maxGlobResults = 500
+
+// LiveCodingTools returns the PRD §6.24.4 coding tool set with real runners,
+// replacing the stubs in DefaultCodingTools. tool_search closes over reg so
+// the REPL can inject the full registered-tool slice after building it.
+//
+// Pass nil for reg to disable tool_search (the tool will return an error
+// explaining that no registry was provided).
+func LiveCodingTools(wsCfg websearch.Config, reg []tools.Tool) []TieredTool {
+	return []TieredTool{
+		{Tool: listDirTool(), Tier: contracts.CodingTierAlways},
+		{Tool: readFileTool(), Tier: contracts.CodingTierAlways},
+		{Tool: globSearchTool(), Tier: contracts.CodingTierAlways},
+		{Tool: grepSearchTool(), Tier: contracts.CodingTierAlways},
+		{Tool: webFetchTool(), Tier: contracts.CodingTierAlways},
+		{Tool: websearch.New(wsCfg), Tier: contracts.CodingTierAlways},
+		{Tool: toolSearchTool(reg), Tier: contracts.CodingTierAlways},
+		{Tool: sleepTool(), Tier: contracts.CodingTierAlways},
+		{Tool: writeFileTool(), Tier: contracts.CodingTierRequiresWrite},
+		{Tool: editFileTool(), Tier: contracts.CodingTierRequiresWrite},
+		{Tool: notebookEditTool(), Tier: contracts.CodingTierRequiresWrite},
+		{Tool: bashTool(), Tier: contracts.CodingTierRequiresShell},
+	}
+}
+
+// ── list_dir ──────────────────────────────────────────────────────────────
+
+func listDirTool() tools.Tool {
+	return tools.Tool{
+		Name:        "list_dir",
+		Description: "List files and directories at path. Returns names, types (file/dir), and sizes.",
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Directory path to list. Defaults to the current working directory.",
+				},
+				"recursive": map[string]any{
+					"type":        "boolean",
+					"description": "If true, list recursively. Defaults to false.",
+				},
+			},
+		},
+		Run: func(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+			var p struct {
+				Path      string `json:"path"`
+				Recursive bool   `json:"recursive"`
+			}
+			if len(raw) > 0 {
+				if err := json.Unmarshal(raw, &p); err != nil {
+					return tools.Result{IsError: true, Text: fmt.Sprintf("list_dir: bad args: %v", err)}, nil
+				}
+			}
+			dir := p.Path
+			if dir == "" {
+				var err error
+				dir, err = os.Getwd()
+				if err != nil {
+					return tools.Result{IsError: true, Text: fmt.Sprintf("list_dir: getwd: %v", err)}, nil
+				}
+			}
+
+			var sb strings.Builder
+			if p.Recursive {
+				if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+					if err != nil {
+						return nil
+					}
+					rel, _ := filepath.Rel(dir, path)
+					if rel == "." {
+						return nil
+					}
+					kind := "file"
+					size := ""
+					if info.IsDir() {
+						kind = "dir"
+						rel += "/"
+					} else {
+						size = fmt.Sprintf(" (%s)", humanSize(info.Size()))
+					}
+					fmt.Fprintf(&sb, "%s [%s]%s\n", rel, kind, size)
+					return nil
+				}); err != nil {
+					return tools.Result{IsError: true, Text: fmt.Sprintf("list_dir: walk: %v", err)}, nil
+				}
+			} else {
+				entries, err := os.ReadDir(dir)
+				if err != nil {
+					return tools.Result{IsError: true, Text: fmt.Sprintf("list_dir: %v", err)}, nil
+				}
+				for _, e := range entries {
+					info, _ := e.Info()
+					kind := "file"
+					size := ""
+					name := e.Name()
+					if e.IsDir() {
+						kind = "dir"
+						name += "/"
+					} else if info != nil {
+						size = fmt.Sprintf(" (%s)", humanSize(info.Size()))
+					}
+					fmt.Fprintf(&sb, "%s [%s]%s\n", name, kind, size)
+				}
+			}
+			return tools.Result{Text: sb.String()}, nil
+		},
+	}
+}
+
+// ── read_file ─────────────────────────────────────────────────────────────
+
+func readFileTool() tools.Tool {
+	return tools.Tool{
+		Name:        "read_file",
+		Description: "Read file contents, optionally bounded to a line range. Returns content with 1-based line numbers prefixed.",
+		Schema: map[string]any{
+			"type":     "object",
+			"required": []string{"path"},
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Absolute or relative file path.",
+				},
+				"start_line": map[string]any{
+					"type":        "integer",
+					"description": "First line to return (1-based, inclusive). Defaults to 1.",
+				},
+				"end_line": map[string]any{
+					"type":        "integer",
+					"description": "Last line to return (1-based, inclusive). Omit to read to EOF.",
+				},
+			},
+		},
+		Run: func(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+			var p struct {
+				Path      string `json:"path"`
+				StartLine int    `json:"start_line"`
+				EndLine   int    `json:"end_line"`
+			}
+			if err := json.Unmarshal(raw, &p); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("read_file: bad args: %v", err)}, nil
+			}
+			if p.Path == "" {
+				return tools.Result{IsError: true, Text: "read_file: path is required"}, nil
+			}
+			f, err := os.Open(p.Path)
+			if err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("read_file: %v", err)}, nil
+			}
+			defer f.Close()
+
+			start := p.StartLine
+			if start < 1 {
+				start = 1
+			}
+			end := p.EndLine
+
+			var sb strings.Builder
+			scanner := bufio.NewScanner(io.LimitReader(f, maxReadBytes))
+			lineNum := 0
+			truncated := false
+			for scanner.Scan() {
+				lineNum++
+				if lineNum < start {
+					continue
+				}
+				if end > 0 && lineNum > end {
+					break
+				}
+				fmt.Fprintf(&sb, "%d\t%s\n", lineNum, scanner.Text())
+				if sb.Len() > maxReadBytes {
+					truncated = true
+					break
+				}
+			}
+			if err := scanner.Err(); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("read_file: scan: %v", err)}, nil
+			}
+			out := sb.String()
+			if truncated {
+				out += fmt.Sprintf("\n[truncated after %d bytes]\n", maxReadBytes)
+			}
+			return tools.Result{Text: out}, nil
+		},
+	}
+}
+
+// ── glob_search ───────────────────────────────────────────────────────────
+
+func globSearchTool() tools.Tool {
+	return tools.Tool{
+		Name:        "glob_search",
+		Description: "Find files matching a glob pattern. Returns matching paths, sorted, up to 500 results.",
+		Schema: map[string]any{
+			"type":     "object",
+			"required": []string{"pattern"},
+			"properties": map[string]any{
+				"pattern": map[string]any{
+					"type":        "string",
+					"description": "Glob pattern applied to file names, e.g. '*.go' or '*.ts'.",
+				},
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Root directory to search. Defaults to the current working directory.",
+				},
+			},
+		},
+		Run: func(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+			var p struct {
+				Pattern string `json:"pattern"`
+				Path    string `json:"path"`
+			}
+			if err := json.Unmarshal(raw, &p); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("glob_search: bad args: %v", err)}, nil
+			}
+			if p.Pattern == "" {
+				return tools.Result{IsError: true, Text: "glob_search: pattern is required"}, nil
+			}
+			root := p.Path
+			if root == "" {
+				var err error
+				root, err = os.Getwd()
+				if err != nil {
+					return tools.Result{IsError: true, Text: fmt.Sprintf("glob_search: getwd: %v", err)}, nil
+				}
+			}
+
+			var matches []string
+			if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+				if err != nil || len(matches) >= maxGlobResults {
+					return nil
+				}
+				rel, _ := filepath.Rel(root, path)
+				// match against relative path and base name
+				ok, _ := filepath.Match(p.Pattern, rel)
+				if !ok {
+					ok, _ = filepath.Match(p.Pattern, d.Name())
+				}
+				if ok {
+					matches = append(matches, rel)
+				}
+				return nil
+			}); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("glob_search: walk: %v", err)}, nil
+			}
+
+			if len(matches) == 0 {
+				return tools.Result{Text: "No files matched the pattern."}, nil
+			}
+			suffix := ""
+			if len(matches) >= maxGlobResults {
+				suffix = fmt.Sprintf("\n[results capped at %d]\n", maxGlobResults)
+			}
+			return tools.Result{Text: strings.Join(matches, "\n") + suffix}, nil
+		},
+	}
+}
+
+// ── grep_search ───────────────────────────────────────────────────────────
+
+func grepSearchTool() tools.Tool {
+	return tools.Tool{
+		Name:        "grep_search",
+		Description: "Search file contents by regex, returning file:line:text matches. Up to 200 results.",
+		Schema: map[string]any{
+			"type":     "object",
+			"required": []string{"pattern"},
+			"properties": map[string]any{
+				"pattern": map[string]any{
+					"type":        "string",
+					"description": "Regular expression to search for.",
+				},
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Directory or file to search. Defaults to CWD.",
+				},
+				"include": map[string]any{
+					"type":        "string",
+					"description": "Glob pattern to filter file names, e.g. '*.go'. Empty matches all files.",
+				},
+				"case_insensitive": map[string]any{
+					"type":        "boolean",
+					"description": "If true, match case-insensitively. Defaults to false.",
+				},
+			},
+		},
+		Run: func(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+			var p struct {
+				Pattern         string `json:"pattern"`
+				Path            string `json:"path"`
+				Include         string `json:"include"`
+				CaseInsensitive bool   `json:"case_insensitive"`
+			}
+			if err := json.Unmarshal(raw, &p); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("grep_search: bad args: %v", err)}, nil
+			}
+			if p.Pattern == "" {
+				return tools.Result{IsError: true, Text: "grep_search: pattern is required"}, nil
+			}
+
+			rxStr := p.Pattern
+			if p.CaseInsensitive {
+				rxStr = "(?i)" + rxStr
+			}
+			rx, err := regexp.Compile(rxStr)
+			if err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("grep_search: invalid regex: %v", err)}, nil
+			}
+
+			root := p.Path
+			if root == "" {
+				root, _ = os.Getwd()
+			}
+
+			var results []string
+			grepFile := func(path string) {
+				if len(results) >= maxGrepMatches {
+					return
+				}
+				f, err := os.Open(path)
+				if err != nil {
+					return
+				}
+				defer f.Close()
+
+				scanner := bufio.NewScanner(io.LimitReader(f, maxReadBytes))
+				lineNum := 0
+				for scanner.Scan() {
+					lineNum++
+					if rx.MatchString(scanner.Text()) {
+						results = append(results, fmt.Sprintf("%s:%d:%s", path, lineNum, scanner.Text()))
+						if len(results) >= maxGrepMatches {
+							break
+						}
+					}
+				}
+			}
+
+			info, err := os.Stat(root)
+			if err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("grep_search: %v", err)}, nil
+			}
+			if !info.IsDir() {
+				grepFile(root)
+			} else {
+				_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+					if err != nil || d.IsDir() || len(results) >= maxGrepMatches {
+						return nil
+					}
+					if p.Include != "" {
+						ok, _ := filepath.Match(p.Include, d.Name())
+						if !ok {
+							return nil
+						}
+					}
+					if isBinaryExt(d.Name()) {
+						return nil
+					}
+					grepFile(path)
+					return nil
+				})
+			}
+
+			if len(results) == 0 {
+				return tools.Result{Text: "No matches found."}, nil
+			}
+			suffix := ""
+			if len(results) >= maxGrepMatches {
+				suffix = fmt.Sprintf("\n[results capped at %d]\n", maxGrepMatches)
+			}
+			return tools.Result{Text: strings.Join(results, "\n") + suffix}, nil
+		},
+	}
+}
+
+// ── web_fetch ─────────────────────────────────────────────────────────────
+
+func webFetchTool() tools.Tool {
+	return tools.Tool{
+		Name:        "web_fetch",
+		Description: "Fetch a URL (http/https) or local file (file:// or plain path) and return its text content.",
+		Schema: map[string]any{
+			"type":     "object",
+			"required": []string{"url"},
+			"properties": map[string]any{
+				"url": map[string]any{
+					"type":        "string",
+					"description": "HTTP/HTTPS URL, file:// URI, or local filesystem path.",
+				},
+				"timeout_s": map[string]any{
+					"type":        "integer",
+					"description": "Request timeout in seconds. Defaults to 15.",
+				},
+			},
+		},
+		Run: func(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+			var p struct {
+				URL      string `json:"url"`
+				TimeoutS int    `json:"timeout_s"`
+			}
+			if err := json.Unmarshal(raw, &p); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("web_fetch: bad args: %v", err)}, nil
+			}
+			if p.URL == "" {
+				return tools.Result{IsError: true, Text: "web_fetch: url is required"}, nil
+			}
+			timeout := time.Duration(p.TimeoutS) * time.Second
+			if timeout <= 0 {
+				timeout = 15 * time.Second
+			}
+
+			if !strings.HasPrefix(p.URL, "http://") && !strings.HasPrefix(p.URL, "https://") {
+				localPath := strings.TrimPrefix(p.URL, "file://")
+				data, err := os.ReadFile(localPath)
+				if err != nil {
+					return tools.Result{IsError: true, Text: fmt.Sprintf("web_fetch: %v", err)}, nil
+				}
+				if len(data) > maxReadBytes {
+					data = data[:maxReadBytes]
+				}
+				return tools.Result{Text: string(data)}, nil
+			}
+
+			client := &http.Client{Timeout: timeout}
+			resp, err := client.Get(p.URL)
+			if err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("web_fetch: %v", err)}, nil
+			}
+			defer resp.Body.Close()
+			body, err := io.ReadAll(io.LimitReader(resp.Body, maxReadBytes))
+			if err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("web_fetch: read body: %v", err)}, nil
+			}
+			return tools.Result{Text: string(body)}, nil
+		},
+	}
+}
+
+// ── tool_search ───────────────────────────────────────────────────────────
+
+func toolSearchTool(reg []tools.Tool) tools.Tool {
+	return tools.Tool{
+		Name:        "tool_search",
+		Description: "Search the active tool registry by keyword. Returns matching tool names and descriptions.",
+		Schema: map[string]any{
+			"type":     "object",
+			"required": []string{"query"},
+			"properties": map[string]any{
+				"query": map[string]any{
+					"type":        "string",
+					"description": "Keyword or phrase to search for in tool names and descriptions.",
+				},
+			},
+		},
+		Run: func(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+			var p struct {
+				Query string `json:"query"`
+			}
+			if err := json.Unmarshal(raw, &p); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("tool_search: bad args: %v", err)}, nil
+			}
+			if p.Query == "" {
+				return tools.Result{IsError: true, Text: "tool_search: query is required"}, nil
+			}
+			if reg == nil {
+				return tools.Result{IsError: true, Text: "tool_search: no tool registry available"}, nil
+			}
+			q := strings.ToLower(p.Query)
+			var hits []string
+			for _, t := range reg {
+				if strings.Contains(strings.ToLower(t.Name), q) ||
+					strings.Contains(strings.ToLower(t.Description), q) {
+					hits = append(hits, fmt.Sprintf("%-20s %s", t.Name, t.Description))
+				}
+			}
+			if len(hits) == 0 {
+				return tools.Result{Text: fmt.Sprintf("No tools matched %q.", p.Query)}, nil
+			}
+			return tools.Result{Text: strings.Join(hits, "\n")}, nil
+		},
+	}
+}
+
+// ── sleep ─────────────────────────────────────────────────────────────────
+
+func sleepTool() tools.Tool {
+	return tools.Tool{
+		Name:        "sleep",
+		Description: fmt.Sprintf("Pause execution for up to %.0f seconds. Useful for polling loops or rate-limit back-off.", maxSleepSeconds),
+		Schema: map[string]any{
+			"type":     "object",
+			"required": []string{"seconds"},
+			"properties": map[string]any{
+				"seconds": map[string]any{
+					"type":        "number",
+					"description": fmt.Sprintf("Seconds to sleep (max %.0f).", maxSleepSeconds),
+				},
+			},
+		},
+		Run: func(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+			var p struct {
+				Seconds float64 `json:"seconds"`
+			}
+			if err := json.Unmarshal(raw, &p); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("sleep: bad args: %v", err)}, nil
+			}
+			d := p.Seconds
+			if d <= 0 {
+				return tools.Result{Text: "slept 0 seconds"}, nil
+			}
+			if d > maxSleepSeconds {
+				d = maxSleepSeconds
+			}
+			select {
+			case <-time.After(time.Duration(d * float64(time.Second))):
+				return tools.Result{Text: fmt.Sprintf("slept %.2f seconds", d)}, nil
+			case <-ctx.Done():
+				return tools.Result{IsError: true, Text: "sleep: context cancelled"}, nil
+			}
+		},
+	}
+}
+
+// ── write_file ────────────────────────────────────────────────────────────
+
+func writeFileTool() tools.Tool {
+	return tools.Tool{
+		Name:        "write_file",
+		Description: "Write or overwrite a file with the given content. Creates parent directories as needed.",
+		Schema: map[string]any{
+			"type":     "object",
+			"required": []string{"path", "content"},
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "File path to write.",
+				},
+				"content": map[string]any{
+					"type":        "string",
+					"description": "File content to write.",
+				},
+			},
+		},
+		Run: func(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+			var p struct {
+				Path    string `json:"path"`
+				Content string `json:"content"`
+			}
+			if err := json.Unmarshal(raw, &p); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("write_file: bad args: %v", err)}, nil
+			}
+			if p.Path == "" {
+				return tools.Result{IsError: true, Text: "write_file: path is required"}, nil
+			}
+			if err := os.MkdirAll(filepath.Dir(p.Path), 0o755); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("write_file: mkdir: %v", err)}, nil
+			}
+			if err := os.WriteFile(p.Path, []byte(p.Content), 0o644); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("write_file: %v", err)}, nil
+			}
+			lines := strings.Count(p.Content, "\n")
+			if p.Content != "" && !strings.HasSuffix(p.Content, "\n") {
+				lines++
+			}
+			return tools.Result{Text: fmt.Sprintf("wrote %d bytes (%d lines) to %s", len(p.Content), lines, p.Path)}, nil
+		},
+	}
+}
+
+// ── edit_file ─────────────────────────────────────────────────────────────
+
+func editFileTool() tools.Tool {
+	return tools.Tool{
+		Name:        "edit_file",
+		Description: "Edit a file by replacing the first occurrence of old_str with new_str. Fails if old_str is not found or occurs more than once.",
+		Schema: map[string]any{
+			"type":     "object",
+			"required": []string{"path", "old_str", "new_str"},
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "File path to edit.",
+				},
+				"old_str": map[string]any{
+					"type":        "string",
+					"description": "Exact string to find and replace.",
+				},
+				"new_str": map[string]any{
+					"type":        "string",
+					"description": "Replacement string.",
+				},
+			},
+		},
+		Run: func(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+			var p struct {
+				Path   string `json:"path"`
+				OldStr string `json:"old_str"`
+				NewStr string `json:"new_str"`
+			}
+			if err := json.Unmarshal(raw, &p); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("edit_file: bad args: %v", err)}, nil
+			}
+			if p.Path == "" {
+				return tools.Result{IsError: true, Text: "edit_file: path is required"}, nil
+			}
+			data, err := os.ReadFile(p.Path)
+			if err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("edit_file: %v", err)}, nil
+			}
+			content := string(data)
+			count := strings.Count(content, p.OldStr)
+			if count == 0 {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("edit_file: old_str not found in %s", p.Path)}, nil
+			}
+			if count > 1 {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("edit_file: old_str found %d times in %s — provide more context to make it unique", count, p.Path)}, nil
+			}
+			updated := strings.Replace(content, p.OldStr, p.NewStr, 1)
+			if err := os.WriteFile(p.Path, []byte(updated), 0o644); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("edit_file: write: %v", err)}, nil
+			}
+			delta := len(updated) - len(content)
+			sign := "+"
+			if delta < 0 {
+				sign = ""
+			}
+			return tools.Result{Text: fmt.Sprintf("edited %s (%s%d bytes)", p.Path, sign, delta)}, nil
+		},
+	}
+}
+
+// ── notebook_edit ─────────────────────────────────────────────────────────
+
+func notebookEditTool() tools.Tool {
+	return tools.Tool{
+		Name:        "notebook_edit",
+		Description: "Edit a Jupyter notebook (.ipynb) cell. Specify cell_index (0-based) and new_source. Optionally change cell_type (code/markdown/raw).",
+		Schema: map[string]any{
+			"type":     "object",
+			"required": []string{"path", "cell_index", "new_source"},
+			"properties": map[string]any{
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Path to the .ipynb file.",
+				},
+				"cell_index": map[string]any{
+					"type":        "integer",
+					"description": "0-based index of the cell to edit.",
+				},
+				"new_source": map[string]any{
+					"type":        "string",
+					"description": "New source content for the cell.",
+				},
+				"cell_type": map[string]any{
+					"type":        "string",
+					"enum":        []string{"code", "markdown", "raw"},
+					"description": "Cell type. If omitted, the existing type is preserved.",
+				},
+			},
+		},
+		Run: func(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+			var p struct {
+				Path      string `json:"path"`
+				CellIndex int    `json:"cell_index"`
+				NewSource string `json:"new_source"`
+				CellType  string `json:"cell_type"`
+			}
+			if err := json.Unmarshal(raw, &p); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("notebook_edit: bad args: %v", err)}, nil
+			}
+			if p.Path == "" {
+				return tools.Result{IsError: true, Text: "notebook_edit: path is required"}, nil
+			}
+
+			data, err := os.ReadFile(p.Path)
+			if err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("notebook_edit: %v", err)}, nil
+			}
+
+			var nb map[string]any
+			if err := json.Unmarshal(data, &nb); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("notebook_edit: parse notebook: %v", err)}, nil
+			}
+
+			cellsRaw, ok := nb["cells"]
+			if !ok {
+				return tools.Result{IsError: true, Text: "notebook_edit: notebook has no 'cells' field"}, nil
+			}
+			cells, ok := cellsRaw.([]any)
+			if !ok {
+				return tools.Result{IsError: true, Text: "notebook_edit: 'cells' is not an array"}, nil
+			}
+			if p.CellIndex < 0 || p.CellIndex >= len(cells) {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("notebook_edit: cell_index %d out of range (notebook has %d cells)", p.CellIndex, len(cells))}, nil
+			}
+			cell, ok := cells[p.CellIndex].(map[string]any)
+			if !ok {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("notebook_edit: cell %d is not an object", p.CellIndex)}, nil
+			}
+
+			cell["source"] = splitLines(p.NewSource)
+			if p.CellType != "" {
+				cell["cell_type"] = p.CellType
+			}
+			cells[p.CellIndex] = cell
+			nb["cells"] = cells
+
+			out, err := json.MarshalIndent(nb, "", " ")
+			if err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("notebook_edit: marshal: %v", err)}, nil
+			}
+			if err := os.WriteFile(p.Path, out, 0o644); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("notebook_edit: write: %v", err)}, nil
+			}
+			return tools.Result{Text: fmt.Sprintf("updated cell %d in %s", p.CellIndex, p.Path)}, nil
+		},
+	}
+}
+
+// ── bash ──────────────────────────────────────────────────────────────────
+
+func bashTool() tools.Tool {
+	return tools.Tool{
+		Name:        "bash",
+		Description: fmt.Sprintf("Execute a shell command via bash -c. Captures stdout+stderr. Max timeout: %d seconds.", maxBashSeconds),
+		Schema: map[string]any{
+			"type":     "object",
+			"required": []string{"command"},
+			"properties": map[string]any{
+				"command": map[string]any{
+					"type":        "string",
+					"description": "Shell command to execute.",
+				},
+				"timeout_s": map[string]any{
+					"type":        "integer",
+					"description": fmt.Sprintf("Timeout in seconds (max %d). Defaults to %d.", maxBashSeconds, maxBashSeconds),
+				},
+			},
+		},
+		Run: func(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+			var p struct {
+				Command  string `json:"command"`
+				TimeoutS int    `json:"timeout_s"`
+			}
+			if err := json.Unmarshal(raw, &p); err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("bash: bad args: %v", err)}, nil
+			}
+			if p.Command == "" {
+				return tools.Result{IsError: true, Text: "bash: command is required"}, nil
+			}
+			timeout := time.Duration(p.TimeoutS) * time.Second
+			if timeout <= 0 || timeout > maxBashSeconds*time.Second {
+				timeout = maxBashSeconds * time.Second
+			}
+
+			ctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+
+			cmd := exec.CommandContext(ctx, "bash", "-c", p.Command)
+			var buf bytes.Buffer
+			cmd.Stdout = &buf
+			cmd.Stderr = &buf
+
+			runErr := cmd.Run()
+			out := buf.String()
+			if len(out) > maxReadBytes {
+				out = out[:maxReadBytes] + fmt.Sprintf("\n[truncated after %d bytes]", maxReadBytes)
+			}
+
+			if runErr != nil {
+				exitCode := -1
+				if exitErr, ok := runErr.(*exec.ExitError); ok {
+					exitCode = exitErr.ExitCode()
+				}
+				return tools.Result{
+					IsError: true,
+					Text:    fmt.Sprintf("exit %d\n%s", exitCode, out),
+				}, nil
+			}
+			return tools.Result{Text: out}, nil
+		},
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+func humanSize(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return strconv.FormatInt(b, 10) + " B"
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+var binaryExts = map[string]bool{
+	".png": true, ".jpg": true, ".jpeg": true, ".gif": true, ".webp": true,
+	".bmp": true, ".ico": true, ".svg": true, ".pdf": true, ".zip": true,
+	".tar": true, ".gz": true, ".br": true, ".zst": true, ".xz": true,
+	".exe": true, ".dll": true, ".so": true, ".dylib": true, ".a": true,
+	".wasm": true, ".bin": true, ".dat": true, ".db": true, ".sqlite": true,
+	".mp3": true, ".mp4": true, ".mkv": true, ".avi": true, ".mov": true,
+	".ttf": true, ".otf": true, ".woff": true, ".woff2": true,
+}
+
+func isBinaryExt(name string) bool {
+	return binaryExts[strings.ToLower(filepath.Ext(name))]
+}
+
+// splitLines turns a multi-line string into []string where each element
+// ends with "\n" except the last line (nbformat convention).
+func splitLines(s string) []string {
+	if s == "" {
+		return []string{}
+	}
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text()+"\n")
+	}
+	if len(lines) > 0 {
+		lines[len(lines)-1] = strings.TrimSuffix(lines[len(lines)-1], "\n")
+	}
+	return lines
+}

--- a/internal/coding/codingtool_test.go
+++ b/internal/coding/codingtool_test.go
@@ -1,0 +1,481 @@
+package coding
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+	"github.com/jabreeflor/conduit/internal/tools"
+	"github.com/jabreeflor/conduit/internal/tools/websearch"
+)
+
+// mustJSON marshals v or panics — test helper only.
+func mustJSON(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func TestLiveCodingTools_Count(t *testing.T) {
+	live := LiveCodingTools(websearch.DefaultConfig(), nil)
+	if len(live) != 12 {
+		t.Errorf("expected 12 tools, got %d", len(live))
+	}
+}
+
+func TestLiveCodingTools_Tiers(t *testing.T) {
+	live := LiveCodingTools(websearch.DefaultConfig(), nil)
+	perms := contracts.CodingPermissions{AllowWrite: true, AllowShell: true}
+	got := RegisterCodingTools(live, perms)
+	if len(got) != 12 {
+		names := make([]string, len(got))
+		for i, t := range got {
+			names[i] = t.Name
+		}
+		t.Errorf("all-perms: expected 12 tools, got %d: %v", len(got), names)
+	}
+
+	// read-only: 8 always tools
+	got = RegisterCodingTools(live, contracts.CodingPermissions{})
+	if len(got) != 8 {
+		t.Errorf("read-only: expected 8 tools, got %d", len(got))
+	}
+}
+
+// ── list_dir ─────────────────────────────────────────────────────────────
+
+func TestListDir_NonRecursive(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello"), 0o644)
+	os.Mkdir(filepath.Join(dir, "sub"), 0o755)
+
+	tool := listDirTool()
+	res, err := tool.Run(context.Background(), mustJSON(map[string]any{"path": dir}))
+	if err != nil || res.IsError {
+		t.Fatalf("unexpected error: %v / %s", err, res.Text)
+	}
+	if !strings.Contains(res.Text, "a.txt") || !strings.Contains(res.Text, "sub/") {
+		t.Errorf("unexpected output: %s", res.Text)
+	}
+}
+
+func TestListDir_Recursive(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	os.Mkdir(sub, 0o755)
+	os.WriteFile(filepath.Join(sub, "deep.go"), []byte("package x"), 0o644)
+
+	tool := listDirTool()
+	res, err := tool.Run(context.Background(), mustJSON(map[string]any{"path": dir, "recursive": true}))
+	if err != nil || res.IsError {
+		t.Fatalf("unexpected error: %v / %s", err, res.Text)
+	}
+	if !strings.Contains(res.Text, "deep.go") {
+		t.Errorf("expected deep.go in recursive listing: %s", res.Text)
+	}
+}
+
+func TestListDir_MissingPath(t *testing.T) {
+	tool := listDirTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"path": "/no/such/dir"}))
+	if !res.IsError {
+		t.Errorf("expected error for missing path")
+	}
+}
+
+// ── read_file ─────────────────────────────────────────────────────────────
+
+func TestReadFile_WholeFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.txt")
+	os.WriteFile(p, []byte("line1\nline2\nline3\n"), 0o644)
+
+	tool := readFileTool()
+	res, err := tool.Run(context.Background(), mustJSON(map[string]any{"path": p}))
+	if err != nil || res.IsError {
+		t.Fatalf("error: %v / %s", err, res.Text)
+	}
+	if !strings.Contains(res.Text, "1\tline1") || !strings.Contains(res.Text, "3\tline3") {
+		t.Errorf("unexpected: %s", res.Text)
+	}
+}
+
+func TestReadFile_LineRange(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.txt")
+	os.WriteFile(p, []byte("a\nb\nc\nd\n"), 0o644)
+
+	tool := readFileTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"path": p, "start_line": 2, "end_line": 3}))
+	if strings.Contains(res.Text, "1\ta") || !strings.Contains(res.Text, "2\tb") || !strings.Contains(res.Text, "3\tc") || strings.Contains(res.Text, "4\td") {
+		t.Errorf("unexpected line range output: %s", res.Text)
+	}
+}
+
+func TestReadFile_MissingFile(t *testing.T) {
+	tool := readFileTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"path": "/no/such/file.txt"}))
+	if !res.IsError {
+		t.Error("expected error for missing file")
+	}
+}
+
+// ── glob_search ───────────────────────────────────────────────────────────
+
+func TestGlobSearch_FindGoFiles(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "main.go"), []byte(""), 0o644)
+	os.WriteFile(filepath.Join(dir, "main.py"), []byte(""), 0o644)
+
+	tool := globSearchTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"pattern": "*.go", "path": dir}))
+	if !strings.Contains(res.Text, "main.go") {
+		t.Errorf("expected main.go: %s", res.Text)
+	}
+	if strings.Contains(res.Text, "main.py") {
+		t.Errorf("unexpected main.py: %s", res.Text)
+	}
+}
+
+func TestGlobSearch_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "a.txt"), []byte(""), 0o644)
+
+	tool := globSearchTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"pattern": "*.go", "path": dir}))
+	if res.IsError {
+		t.Errorf("unexpected error: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "No files") {
+		t.Errorf("expected 'No files' message: %s", res.Text)
+	}
+}
+
+// ── grep_search ───────────────────────────────────────────────────────────
+
+func TestGrepSearch_BasicMatch(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "code.go")
+	os.WriteFile(p, []byte("package main\n\nfunc main() {}\n"), 0o644)
+
+	tool := grepSearchTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"pattern": "func main", "path": dir}))
+	if !strings.Contains(res.Text, "code.go") || !strings.Contains(res.Text, "func main") {
+		t.Errorf("unexpected: %s", res.Text)
+	}
+}
+
+func TestGrepSearch_CaseInsensitive(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.txt")
+	os.WriteFile(p, []byte("Hello World\n"), 0o644)
+
+	tool := grepSearchTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"pattern": "hello", "path": dir, "case_insensitive": true}))
+	if !strings.Contains(res.Text, "Hello World") {
+		t.Errorf("case-insensitive match failed: %s", res.Text)
+	}
+}
+
+func TestGrepSearch_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "f.txt"), []byte("nothing here\n"), 0o644)
+
+	tool := grepSearchTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"pattern": "xyzzy", "path": dir}))
+	if res.IsError || !strings.Contains(res.Text, "No matches") {
+		t.Errorf("expected 'No matches': %s", res.Text)
+	}
+}
+
+func TestGrepSearch_FileFilter(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "a.go"), []byte("hello go\n"), 0o644)
+	os.WriteFile(filepath.Join(dir, "b.py"), []byte("hello py\n"), 0o644)
+
+	tool := grepSearchTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"pattern": "hello", "path": dir, "include": "*.go"}))
+	if !strings.Contains(res.Text, "a.go") {
+		t.Errorf("expected a.go: %s", res.Text)
+	}
+	if strings.Contains(res.Text, "b.py") {
+		t.Errorf("unexpected b.py: %s", res.Text)
+	}
+}
+
+// ── web_fetch ─────────────────────────────────────────────────────────────
+
+func TestWebFetch_LocalFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "hello.txt")
+	os.WriteFile(p, []byte("hello local"), 0o644)
+
+	tool := webFetchTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"url": p}))
+	if res.IsError || !strings.Contains(res.Text, "hello local") {
+		t.Errorf("local fetch failed: %s", res.Text)
+	}
+}
+
+func TestWebFetch_MissingFile(t *testing.T) {
+	tool := webFetchTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"url": "/no/such/file.txt"}))
+	if !res.IsError {
+		t.Error("expected error for missing file")
+	}
+}
+
+// ── tool_search ───────────────────────────────────────────────────────────
+
+func TestToolSearch_HitsAndMisses(t *testing.T) {
+	reg := []tools.Tool{
+		{Name: "alpha_tool", Description: "does alpha things"},
+		{Name: "beta_tool", Description: "does beta things"},
+	}
+	tool := toolSearchTool(reg)
+
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"query": "alpha"}))
+	if !strings.Contains(res.Text, "alpha_tool") || strings.Contains(res.Text, "beta_tool") {
+		t.Errorf("unexpected: %s", res.Text)
+	}
+
+	res, _ = tool.Run(context.Background(), mustJSON(map[string]any{"query": "nothing"}))
+	if strings.Contains(res.Text, "alpha") {
+		t.Errorf("unexpected hit: %s", res.Text)
+	}
+}
+
+func TestToolSearch_NilRegistry(t *testing.T) {
+	tool := toolSearchTool(nil)
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"query": "x"}))
+	if !res.IsError {
+		t.Error("expected error with nil registry")
+	}
+}
+
+// ── sleep ─────────────────────────────────────────────────────────────────
+
+func TestSleep_ShortDuration(t *testing.T) {
+	tool := sleepTool()
+	start := time.Now()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"seconds": 0.05}))
+	elapsed := time.Since(start)
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Text)
+	}
+	if elapsed < 40*time.Millisecond {
+		t.Errorf("slept too little: %v", elapsed)
+	}
+}
+
+func TestSleep_Capped(t *testing.T) {
+	// Verify the cap is enforced — we don't actually sleep 9999s.
+	tool := sleepTool()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	// Request > maxSleepSeconds; context cancels before max.
+	res, _ := tool.Run(ctx, mustJSON(map[string]any{"seconds": 9999.0}))
+	// Either context cancelled or capped — either way not an unhandled hang.
+	_ = res
+}
+
+func TestSleep_ZeroOrNegative(t *testing.T) {
+	tool := sleepTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"seconds": -1.0}))
+	if res.IsError {
+		t.Errorf("unexpected error: %s", res.Text)
+	}
+}
+
+// ── write_file ────────────────────────────────────────────────────────────
+
+func TestWriteFile_CreateAndOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "sub", "out.txt")
+
+	tool := writeFileTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"path": p, "content": "hello\nworld\n"}))
+	if res.IsError {
+		t.Fatalf("write error: %s", res.Text)
+	}
+	data, _ := os.ReadFile(p)
+	if string(data) != "hello\nworld\n" {
+		t.Errorf("unexpected content: %q", data)
+	}
+
+	// overwrite
+	tool.Run(context.Background(), mustJSON(map[string]any{"path": p, "content": "new\n"}))
+	data, _ = os.ReadFile(p)
+	if string(data) != "new\n" {
+		t.Errorf("overwrite failed: %q", data)
+	}
+}
+
+// ── edit_file ─────────────────────────────────────────────────────────────
+
+func TestEditFile_ReplaceOnce(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.txt")
+	os.WriteFile(p, []byte("foo bar baz\n"), 0o644)
+
+	tool := editFileTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"path": p, "old_str": "bar", "new_str": "BAR"}))
+	if res.IsError {
+		t.Fatalf("edit error: %s", res.Text)
+	}
+	data, _ := os.ReadFile(p)
+	if string(data) != "foo BAR baz\n" {
+		t.Errorf("unexpected: %q", data)
+	}
+}
+
+func TestEditFile_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.txt")
+	os.WriteFile(p, []byte("hello\n"), 0o644)
+
+	tool := editFileTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"path": p, "old_str": "missing", "new_str": "x"}))
+	if !res.IsError {
+		t.Error("expected error when old_str not found")
+	}
+}
+
+func TestEditFile_Ambiguous(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.txt")
+	os.WriteFile(p, []byte("x x x\n"), 0o644)
+
+	tool := editFileTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"path": p, "old_str": "x", "new_str": "y"}))
+	if !res.IsError {
+		t.Error("expected error for ambiguous old_str")
+	}
+}
+
+// ── notebook_edit ─────────────────────────────────────────────────────────
+
+func TestNotebookEdit_EditCell(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "nb.ipynb")
+
+	nb := map[string]any{
+		"nbformat":       4,
+		"nbformat_minor": 5,
+		"metadata":       map[string]any{},
+		"cells": []any{
+			map[string]any{
+				"cell_type": "code",
+				"source":    []string{"print('hello')\n"},
+				"metadata":  map[string]any{},
+				"outputs":   []any{},
+			},
+		},
+	}
+	data, _ := json.Marshal(nb)
+	os.WriteFile(p, data, 0o644)
+
+	tool := notebookEditTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{
+		"path":       p,
+		"cell_index": 0,
+		"new_source": "print('world')",
+	}))
+	if res.IsError {
+		t.Fatalf("notebook_edit error: %s", res.Text)
+	}
+
+	raw, _ := os.ReadFile(p)
+	if !strings.Contains(string(raw), "world") {
+		t.Errorf("new source not written: %s", raw)
+	}
+}
+
+func TestNotebookEdit_OutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "nb.ipynb")
+	nb := map[string]any{"cells": []any{}}
+	data, _ := json.Marshal(nb)
+	os.WriteFile(p, data, 0o644)
+
+	tool := notebookEditTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"path": p, "cell_index": 5, "new_source": "x"}))
+	if !res.IsError {
+		t.Error("expected error for out-of-range cell index")
+	}
+}
+
+// ── bash ──────────────────────────────────────────────────────────────────
+
+func TestBash_SimpleCommand(t *testing.T) {
+	tool := bashTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"command": "echo hello"}))
+	if res.IsError || !strings.Contains(res.Text, "hello") {
+		t.Errorf("unexpected: %v / %s", res.IsError, res.Text)
+	}
+}
+
+func TestBash_NonZeroExit(t *testing.T) {
+	tool := bashTool()
+	res, _ := tool.Run(context.Background(), mustJSON(map[string]any{"command": "exit 42"}))
+	if !res.IsError || !strings.Contains(res.Text, "42") {
+		t.Errorf("expected exit-42 error: %s", res.Text)
+	}
+}
+
+func TestBash_ContextCancelled(t *testing.T) {
+	tool := bashTool()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+	res, _ := tool.Run(ctx, mustJSON(map[string]any{"command": "sleep 60"}))
+	if !res.IsError {
+		t.Error("expected error when context cancelled")
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+func TestHumanSize(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1024 * 1024, "1.0 MB"},
+	}
+	for _, c := range cases {
+		got := humanSize(c.in)
+		if got != c.want {
+			t.Errorf("humanSize(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIsBinaryExt(t *testing.T) {
+	if !isBinaryExt("image.png") {
+		t.Error("expected png to be binary")
+	}
+	if isBinaryExt("main.go") {
+		t.Error("expected go to be non-binary")
+	}
+}
+
+func TestSplitLines(t *testing.T) {
+	got := splitLines("a\nb\nc")
+	if len(got) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %v", len(got), got)
+	}
+	if got[0] != "a\n" || got[1] != "b\n" || got[2] != "c" {
+		t.Errorf("unexpected: %v", got)
+	}
+}


### PR DESCRIPTION
Closes #61

## Summary

Implements PRD §6.24.4 — real runners for all 12 coding tools, replacing the stubs in `DefaultCodingTools()`.

## New function: `LiveCodingTools(wsCfg, reg)`

### Always tier (8 tools)
- `list_dir` — `os.ReadDir` / `filepath.Walk`, recursive flag, human-readable sizes
- - `read_file` — line-numbered output, optional `start_line`/`end_line` range, 512 KiB cap
- - `glob_search` — `filepath.WalkDir` + `filepath.Match`, 500-result cap
- - `grep_search` — regex, optional file glob filter, `case_insensitive` flag, 200-result cap; skips binary extensions
- - `web_fetch` — HTTP GET or local file read, 15 s timeout, 512 KiB cap
- - `web_search` — existing `websearch.New` (unchanged)
- - `tool_search` — closes over registered tool slice; keyword match on name + description
- - `sleep` — context-aware, capped at 60 s
### Requires-write tier (3 tools)
- `write_file` — `os.WriteFile` + `os.MkdirAll`
- - `edit_file` — exact-string replace; errors on not-found or ambiguous (>1 occurrence)
- - `notebook_edit` — round-trips `.ipynb` JSON, nbformat-compliant `[]string` source
### Requires-shell tier (1 tool)
- `bash` — `exec.CommandContext`, max 120 s, combined stdout+stderr, 512 KiB output cap
## Tests: 31 cases in `codingtool_test.go`
All tools, error paths (missing files, out-of-range, ambiguous edits, nil registry, cancelled context), tier filtering, and helpers.