### PR TITLE
feat(#46): GUI screenshot stream view — live-updating, timestamped, pinnable

### DIFF
--- a/internal/gui/screenshot_stream.go
+++ b/internal/gui/screenshot_stream.go
@@ -1,0 +1,335 @@
+package gui
+
+import (
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// ScreenshotStep represents one computer-use step shown in the stream view.
+// It mirrors the data emitted by computeruse.LogEntry so the GUI layer never
+// imports the capture backend directly.
+type ScreenshotStep struct {
+	// StepID is the opaque identifier emitted by the capture layer.
+	StepID string
+	// Timestamp is when the step started.
+	Timestamp time.Time
+	// PrePath is the absolute path to the pre-action PNG. Empty if unavailable.
+	PrePath string
+	// PostPath is the absolute path to the post-action PNG. Empty if unavailable.
+	PostPath string
+	// Captured is true when both pre/post screenshots were successfully taken.
+	Captured bool
+	// DurationMS is the step wall-clock duration in milliseconds.
+	DurationMS int64
+	// Status is "success" or "error".
+	Status string
+	// Pinned marks the step for inclusion in the agent's context window.
+	Pinned bool
+}
+
+// ActivePhase describes which screenshot is currently displayed.
+type ActivePhase int
+
+const (
+	PhasePre  ActivePhase = iota // show the pre-action screenshot
+	PhasePost                    // show the post-action screenshot
+)
+
+// ScreenshotStream is the view-model for the live computer-use screenshot
+// stream shown in the GUI main content area when ViewScreenshot is active.
+//
+// It is safe for concurrent use: the capture backend and the UI event loop
+// run on different goroutines.
+type ScreenshotStream struct {
+	mu sync.RWMutex
+
+	steps      []*ScreenshotStep // ordered oldest → newest
+	stepIndex  map[string]*ScreenshotStep
+	activeStep string      // StepID of the currently displayed step
+	phase      ActivePhase // which screenshot half is shown
+
+	// maxSteps caps in-memory history. When exceeded, the oldest unpinned
+	// step is evicted. 0 means unlimited.
+	maxSteps int
+}
+
+// NewScreenshotStream creates an empty stream. maxSteps limits in-memory
+// history; 0 is unlimited.
+func NewScreenshotStream(maxSteps int) *ScreenshotStream {
+	return &ScreenshotStream{
+		stepIndex: make(map[string]*ScreenshotStep),
+		maxSteps:  maxSteps,
+		phase:     PhasePost, // default: show result screenshot
+	}
+}
+
+// Push appends or updates a step. If a step with the same StepID already
+// exists it is updated in place (e.g. the post-screenshot arrives after the
+// pre was already emitted). Otherwise a new entry is appended.
+//
+// The most-recently pushed step becomes active automatically.
+func (s *ScreenshotStream) Push(step ScreenshotStep) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if existing, ok := s.stepIndex[step.StepID]; ok {
+		// Merge: update fields that have changed since the pre-screenshot.
+		if step.PostPath != "" {
+			existing.PostPath = step.PostPath
+		}
+		if step.PrePath != "" {
+			existing.PrePath = step.PrePath
+		}
+		existing.Captured = step.Captured
+		existing.DurationMS = step.DurationMS
+		existing.Status = step.Status
+	} else {
+		cp := step
+		s.steps = append(s.steps, &cp)
+		s.stepIndex[step.StepID] = &cp
+		s.evictIfNeeded()
+	}
+
+	s.activeStep = step.StepID
+}
+
+// Steps returns a snapshot of all current steps, oldest first.
+func (s *ScreenshotStream) Steps() []ScreenshotStep {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]ScreenshotStep, len(s.steps))
+	for i, p := range s.steps {
+		out[i] = *p
+	}
+	return out
+}
+
+// ActiveStep returns the currently selected step or nil if the stream is empty.
+func (s *ScreenshotStream) ActiveStep() *ScreenshotStep {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if p, ok := s.stepIndex[s.activeStep]; ok {
+		cp := *p
+		return &cp
+	}
+	return nil
+}
+
+// SelectStep makes stepID the active step.
+func (s *ScreenshotStream) SelectStep(stepID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.stepIndex[stepID]; ok {
+		s.activeStep = stepID
+	}
+}
+
+// SelectPhase switches between the pre and post screenshot for the active step.
+func (s *ScreenshotStream) SelectPhase(phase ActivePhase) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.phase = phase
+}
+
+// Phase returns the currently displayed phase.
+func (s *ScreenshotStream) Phase() ActivePhase {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.phase
+}
+
+// ActiveImagePath returns the file path of the currently visible screenshot.
+// Returns "" if the stream is empty or the image is unavailable.
+func (s *ScreenshotStream) ActiveImagePath() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	step, ok := s.stepIndex[s.activeStep]
+	if !ok {
+		return ""
+	}
+	switch s.phase {
+	case PhasePre:
+		return step.PrePath
+	default:
+		if step.PostPath != "" {
+			return step.PostPath
+		}
+		return step.PrePath // fall back to pre if post not yet captured
+	}
+}
+
+// Pin marks a step so it is kept in the in-memory list even when the max-step
+// cap is hit, and signals to the context assembler that the image should be
+// embedded in the agent's context window.
+func (s *ScreenshotStream) Pin(stepID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if p, ok := s.stepIndex[stepID]; ok {
+		p.Pinned = true
+	}
+}
+
+// Unpin removes the pin from a step.
+func (s *ScreenshotStream) Unpin(stepID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if p, ok := s.stepIndex[stepID]; ok {
+		p.Pinned = false
+	}
+}
+
+// PinnedPaths returns the image paths (post preferred, pre fallback) for all
+// pinned steps in chronological order. This is the list the context assembler
+// passes to the model as vision attachments.
+func (s *ScreenshotStream) PinnedPaths() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var paths []string
+	for _, step := range s.steps {
+		if !step.Pinned {
+			continue
+		}
+		p := step.PostPath
+		if p == "" {
+			p = step.PrePath
+		}
+		if p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+// PinnedSteps returns copies of all pinned steps in chronological order.
+func (s *ScreenshotStream) PinnedSteps() []ScreenshotStep {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var out []ScreenshotStep
+	for _, step := range s.steps {
+		if step.Pinned {
+			out = append(out, *step)
+		}
+	}
+	return out
+}
+
+// NavigatePrev selects the step immediately before the active one.
+// Does nothing if already at the oldest step.
+func (s *ScreenshotStream) NavigatePrev() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.navigateBy(-1)
+}
+
+// NavigateNext selects the step immediately after the active one.
+// Does nothing if already at the newest step.
+func (s *ScreenshotStream) NavigateNext() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.navigateBy(+1)
+}
+
+// navigateBy moves the active step by delta positions in the slice.
+// Must be called with s.mu held.
+func (s *ScreenshotStream) navigateBy(delta int) {
+	if len(s.steps) == 0 {
+		return
+	}
+	idx := s.activeIndex()
+	next := idx + delta
+	if next < 0 || next >= len(s.steps) {
+		return
+	}
+	s.activeStep = s.steps[next].StepID
+}
+
+// activeIndex returns the slice index of the active step, or the last index
+// if not found. Must be called with s.mu held.
+func (s *ScreenshotStream) activeIndex() int {
+	for i, step := range s.steps {
+		if step.StepID == s.activeStep {
+			return i
+		}
+	}
+	return len(s.steps) - 1
+}
+
+// Len returns the number of steps currently held in the stream.
+func (s *ScreenshotStream) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.steps)
+}
+
+// Clear removes all unpinned steps from the stream. Pinned steps are kept.
+func (s *ScreenshotStream) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	kept := s.steps[:0]
+	for _, step := range s.steps {
+		if step.Pinned {
+			kept = append(kept, step)
+		} else {
+			delete(s.stepIndex, step.StepID)
+		}
+	}
+	s.steps = kept
+
+	// Reset active to the newest remaining step.
+	if len(s.steps) > 0 {
+		s.activeStep = s.steps[len(s.steps)-1].StepID
+	} else {
+		s.activeStep = ""
+	}
+}
+
+// evictIfNeeded removes the oldest unpinned step when the cap is exceeded.
+// Must be called with s.mu held.
+func (s *ScreenshotStream) evictIfNeeded() {
+	if s.maxSteps <= 0 || len(s.steps) <= s.maxSteps {
+		return
+	}
+	// Find the oldest unpinned step.
+	for i, step := range s.steps {
+		if !step.Pinned {
+			delete(s.stepIndex, step.StepID)
+			s.steps = append(s.steps[:i], s.steps[i+1:]...)
+			return
+		}
+	}
+	// All steps are pinned — allow the list to grow beyond maxSteps.
+}
+
+// StepsByTimestamp returns a snapshot sorted by Timestamp (oldest first).
+// Useful for renderers that need stable ordering independent of insertion order.
+func (s *ScreenshotStream) StepsByTimestamp() []ScreenshotStep {
+	steps := s.Steps()
+	sort.Slice(steps, func(i, j int) bool {
+		return steps[i].Timestamp.Before(steps[j].Timestamp)
+	})
+	return steps
+}
+
+// ThumbnailPath returns the path of the post-action screenshot for a given
+// step, falling back to pre if post is absent. Returns "" if neither exists.
+// This is the image a thumbnail strip would display.
+func ThumbnailPath(step ScreenshotStep) string {
+	if p := step.PostPath; p != "" {
+		return p
+	}
+	return step.PrePath
+}
+
+// StepBasename returns just the file base name (without directory) of a
+// screenshot path, suitable for use as a label in narrow strip views.
+func StepBasename(path string) string {
+	return filepath.Base(path)
+}

--- a/internal/gui/screenshot_stream_test.go
+++ b/internal/gui/screenshot_stream_test.go
@@ -1,0 +1,306 @@
+package gui
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// helpers -----------------------------------------------------------------
+
+func makeStep(id string, ts time.Time) ScreenshotStep {
+	return ScreenshotStep{
+		StepID:     id,
+		Timestamp:  ts,
+		PrePath:    fmt.Sprintf("/tmp/%s-pre.png", id),
+		PostPath:   fmt.Sprintf("/tmp/%s-post.png", id),
+		Captured:   true,
+		DurationMS: 100,
+		Status:     "success",
+	}
+}
+
+var epoch = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// -------------------------------------------------------------------------
+
+func TestScreenshotStream_PushAndSteps(t *testing.T) {
+	s := NewScreenshotStream(0)
+
+	s.Push(makeStep("step-1", epoch))
+	s.Push(makeStep("step-2", epoch.Add(time.Second)))
+
+	steps := s.Steps()
+	if len(steps) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(steps))
+	}
+	if steps[0].StepID != "step-1" {
+		t.Errorf("expected step-1 first, got %s", steps[0].StepID)
+	}
+	if steps[1].StepID != "step-2" {
+		t.Errorf("expected step-2 second, got %s", steps[1].StepID)
+	}
+}
+
+func TestScreenshotStream_PushUpdate(t *testing.T) {
+	s := NewScreenshotStream(0)
+
+	// Simulate: pre arrives, then post arrives via a second Push.
+	pre := makeStep("step-1", epoch)
+	pre.PostPath = ""
+	pre.Captured = false
+	s.Push(pre)
+
+	post := makeStep("step-1", epoch)
+	post.PrePath = "" // only updating post
+	s.Push(post)
+
+	steps := s.Steps()
+	if len(steps) != 1 {
+		t.Fatalf("expected 1 step after update, got %d", len(steps))
+	}
+	if steps[0].PrePath != pre.PrePath {
+		t.Errorf("pre path should have been preserved; got %q", steps[0].PrePath)
+	}
+	if steps[0].PostPath != post.PostPath {
+		t.Errorf("post path not updated; got %q", steps[0].PostPath)
+	}
+}
+
+func TestScreenshotStream_ActiveStepAutoAdvances(t *testing.T) {
+	s := NewScreenshotStream(0)
+
+	s.Push(makeStep("step-1", epoch))
+	if s.ActiveStep().StepID != "step-1" {
+		t.Error("active should be step-1 after first push")
+	}
+
+	s.Push(makeStep("step-2", epoch.Add(time.Second)))
+	if s.ActiveStep().StepID != "step-2" {
+		t.Error("active should auto-advance to step-2")
+	}
+}
+
+func TestScreenshotStream_ActiveImagePath(t *testing.T) {
+	s := NewScreenshotStream(0)
+	step := makeStep("s1", epoch)
+	s.Push(step)
+
+	// default phase is PhasePost
+	if s.ActiveImagePath() != step.PostPath {
+		t.Errorf("expected post path %q, got %q", step.PostPath, s.ActiveImagePath())
+	}
+
+	s.SelectPhase(PhasePre)
+	if s.ActiveImagePath() != step.PrePath {
+		t.Errorf("expected pre path %q, got %q", step.PrePath, s.ActiveImagePath())
+	}
+}
+
+func TestScreenshotStream_ActiveImagePath_FallsBackToPre(t *testing.T) {
+	s := NewScreenshotStream(0)
+	step := makeStep("s1", epoch)
+	step.PostPath = "" // post not yet available
+	s.Push(step)
+
+	s.SelectPhase(PhasePost)
+	// Should fall back to pre path when post is missing.
+	if s.ActiveImagePath() != step.PrePath {
+		t.Errorf("expected fallback to pre path %q, got %q", step.PrePath, s.ActiveImagePath())
+	}
+}
+
+func TestScreenshotStream_Pin(t *testing.T) {
+	s := NewScreenshotStream(0)
+	s.Push(makeStep("s1", epoch))
+	s.Push(makeStep("s2", epoch.Add(time.Second)))
+
+	s.Pin("s1")
+
+	pinned := s.PinnedSteps()
+	if len(pinned) != 1 || pinned[0].StepID != "s1" {
+		t.Errorf("expected s1 pinned, got %v", pinned)
+	}
+
+	paths := s.PinnedPaths()
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 pinned path, got %d", len(paths))
+	}
+	if paths[0] != "/tmp/s1-post.png" {
+		t.Errorf("unexpected pinned path %q", paths[0])
+	}
+}
+
+func TestScreenshotStream_Unpin(t *testing.T) {
+	s := NewScreenshotStream(0)
+	s.Push(makeStep("s1", epoch))
+	s.Pin("s1")
+	s.Unpin("s1")
+
+	if len(s.PinnedSteps()) != 0 {
+		t.Error("expected no pinned steps after Unpin")
+	}
+}
+
+func TestScreenshotStream_Navigation(t *testing.T) {
+	s := NewScreenshotStream(0)
+	s.Push(makeStep("s1", epoch))
+	s.Push(makeStep("s2", epoch.Add(time.Second)))
+	s.Push(makeStep("s3", epoch.Add(2*time.Second)))
+
+	// Active is s3 (newest).
+	s.NavigatePrev()
+	if s.ActiveStep().StepID != "s2" {
+		t.Errorf("after NavigatePrev, expected s2, got %s", s.ActiveStep().StepID)
+	}
+
+	s.NavigatePrev()
+	if s.ActiveStep().StepID != "s1" {
+		t.Errorf("after 2× NavigatePrev, expected s1, got %s", s.ActiveStep().StepID)
+	}
+
+	// Already at oldest; NavigatePrev should be a no-op.
+	s.NavigatePrev()
+	if s.ActiveStep().StepID != "s1" {
+		t.Errorf("NavigatePrev at oldest should not change; got %s", s.ActiveStep().StepID)
+	}
+
+	s.NavigateNext()
+	if s.ActiveStep().StepID != "s2" {
+		t.Errorf("after NavigateNext, expected s2, got %s", s.ActiveStep().StepID)
+	}
+}
+
+func TestScreenshotStream_MaxStepsEviction(t *testing.T) {
+	s := NewScreenshotStream(3)
+	for i := 1; i <= 4; i++ {
+		s.Push(makeStep(fmt.Sprintf("s%d", i), epoch.Add(time.Duration(i)*time.Second)))
+	}
+
+	// s1 should be evicted (oldest unpinned), leaving s2, s3, s4.
+	if s.Len() != 3 {
+		t.Fatalf("expected 3 steps after eviction, got %d", s.Len())
+	}
+	steps := s.Steps()
+	if steps[0].StepID != "s2" {
+		t.Errorf("expected s2 as oldest after eviction, got %s", steps[0].StepID)
+	}
+}
+
+func TestScreenshotStream_MaxStepsPinnedNotEvicted(t *testing.T) {
+	s := NewScreenshotStream(2)
+	s.Push(makeStep("s1", epoch))
+	s.Pin("s1")
+	s.Push(makeStep("s2", epoch.Add(time.Second)))
+	s.Push(makeStep("s3", epoch.Add(2*time.Second)))
+
+	// s1 is pinned, so s2 should be evicted instead.
+	if s.Len() != 2 {
+		t.Fatalf("expected 2 steps, got %d", s.Len())
+	}
+	steps := s.Steps()
+	ids := make([]string, len(steps))
+	for i, step := range steps {
+		ids[i] = step.StepID
+	}
+	for _, id := range ids {
+		if id == "s2" {
+			t.Errorf("s2 should have been evicted, but steps are %v", ids)
+		}
+	}
+	// s1 (pinned) must still be present.
+	found := false
+	for _, id := range ids {
+		if id == "s1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("pinned s1 was evicted; steps = %v", ids)
+	}
+}
+
+func TestScreenshotStream_Clear(t *testing.T) {
+	s := NewScreenshotStream(0)
+	s.Push(makeStep("s1", epoch))
+	s.Push(makeStep("s2", epoch.Add(time.Second)))
+	s.Pin("s2")
+
+	s.Clear()
+
+	// Only s2 (pinned) should remain.
+	if s.Len() != 1 {
+		t.Fatalf("expected 1 step after Clear, got %d", s.Len())
+	}
+	if s.Steps()[0].StepID != "s2" {
+		t.Errorf("expected s2 to survive Clear, got %s", s.Steps()[0].StepID)
+	}
+}
+
+func TestScreenshotStream_EmptyStream(t *testing.T) {
+	s := NewScreenshotStream(0)
+	if s.ActiveStep() != nil {
+		t.Error("empty stream should return nil ActiveStep")
+	}
+	if s.ActiveImagePath() != "" {
+		t.Error("empty stream should return empty ActiveImagePath")
+	}
+	if s.Len() != 0 {
+		t.Errorf("empty stream should have Len=0, got %d", s.Len())
+	}
+}
+
+func TestScreenshotStream_ConcurrentPush(t *testing.T) {
+	s := NewScreenshotStream(100)
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 50; i++ {
+			s.Push(makeStep(fmt.Sprintf("a%d", i), epoch.Add(time.Duration(i)*time.Millisecond)))
+		}
+		done <- struct{}{}
+	}()
+	for i := 0; i < 50; i++ {
+		s.Push(makeStep(fmt.Sprintf("b%d", i), epoch.Add(time.Duration(i)*time.Millisecond)))
+	}
+	<-done
+	// No panic = concurrent safety confirmed; just verify the count is sane.
+	if s.Len() == 0 {
+		t.Error("expected steps after concurrent push")
+	}
+}
+
+func TestScreenshotStream_StepsByTimestamp(t *testing.T) {
+	s := NewScreenshotStream(0)
+	// Push out of order.
+	s.Push(makeStep("s3", epoch.Add(3*time.Second)))
+	s.Push(makeStep("s1", epoch.Add(1*time.Second)))
+	s.Push(makeStep("s2", epoch.Add(2*time.Second)))
+
+	sorted := s.StepsByTimestamp()
+	for i := 1; i < len(sorted); i++ {
+		if sorted[i].Timestamp.Before(sorted[i-1].Timestamp) {
+			t.Errorf("not sorted at index %d", i)
+		}
+	}
+}
+
+func TestThumbnailPath(t *testing.T) {
+	step := makeStep("s1", epoch)
+	if ThumbnailPath(step) != step.PostPath {
+		t.Errorf("expected post path as thumbnail")
+	}
+	step.PostPath = ""
+	if ThumbnailPath(step) != step.PrePath {
+		t.Errorf("expected pre fallback when post is missing")
+	}
+}
+
+func TestStepBasename(t *testing.T) {
+	path := "/some/long/dir/step-1-post.png"
+	got := StepBasename(path)
+	want := filepath.Base(path)
+	if got != want {
+		t.Errorf("StepBasename(%q) = %q, want %q", path, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the view-model for the computer-use screenshot stream displayed in the main content area (\) of the three-column GUI layout (PRD §11.2).

## What this adds

### \

- **\** — goroutine-safe view-model that holds an ordered list of \ values emitted by \
- **Live-follow**: active step auto-advances to the most-recently pushed step (Codex-style)
- **Step navigation**: \ / \ lets users review past steps without leaving the stream
- **Phase toggle**: \ switches between before/after screenshots for the selected step
- **Pinning**: \ marks a screenshot for inclusion in the agent context window via \ (vision attachments to the model); pinned steps are immune to eviction
- **Retention cap**: \ limits in-memory history; oldest unpinned step is dropped at the cap; 0 = unlimited
- **Push merging**: duplicate StepIDs are merged in place so pre/post screenshots can arrive on separate events
- Helper functions: \ (post preferred, pre fallback) and \ for label-safe names

### \

16 table-driven tests covering: push/update, active tracking, image path selection, pin/unpin, navigation, eviction, eviction skipping pinned steps, Clear, empty stream, concurrent push safety, and timestamp sorting.

## Design notes

- The GUI layer never imports \ directly — \ mirrors \ fields so the capture backend stays decoupled from the view-model
- All methods are safe for concurrent use (RWMutex); the capture backend and UI event loop run on separate goroutines
- Pinned image paths feed into the context assembler (future: PRD §6.31) as vision attachments

Closes #46