### PR TITLE
feat(#60): coding-agent context management

### DIFF
--- a/internal/coding/context.go
+++ b/internal/coding/context.go
@@ -1,12 +1,17 @@
 package coding
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
 )
 
 // defaultCompactThreshold is the input-window utilization fraction at which
@@ -122,14 +127,15 @@ func (b *Budget) Snapshot() BudgetSnapshot {
 	}
 }
 
-// PasteChip is the metadata stored for each collapsed paste. The full text
-// stays accessible via the chip ID so a follow-up tool call can re-expand
-// it; for now only the prefix and first line are retained for surfaces.
+// PasteChip is the metadata stored for each collapsed paste. Text holds the
+// original content so ExpandChips can reverse the substitution; the other
+// fields are for display surfaces that want a lightweight summary.
 type PasteChip struct {
 	ID            string
 	Length        int
 	Sha256Prefix8 string
 	FirstLine     string
+	Text          string
 }
 
 // CollapsePastes replaces blocks of >= threshold characters (split on blank
@@ -232,5 +238,195 @@ func newPasteChip(index int, text string) PasteChip {
 		Length:        len(text),
 		Sha256Prefix8: prefix,
 		FirstLine:     first,
+		Text:          text,
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tokenizer-aware accounting
+// ──────────────────────────────────────────────────────────────────────────────
+
+// EstimateTokens returns an approximate BPE token count for text.
+// The heuristic (len+3)/4 rounds up to the nearest whole token and matches the
+// standard GPT-family approximation used throughout the PRD budget tables.
+func EstimateTokens(text string) int {
+	return (len(text) + 3) / 4
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PasteChip re-expansion
+// ──────────────────────────────────────────────────────────────────────────────
+
+// ExpandChips reverses CollapsePastes: every [paste:chipID] placeholder in s
+// is replaced with the original text stored in the matching chip.
+func ExpandChips(s string, chips []PasteChip) string {
+	for _, chip := range chips {
+		s = strings.ReplaceAll(s, "[paste:"+chip.ID+"]", chip.Text)
+	}
+	return s
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CLAUDE.md / .conduit/rules/*.md discovery
+// ──────────────────────────────────────────────────────────────────────────────
+
+// ContextFile pairs an on-disk path with the file's contents.
+type ContextFile struct {
+	Path    string
+	Content string
+}
+
+// DiscoverContextFiles walks the directory tree from projectRoot to the
+// filesystem root collecting CLAUDE.md files (project-local first), then reads
+// all *.md files under .conduit/rules/ in both projectRoot and homeDir.
+//
+// Missing files and directories are silently skipped; only genuine I/O errors
+// are returned so callers can operate in repos that have no context files at
+// all.
+func DiscoverContextFiles(projectRoot, homeDir string) ([]ContextFile, error) {
+	var result []ContextFile
+
+	dir := filepath.Clean(projectRoot)
+	for {
+		claudePath := filepath.Join(dir, "CLAUDE.md")
+		if data, err := os.ReadFile(claudePath); err == nil {
+			result = append(result, ContextFile{Path: claudePath, Content: string(data)})
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	for _, root := range []string{projectRoot, homeDir} {
+		rulesDir := filepath.Join(root, ".conduit", "rules")
+		entries, err := os.ReadDir(rulesDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+				continue
+			}
+			path := filepath.Join(rulesDir, entry.Name())
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, ContextFile{Path: path, Content: string(data)})
+		}
+	}
+
+	return result, nil
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Auto-snip
+// ──────────────────────────────────────────────────────────────────────────────
+
+// Snip trims the oldest non-system turns from the conversation so the estimated
+// token total fits within the budget threshold. turns[0] is always preserved as
+// the system-context anchor. maxKeepTurns = 0 disables the hard count cap.
+func (b *Budget) Snip(turns []contracts.CodingTurn, maxKeepTurns int) []contracts.CodingTurn {
+	if len(turns) <= 1 {
+		return turns
+	}
+
+	result := make([]contracts.CodingTurn, len(turns))
+	copy(result, turns)
+
+	if maxKeepTurns > 0 && len(result) > maxKeepTurns {
+		keep := maxKeepTurns - 1
+		tail := result[len(result)-keep:]
+		trimmed := make([]contracts.CodingTurn, 1+len(tail))
+		trimmed[0] = result[0]
+		copy(trimmed[1:], tail)
+		result = trimmed
+	}
+
+	b.mu.Lock()
+	window := b.modelInputWindow
+	thresh := b.threshold
+	b.mu.Unlock()
+
+	if window <= 0 {
+		return result
+	}
+
+	limit := int(float64(window) * thresh)
+	total := 0
+	for _, t := range result {
+		total += EstimateTokens(t.Content)
+	}
+
+	for total > limit && len(result) > 1 {
+		total -= EstimateTokens(result[1].Content)
+		result = append(result[:1:1], result[2:]...)
+	}
+
+	return result
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Compactor interface + RunCompaction
+// ──────────────────────────────────────────────────────────────────────────────
+
+// Compactor condenses a conversation history into a summary string that replaces
+// the full turn list after compaction.
+type Compactor interface {
+	Compact(ctx context.Context, turns []contracts.CodingTurn) (string, error)
+}
+
+// DefaultCompactor is the no-op fallback used when no summarisation model is
+// configured; it acknowledges that compaction occurred without producing a real
+// summary.
+type DefaultCompactor struct{}
+
+// Compact implements Compactor.
+func (DefaultCompactor) Compact(_ context.Context, _ []contracts.CodingTurn) (string, error) {
+	return "Context compacted.", nil
+}
+
+// RunCompaction calls c.Compact to summarise turns, resets the budget, then
+// returns a single-element slice holding the summary as an assistant turn.
+func (b *Budget) RunCompaction(ctx context.Context, turns []contracts.CodingTurn, c Compactor) ([]contracts.CodingTurn, error) {
+	summary, err := c.Compact(ctx, turns)
+	if err != nil {
+		return nil, err
+	}
+	b.Reset()
+	return []contracts.CodingTurn{{Role: "assistant", Content: summary}}, nil
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Preflight
+// ──────────────────────────────────────────────────────────────────────────────
+
+// PreflightResult reports the estimated cost of a prompt against the current
+// budget state before the turn is actually sent.
+type PreflightResult struct {
+	EstimatedTokens int
+	ShouldCompact   bool
+	OverBudget      bool
+	BudgetSnap      BudgetSnapshot
+}
+
+// Preflight estimates the token cost of prompt and checks it against the
+// current budget. OverBudget is true when the prompt would push cumulative
+// input past the model's absolute input window — the compaction threshold is a
+// softer signal captured by ShouldCompact.
+func Preflight(budget *Budget, prompt string) PreflightResult {
+	snap := budget.Snapshot()
+	est := EstimateTokens(prompt)
+	overBudget := snap.ModelInputWindow > 0 && (snap.UsedInput+est) > snap.ModelInputWindow
+	return PreflightResult{
+		EstimatedTokens: est,
+		ShouldCompact:   snap.ShouldCompact,
+		OverBudget:      overBudget,
+		BudgetSnap:      snap,
 	}
 }

--- a/internal/coding/context_test.go
+++ b/internal/coding/context_test.go
@@ -126,9 +126,9 @@ func TestEstimateTokens(t *testing.T) {
 		want  int
 	}{
 		{"", 0},
-		{"abc", 1},        // 3 chars → (3+3)/4 = 1
-		{"abcd", 1},       // 4 chars → (4+3)/4 = 1
-		{"abcde", 2},      // 5 chars → (5+3)/4 = 2
+		{"abc", 1},                     // 3 chars → (3+3)/4 = 1
+		{"abcd", 1},                    // 4 chars → (4+3)/4 = 1
+		{"abcde", 2},                   // 5 chars → (5+3)/4 = 2
 		{strings.Repeat("a", 100), 25}, // 100 chars → 25
 	}
 	for _, tc := range cases {
@@ -170,10 +170,10 @@ func TestBudgetSnip(t *testing.T) {
 	// Budget with a small window so we can trigger snipping.
 	b := NewBudget(40).WithThreshold(1.0) // limit = 40 tokens
 	turns := []contracts.CodingTurn{
-		{Role: "system", Content: strings.Repeat("a", 4)},    // 1 token (always kept)
-		{Role: "user", Content: strings.Repeat("b", 80)},     // 20 tokens
+		{Role: "system", Content: strings.Repeat("a", 4)},     // 1 token (always kept)
+		{Role: "user", Content: strings.Repeat("b", 80)},      // 20 tokens
 		{Role: "assistant", Content: strings.Repeat("c", 80)}, // 20 tokens
-		{Role: "user", Content: strings.Repeat("d", 80)},     // 20 tokens
+		{Role: "user", Content: strings.Repeat("d", 80)},      // 20 tokens
 	}
 	result := b.Snip(turns, 0)
 	// First turn must always be preserved.

--- a/internal/coding/context_test.go
+++ b/internal/coding/context_test.go
@@ -1,8 +1,13 @@
 package coding
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
 )
 
 func TestBudgetThresholdBoundary(t *testing.T) {
@@ -112,5 +117,176 @@ func TestCollapsePastesDefaultThreshold(t *testing.T) {
 	_, chips := CollapsePastes(long, 0)
 	if len(chips) != 1 {
 		t.Fatalf("expected default 500-char threshold to collapse, got %d chips", len(chips))
+	}
+}
+
+func TestEstimateTokens(t *testing.T) {
+	cases := []struct {
+		input string
+		want  int
+	}{
+		{"", 0},
+		{"abc", 1},        // 3 chars → (3+3)/4 = 1
+		{"abcd", 1},       // 4 chars → (4+3)/4 = 1
+		{"abcde", 2},      // 5 chars → (5+3)/4 = 2
+		{strings.Repeat("a", 100), 25}, // 100 chars → 25
+	}
+	for _, tc := range cases {
+		got := EstimateTokens(tc.input)
+		if got != tc.want {
+			t.Errorf("EstimateTokens(%q) = %d, want %d", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestExpandChipsRoundTrip(t *testing.T) {
+	long := strings.Repeat("x", 600)
+	collapsed, chips := CollapsePastes(long, 500)
+	if len(chips) != 1 {
+		t.Fatalf("expected 1 chip, got %d", len(chips))
+	}
+	expanded := ExpandChips(collapsed, chips)
+	if expanded != long {
+		t.Fatalf("round-trip mismatch:\n got %q\nwant %q", expanded[:min(50, len(expanded))], long[:min(50, len(long))])
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func TestExpandChipsNoMatch(t *testing.T) {
+	s := "[paste:unknown-id]"
+	out := ExpandChips(s, nil)
+	if out != s {
+		t.Fatalf("no-match chip should pass through unchanged, got %q", out)
+	}
+}
+
+func TestBudgetSnip(t *testing.T) {
+	// Budget with a small window so we can trigger snipping.
+	b := NewBudget(40).WithThreshold(1.0) // limit = 40 tokens
+	turns := []contracts.CodingTurn{
+		{Role: "system", Content: strings.Repeat("a", 4)},    // 1 token (always kept)
+		{Role: "user", Content: strings.Repeat("b", 80)},     // 20 tokens
+		{Role: "assistant", Content: strings.Repeat("c", 80)}, // 20 tokens
+		{Role: "user", Content: strings.Repeat("d", 80)},     // 20 tokens
+	}
+	result := b.Snip(turns, 0)
+	// First turn must always be preserved.
+	if result[0].Role != "system" {
+		t.Fatal("first turn (system) was dropped")
+	}
+	// Total should now be under limit.
+	total := 0
+	for _, tr := range result {
+		total += EstimateTokens(tr.Content)
+	}
+	if total >= 40 {
+		t.Fatalf("snip did not reduce tokens: total=%d, limit=40", total)
+	}
+}
+
+func TestBudgetSnipPreservesFirstWhenAlreadyFit(t *testing.T) {
+	b := NewBudget(1000)
+	turns := []contracts.CodingTurn{
+		{Role: "user", Content: "short"},
+		{Role: "assistant", Content: "reply"},
+	}
+	result := b.Snip(turns, 0)
+	if len(result) != 2 {
+		t.Fatalf("snip dropped turns when already under budget: got %d", len(result))
+	}
+}
+
+func TestDefaultCompactor(t *testing.T) {
+	c := DefaultCompactor{}
+	summary, err := c.Compact(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary == "" {
+		t.Fatal("expected non-empty summary")
+	}
+}
+
+func TestRunCompactionResetsAndReplaces(t *testing.T) {
+	b := NewBudget(1000)
+	b.Observe(500, 100)
+	turns := []contracts.CodingTurn{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "world"},
+	}
+	result, err := b.RunCompaction(context.Background(), turns, DefaultCompactor{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 compacted turn, got %d", len(result))
+	}
+	if result[0].Role != "assistant" {
+		t.Fatalf("compacted turn should be assistant, got %q", result[0].Role)
+	}
+	snap := b.Snapshot()
+	if snap.UsedInput != 0 || snap.UsedOutput != 0 {
+		t.Fatalf("budget not reset after compaction: %+v", snap)
+	}
+}
+
+func TestPreflight(t *testing.T) {
+	b := NewBudget(1000)
+	b.Observe(800, 0) // 80% used → ShouldCompact = true
+
+	prompt := strings.Repeat("a", 40) // ~10 tokens
+	result := Preflight(b, prompt)
+
+	if !result.ShouldCompact {
+		t.Fatal("expected ShouldCompact = true at 80% usage")
+	}
+	if result.EstimatedTokens != EstimateTokens(prompt) {
+		t.Fatalf("EstimatedTokens mismatch: got %d", result.EstimatedTokens)
+	}
+}
+
+func TestPreflightOverBudget(t *testing.T) {
+	b := NewBudget(100)
+	b.Observe(95, 0) // 95 used
+	// Prompt that pushes us over the 100-token window.
+	prompt := strings.Repeat("a", 24) // 6 tokens → 95+6=101 > 100
+	result := Preflight(b, prompt)
+	if !result.OverBudget {
+		t.Fatalf("expected OverBudget=true (95+6 > 100)")
+	}
+}
+
+func TestDiscoverContextFiles(t *testing.T) {
+	// Build a temp tree:
+	//   root/
+	//     CLAUDE.md
+	//     project/
+	//       CLAUDE.md
+	//       .conduit/rules/rule1.md
+	tmp := t.TempDir()
+	projectRoot := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(filepath.Join(projectRoot, ".conduit", "rules"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(tmp, "CLAUDE.md"), []byte("root context"), 0o600)
+	os.WriteFile(filepath.Join(projectRoot, "CLAUDE.md"), []byte("project context"), 0o600)
+	os.WriteFile(filepath.Join(projectRoot, ".conduit", "rules", "rule1.md"), []byte("rule1"), 0o600)
+
+	files, err := DiscoverContextFiles(projectRoot, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) < 2 {
+		t.Fatalf("expected at least 2 context files, got %d: %v", len(files), files)
+	}
+	// First file should be project-local CLAUDE.md.
+	if files[0].Content != "project context" {
+		t.Fatalf("first file should be project CLAUDE.md, got %q", files[0].Content)
 	}
 }


### PR DESCRIPTION
Closes #60

## Summary

Implements PRD §6.24.2 — full context management layer for the coding agent.

## New functions

### Context file discovery
- `DiscoverContextFiles(projectRoot, homeDir string)`: walks from project root → filesystem root collecting CLAUDE.md files (project-local first), plus reads all `.conduit/rules/*.md` from project and home dirs

### Tokenizer accounting
- `EstimateTokens(text string) int`: BPE heuristic — `(len+3)/4` — for preflight token estimation before provider counts arrive
- Added `FullText` field to `PasteChip` to enable round-trip chip expansion

### Auto-snip
- `Budget.Snip(turns, maxKeepTurns)`: drops oldest non-system turns until under the compaction threshold; always preserves turn 0 (system context)

### Compaction
- `Compactor` interface: pluggable context summariser
- `DefaultCompactor`: no-op stub returning `"Context compacted."` (real LLM call in follow-up PR)
- `Budget.RunCompaction(ctx, turns, compactor)`: calls Compact, replaces turns with one summary turn, resets budget

### Preflight
- `Preflight(budget, prompt) PreflightResult`: estimates token cost of next prompt and checks against model window before each turn

### Chip expansion
- `ExpandChips(s, chips)`: inverse of CollapsePastes — re-expands `[paste:chipID]` placeholders back to original text

## Tests
14 new test cases covering all new functions, edge cases, and round-trips (EstimateTokens, ExpandChips round-trip, Snip, DefaultCompactor, RunCompaction, Preflight, PreflightOverBudget, DiscoverContextFiles).