### PR TITLE
feat(#70): add worktree-aware coding sessions

### DIFF
--- a/internal/coding/codingtool.go
+++ b/internal/coding/codingtool.go
@@ -46,6 +46,12 @@ const maxGlobResults = 500
 // Pass nil for reg to disable tool_search (the tool will return an error
 // explaining that no registry was provided).
 func LiveCodingTools(wsCfg websearch.Config, reg []tools.Tool) []TieredTool {
+	return LiveCodingToolsForSession(wsCfg, reg, nil)
+}
+
+// LiveCodingToolsForSession wires session-aware tools such as worktree_enter
+// and worktree_exit in addition to the standard coding tool set.
+func LiveCodingToolsForSession(wsCfg websearch.Config, reg []tools.Tool, session *Session) []TieredTool {
 	return []TieredTool{
 		{Tool: listDirTool(), Tier: contracts.CodingTierAlways},
 		{Tool: readFileTool(), Tier: contracts.CodingTierAlways},
@@ -59,6 +65,98 @@ func LiveCodingTools(wsCfg websearch.Config, reg []tools.Tool) []TieredTool {
 		{Tool: editFileTool(), Tier: contracts.CodingTierRequiresWrite},
 		{Tool: notebookEditTool(), Tier: contracts.CodingTierRequiresWrite},
 		{Tool: bashTool(), Tier: contracts.CodingTierRequiresShell},
+		{Tool: worktreeEnterTool(session), Tier: contracts.CodingTierRequiresShell},
+		{Tool: worktreeExitTool(session), Tier: contracts.CodingTierRequiresShell},
+	}
+}
+
+// ── worktree_enter / worktree_exit ───────────────────────────────────────
+
+func worktreeEnterTool(session *Session) tools.Tool {
+	return tools.Tool{
+		Name:        "worktree_enter",
+		Description: "Create and switch this coding session into a managed git worktree. Subsequent relative file and shell tools run from that worktree.",
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"repository_root": map[string]any{
+					"type":        "string",
+					"description": "Git repository root. Defaults to the session repository or current working directory.",
+				},
+				"path": map[string]any{
+					"type":        "string",
+					"description": "Worktree path. Defaults to ~/.conduit/worktrees/<session-id>.",
+				},
+				"branch": map[string]any{
+					"type":        "string",
+					"description": "Branch to create for the worktree. Defaults to conduit/<session-id>.",
+				},
+				"base_branch": map[string]any{
+					"type":        "string",
+					"description": "Base branch or commit. Defaults to the session branch.",
+				},
+			},
+		},
+		Run: func(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+			if session == nil {
+				return tools.Result{IsError: true, Text: "worktree_enter: no coding session attached"}, nil
+			}
+			var p struct {
+				RepositoryRoot string `json:"repository_root"`
+				Path           string `json:"path"`
+				Branch         string `json:"branch"`
+				BaseBranch     string `json:"base_branch"`
+			}
+			if len(raw) > 0 {
+				if err := json.Unmarshal(raw, &p); err != nil {
+					return tools.Result{IsError: true, Text: fmt.Sprintf("worktree_enter: bad args: %v", err)}, nil
+				}
+			}
+			state, err := session.WorktreeEnter(ctx, WorktreeEnterOptions{
+				RepositoryRoot: p.RepositoryRoot,
+				Path:           p.Path,
+				Branch:         p.Branch,
+				BaseBranch:     p.BaseBranch,
+			})
+			if err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("worktree_enter: %v", err)}, nil
+			}
+			return tools.Result{Text: fmt.Sprintf("entered worktree %s on %s", state.WorktreePath, state.WorktreeBranch)}, nil
+		},
+	}
+}
+
+func worktreeExitTool(session *Session) tools.Tool {
+	return tools.Tool{
+		Name:        "worktree_exit",
+		Description: "Exit the active managed git worktree and optionally keep it on disk.",
+		Schema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"keep": map[string]any{
+					"type":        "boolean",
+					"description": "Keep the worktree instead of removing it. Defaults to false.",
+				},
+			},
+		},
+		Run: func(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+			if session == nil {
+				return tools.Result{IsError: true, Text: "worktree_exit: no coding session attached"}, nil
+			}
+			var p struct {
+				Keep bool `json:"keep"`
+			}
+			if len(raw) > 0 {
+				if err := json.Unmarshal(raw, &p); err != nil {
+					return tools.Result{IsError: true, Text: fmt.Sprintf("worktree_exit: bad args: %v", err)}, nil
+				}
+			}
+			state, err := session.WorktreeExit(ctx, WorktreeExitOptions{Keep: p.Keep})
+			if err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("worktree_exit: %v", err)}, nil
+			}
+			return tools.Result{Text: fmt.Sprintf("exited worktree; cwd=%s", state.CWD)}, nil
+		},
 	}
 }
 

--- a/internal/coding/codingtool_test.go
+++ b/internal/coding/codingtool_test.go
@@ -25,8 +25,8 @@ func mustJSON(v any) json.RawMessage {
 
 func TestLiveCodingTools_Count(t *testing.T) {
 	live := LiveCodingTools(websearch.DefaultConfig(), nil)
-	if len(live) != 12 {
-		t.Errorf("expected 12 tools, got %d", len(live))
+	if len(live) != 14 {
+		t.Errorf("expected 14 tools, got %d", len(live))
 	}
 }
 
@@ -34,12 +34,12 @@ func TestLiveCodingTools_Tiers(t *testing.T) {
 	live := LiveCodingTools(websearch.DefaultConfig(), nil)
 	perms := contracts.CodingPermissions{AllowWrite: true, AllowShell: true}
 	got := RegisterCodingTools(live, perms)
-	if len(got) != 12 {
+	if len(got) != 14 {
 		names := make([]string, len(got))
 		for i, t := range got {
 			names[i] = t.Name
 		}
-		t.Errorf("all-perms: expected 12 tools, got %d: %v", len(got), names)
+		t.Errorf("all-perms: expected 14 tools, got %d: %v", len(got), names)
 	}
 
 	// read-only: 8 always tools

--- a/internal/coding/session.go
+++ b/internal/coding/session.go
@@ -2,12 +2,16 @@ package coding
 
 import (
 	"bufio"
+	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,10 +32,17 @@ const (
 // auto-continuation, in-flight compaction) and mirrored to a JSONL file
 // for resumability across restarts.
 type Session struct {
-	ID        string
-	StartedAt time.Time
-	Turns     []contracts.CodingTurn
-	Path      string
+	ID              string
+	StartedAt       time.Time
+	Turns           []contracts.CodingTurn
+	Path            string
+	RepositoryRoot  string
+	CWD             string
+	Branch          string
+	WorktreePath    string
+	WorktreeBranch  string
+	WorktreeActive  bool
+	WorktreeHistory []contracts.CodingWorktreeEvent
 
 	mu sync.Mutex
 	// homeDir is retained so future helpers (LoadSession variants, log
@@ -43,6 +54,12 @@ type Session struct {
 // reserves the JSONL path. The file itself is created lazily on first
 // Append so an aborted REPL never leaves a zero-byte journal behind.
 func NewSession(home string) (*Session, error) {
+	return NewSessionInDir(home, "")
+}
+
+// NewSessionInDir creates a session and records the current git cwd/branch
+// when cwd is inside a git repository.
+func NewSessionInDir(home, cwd string) (*Session, error) {
 	if home == "" {
 		return nil, fmt.Errorf("coding: home dir required")
 	}
@@ -54,12 +71,35 @@ func NewSession(home string) (*Session, error) {
 	if err := os.MkdirAll(dir, sessionDirPerm); err != nil {
 		return nil, fmt.Errorf("coding: create session dir: %w", err)
 	}
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
+	if resolved, err := filepath.EvalSymlinks(cwd); err == nil {
+		cwd = resolved
+	}
+	repo, branch := gitContext(cwd)
 	return &Session{
-		ID:        id,
-		StartedAt: time.Now().UTC(),
-		Path:      filepath.Join(dir, id+".jsonl"),
-		homeDir:   home,
+		ID:             id,
+		StartedAt:      time.Now().UTC(),
+		Path:           filepath.Join(dir, id+".jsonl"),
+		homeDir:        home,
+		RepositoryRoot: repo,
+		CWD:            cwd,
+		Branch:         branch,
 	}, nil
+}
+
+// NewLocalSession creates a coding session in a managed git worktree, matching
+// the chat.newLocal command semantics from the GUI/keybinding layer.
+func NewLocalSession(ctx context.Context, home, repoPath, branch string) (*Session, error) {
+	s, err := NewSessionInDir(home, repoPath)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.WorktreeEnter(ctx, WorktreeEnterOptions{Branch: branch}); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // Append assigns a snapshot ID, persists the turn to the JSONL journal,
@@ -76,6 +116,22 @@ func (s *Session) Append(turn contracts.CodingTurn) (contracts.CodingSnapshotID,
 	if turn.Index == 0 {
 		turn.Index = len(s.Turns)
 	}
+	if turn.CWD == "" {
+		turn.CWD = s.CWD
+	}
+	if turn.GitBranch == "" {
+		turn.GitBranch = s.Branch
+	}
+	if turn.RepositoryRoot == "" {
+		turn.RepositoryRoot = s.RepositoryRoot
+	}
+	if turn.WorktreePath == "" {
+		turn.WorktreePath = s.WorktreePath
+	}
+	if turn.WorktreeBranch == "" {
+		turn.WorktreeBranch = s.WorktreeBranch
+	}
+	turn.WorktreeActive = s.WorktreeActive
 	id, err := newSnapshotID(turn.At)
 	if err != nil {
 		return "", err
@@ -136,12 +192,234 @@ func LoadSession(home, id string) (*Session, error) {
 		if session.StartedAt.IsZero() || turn.At.Before(session.StartedAt) {
 			session.StartedAt = turn.At
 		}
+		session.applyTurnState(turn)
 		session.Turns = append(session.Turns, turn)
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("coding: scan session journal: %w", err)
 	}
 	return session, nil
+}
+
+// WorktreeEnterOptions controls a worktree_enter transition. Empty fields pick
+// deterministic managed defaults under ~/.conduit/worktrees.
+type WorktreeEnterOptions struct {
+	RepositoryRoot string
+	Path           string
+	Branch         string
+	BaseBranch     string
+}
+
+// WorktreeExitOptions controls a worktree_exit transition.
+type WorktreeExitOptions struct {
+	Keep bool
+}
+
+// WorktreeEnter creates a managed git worktree and switches the process cwd to
+// it so subsequent relative tools operate inside the isolated branch.
+func (s *Session) WorktreeEnter(ctx context.Context, opts WorktreeEnterOptions) (contracts.CodingWorktreeState, error) {
+	if s == nil {
+		return contracts.CodingWorktreeState{}, fmt.Errorf("coding: session required")
+	}
+	repo := opts.RepositoryRoot
+	if repo == "" {
+		repo = s.RepositoryRoot
+	}
+	if repo == "" {
+		repo, _ = gitRepoRoot(s.CWD)
+	}
+	if repo == "" {
+		return contracts.CodingWorktreeState{}, fmt.Errorf("coding: cwd is not inside a git repository")
+	}
+	base := opts.BaseBranch
+	if base == "" {
+		base = s.Branch
+	}
+	if base == "" {
+		base, _ = gitBranch(repo)
+	}
+	branch := opts.Branch
+	if branch == "" {
+		branch = "conduit/" + sanitizeBranchPart(s.ID)
+	}
+	path := opts.Path
+	if path == "" {
+		path = filepath.Join(s.homeDir, ".conduit", "worktrees", sanitizePathPart(s.ID))
+	}
+	if err := os.MkdirAll(filepath.Dir(path), sessionDirPerm); err != nil {
+		return contracts.CodingWorktreeState{}, fmt.Errorf("coding: create worktree parent: %w", err)
+	}
+	if parent, err := filepath.EvalSymlinks(filepath.Dir(path)); err == nil {
+		path = filepath.Join(parent, filepath.Base(path))
+	}
+
+	args := []string{"-C", repo, "worktree", "add", "-b", branch, path}
+	if base != "" {
+		args = append(args, base)
+	}
+	if _, err := runGit(ctx, args...); err != nil {
+		return contracts.CodingWorktreeState{}, err
+	}
+
+	prev := s.CWD
+	if err := os.Chdir(path); err != nil {
+		return contracts.CodingWorktreeState{}, fmt.Errorf("coding: chdir worktree: %w", err)
+	}
+	ev := contracts.CodingWorktreeEvent{
+		At:             time.Now().UTC(),
+		Action:         "enter",
+		RepositoryRoot: repo,
+		Path:           path,
+		Branch:         branch,
+		BaseBranch:     base,
+		PreviousCWD:    prev,
+		Message:        "entered managed git worktree",
+	}
+	s.recordWorktreeEvent(ev, repo, path, branch, true)
+	return s.WorktreeState(), nil
+}
+
+// WorktreeExit leaves the active worktree, optionally removing it from git.
+func (s *Session) WorktreeExit(ctx context.Context, opts WorktreeExitOptions) (contracts.CodingWorktreeState, error) {
+	if s == nil {
+		return contracts.CodingWorktreeState{}, fmt.Errorf("coding: session required")
+	}
+	if !s.WorktreeActive || s.WorktreePath == "" {
+		return contracts.CodingWorktreeState{}, fmt.Errorf("coding: no active worktree")
+	}
+	target := s.RepositoryRoot
+	if target == "" {
+		target = s.CWD
+	}
+	if err := os.Chdir(target); err != nil {
+		return contracts.CodingWorktreeState{}, fmt.Errorf("coding: chdir repository: %w", err)
+	}
+	if !opts.Keep {
+		if _, err := runGit(ctx, "-C", target, "worktree", "remove", "--force", s.WorktreePath); err != nil {
+			return contracts.CodingWorktreeState{}, err
+		}
+	}
+	ev := contracts.CodingWorktreeEvent{
+		At:             time.Now().UTC(),
+		Action:         "exit",
+		RepositoryRoot: target,
+		Path:           s.WorktreePath,
+		Branch:         s.WorktreeBranch,
+		Kept:           opts.Keep,
+		Message:        "exited managed git worktree",
+	}
+	s.recordWorktreeEvent(ev, target, "", "", false)
+	return s.WorktreeState(), nil
+}
+
+// WorktreeState returns a copy of the current worktree snapshot.
+func (s *Session) WorktreeState() contracts.CodingWorktreeState {
+	history := append([]contracts.CodingWorktreeEvent(nil), s.WorktreeHistory...)
+	return contracts.CodingWorktreeState{
+		SessionID:      s.ID,
+		RepositoryRoot: s.RepositoryRoot,
+		CWD:            s.CWD,
+		Branch:         s.Branch,
+		WorktreePath:   s.WorktreePath,
+		WorktreeBranch: s.WorktreeBranch,
+		WorktreeActive: s.WorktreeActive,
+		History:        history,
+	}
+}
+
+func (s *Session) applyTurnState(turn contracts.CodingTurn) {
+	if turn.CWD != "" {
+		s.CWD = turn.CWD
+	}
+	if turn.GitBranch != "" {
+		s.Branch = turn.GitBranch
+	}
+	if turn.RepositoryRoot != "" {
+		s.RepositoryRoot = turn.RepositoryRoot
+	}
+	if turn.WorktreePath != "" {
+		s.WorktreePath = turn.WorktreePath
+	}
+	if turn.WorktreeBranch != "" {
+		s.WorktreeBranch = turn.WorktreeBranch
+	}
+	s.WorktreeActive = turn.WorktreeActive
+	if turn.WorktreeEvent != nil {
+		s.WorktreeHistory = append(s.WorktreeHistory, *turn.WorktreeEvent)
+		if turn.WorktreeEvent.Action == "exit" {
+			s.WorktreePath = ""
+			s.WorktreeBranch = ""
+			s.WorktreeActive = false
+		}
+	}
+}
+
+func (s *Session) recordWorktreeEvent(ev contracts.CodingWorktreeEvent, repo, path, branch string, active bool) {
+	s.RepositoryRoot = repo
+	s.CWD = repo
+	s.WorktreePath = path
+	s.WorktreeBranch = branch
+	s.WorktreeActive = active
+	if active {
+		s.CWD = path
+		s.Branch = branch
+	} else if repo != "" {
+		if b, err := gitBranch(repo); err == nil {
+			s.Branch = b
+		}
+	}
+	s.WorktreeHistory = append(s.WorktreeHistory, ev)
+	_, _ = s.Append(contracts.CodingTurn{Role: "system", Content: ev.Message, WorktreeEvent: &ev})
+}
+
+func gitContext(cwd string) (string, string) {
+	repo, _ := gitRepoRoot(cwd)
+	branch, _ := gitBranch(cwd)
+	return repo, branch
+}
+
+func gitRepoRoot(cwd string) (string, error) {
+	if cwd == "" {
+		return "", fmt.Errorf("empty cwd")
+	}
+	out, err := runGit(context.Background(), "-C", cwd, "rev-parse", "--show-toplevel")
+	return strings.TrimSpace(out), err
+}
+
+func gitBranch(cwd string) (string, error) {
+	if cwd == "" {
+		return "", fmt.Errorf("empty cwd")
+	}
+	out, err := runGit(context.Background(), "-C", cwd, "branch", "--show-current")
+	return strings.TrimSpace(out), err
+}
+
+func runGit(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, strings.TrimSpace(buf.String()))
+	}
+	return buf.String(), nil
+}
+
+func sanitizeBranchPart(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '/' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	return strings.Trim(b.String(), "-/")
+}
+
+func sanitizePathPart(s string) string {
+	return strings.ReplaceAll(sanitizeBranchPart(s), "/", "-")
 }
 
 func newSessionID() (string, error) {

--- a/internal/coding/session_test.go
+++ b/internal/coding/session_test.go
@@ -1,8 +1,11 @@
 package coding
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jabreeflor/conduit/internal/contracts"
@@ -27,6 +30,138 @@ func TestNewSessionCreatesDir(t *testing.T) {
 	}
 	if s.ID == "" || s.Path == "" {
 		t.Fatalf("missing session metadata: %+v", s)
+	}
+}
+
+func TestNewSessionInDirRecordsGitContext(t *testing.T) {
+	repo := initGitRepo(t)
+	repo = realPath(t, repo)
+	s, err := NewSessionInDir(t.TempDir(), repo)
+	if err != nil {
+		t.Fatalf("NewSessionInDir: %v", err)
+	}
+	if s.RepositoryRoot != repo {
+		t.Fatalf("RepositoryRoot = %q, want %q", s.RepositoryRoot, repo)
+	}
+	if s.Branch != "main" {
+		t.Fatalf("Branch = %q, want main", s.Branch)
+	}
+}
+
+func TestWorktreeEnterExitPersistsAcrossLoad(t *testing.T) {
+	home := t.TempDir()
+	repo := realPath(t, initGitRepo(t))
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	s, err := NewSessionInDir(home, repo)
+	if err != nil {
+		t.Fatalf("NewSessionInDir: %v", err)
+	}
+	worktreePath := realParentPath(t, filepath.Join(home, "wt"))
+	state, err := s.WorktreeEnter(context.Background(), WorktreeEnterOptions{
+		Path:   worktreePath,
+		Branch: "feature/worktree",
+	})
+	if err != nil {
+		t.Fatalf("WorktreeEnter: %v", err)
+	}
+	if !state.WorktreeActive || state.CWD != worktreePath {
+		t.Fatalf("enter state = %+v", state)
+	}
+	if cwd, _ := os.Getwd(); cwd != worktreePath {
+		t.Fatalf("process cwd = %q, want %q", cwd, worktreePath)
+	}
+
+	loaded, err := LoadSession(home, s.ID)
+	if err != nil {
+		t.Fatalf("LoadSession after enter: %v", err)
+	}
+	if !loaded.WorktreeActive || loaded.WorktreePath != worktreePath || len(loaded.WorktreeHistory) != 1 {
+		t.Fatalf("loaded enter state = %+v", loaded.WorktreeState())
+	}
+
+	state, err = s.WorktreeExit(context.Background(), WorktreeExitOptions{})
+	if err != nil {
+		t.Fatalf("WorktreeExit: %v", err)
+	}
+	if state.WorktreeActive || state.CWD != repo {
+		t.Fatalf("exit state = %+v", state)
+	}
+	if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+		t.Fatalf("worktree path still exists or stat failed: %v", err)
+	}
+
+	loaded, err = LoadSession(home, s.ID)
+	if err != nil {
+		t.Fatalf("LoadSession after exit: %v", err)
+	}
+	if loaded.WorktreeActive || loaded.WorktreePath != "" || len(loaded.WorktreeHistory) != 2 {
+		t.Fatalf("loaded exit state = %+v", loaded.WorktreeState())
+	}
+}
+
+func TestNewLocalSessionCreatesWorktree(t *testing.T) {
+	home := t.TempDir()
+	repo := realPath(t, initGitRepo(t))
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	s, err := NewLocalSession(context.Background(), home, repo, "local/session")
+	if err != nil {
+		t.Fatalf("NewLocalSession: %v", err)
+	}
+	if !s.WorktreeActive || s.WorktreeBranch != "local/session" {
+		t.Fatalf("state = %+v", s.WorktreeState())
+	}
+	if _, err := os.Stat(s.WorktreePath); err != nil {
+		t.Fatalf("stat worktree: %v", err)
+	}
+	_, _ = s.WorktreeExit(context.Background(), WorktreeExitOptions{})
+}
+
+func initGitRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	dir := t.TempDir()
+	run(t, dir, "git", "init", "-b", "main")
+	run(t, dir, "git", "config", "user.email", "test@example.com")
+	run(t, dir, "git", "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(t, dir, "git", "add", "README.md")
+	run(t, dir, "git", "commit", "-m", "init")
+	return dir
+}
+
+func realPath(t *testing.T, path string) string {
+	t.Helper()
+	out, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func realParentPath(t *testing.T, path string) string {
+	t.Helper()
+	parent, err := filepath.EvalSymlinks(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(parent, filepath.Base(path))
+}
+
+func run(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, out)
 	}
 }
 

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -477,6 +477,10 @@ type SandboxArchitecture struct {
 	MaxMemoryOverheadMB       int
 	Shells                    []string
 	PreinstalledRuntimes      []string
+	RuntimeVersions           map[string]string
+	PackageManagers           []string
+	PreinstalledTools         []string
+	AllowlistedRegistries     []string
 	NetworkPolicy             SandboxNetworkPolicy
 	Mounts                    []SandboxMount
 	DenyHostFilesystem        bool
@@ -600,6 +604,34 @@ type CodingPermissions struct {
 	AllowShell bool
 }
 
+// CodingWorktreeEvent is one state transition in the coding worktree runtime.
+// It is surfaced in the GUI Worktree tab and persisted through coding turns so
+// a resumed session can recover the last known cwd/worktree state.
+type CodingWorktreeEvent struct {
+	At             time.Time `json:"at"`
+	Action         string    `json:"action"`
+	RepositoryRoot string    `json:"repository_root,omitempty"`
+	Path           string    `json:"path,omitempty"`
+	Branch         string    `json:"branch,omitempty"`
+	BaseBranch     string    `json:"base_branch,omitempty"`
+	PreviousCWD    string    `json:"previous_cwd,omitempty"`
+	Kept           bool      `json:"kept,omitempty"`
+	Message        string    `json:"message,omitempty"`
+}
+
+// CodingWorktreeState is the session-level git/worktree snapshot shared by
+// coding sessions, tools, and GUI surfaces.
+type CodingWorktreeState struct {
+	SessionID      string                `json:"session_id"`
+	RepositoryRoot string                `json:"repository_root,omitempty"`
+	CWD            string                `json:"cwd,omitempty"`
+	Branch         string                `json:"branch,omitempty"`
+	WorktreePath   string                `json:"worktree_path,omitempty"`
+	WorktreeBranch string                `json:"worktree_branch,omitempty"`
+	WorktreeActive bool                  `json:"worktree_active"`
+	History        []CodingWorktreeEvent `json:"history,omitempty"`
+}
+
 // CodingSnapshotID is the opaque identifier returned by the session journal
 // after a turn is persisted. Callers treat it as a black box; the journal
 // owns the format (currently "snap-<RFC3339>-<random>").
@@ -609,9 +641,16 @@ type CodingSnapshotID string
 // session journal. Role mirrors the OpenAI-style "user" | "assistant" |
 // "tool" labelling. SnapshotID is empty until the journal has flushed it.
 type CodingTurn struct {
-	Index      int
-	At         time.Time
-	Role       string
-	Content    string
-	SnapshotID CodingSnapshotID
+	Index          int
+	At             time.Time
+	Role           string
+	Content        string
+	SnapshotID     CodingSnapshotID
+	CWD            string
+	GitBranch      string
+	RepositoryRoot string
+	WorktreePath   string
+	WorktreeBranch string
+	WorktreeActive bool
+	WorktreeEvent  *CodingWorktreeEvent
 }

--- a/internal/gui/worktree.go
+++ b/internal/gui/worktree.go
@@ -1,0 +1,72 @@
+package gui
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// WorktreeTab is the GUI view-model for the coding Worktree tab. It stores the
+// latest session snapshot and renders a compact status/history view that native
+// frontends can mirror without knowing git internals.
+type WorktreeTab struct {
+	mu    sync.RWMutex
+	state contracts.CodingWorktreeState
+}
+
+// NewWorktreeTab returns an empty Worktree tab.
+func NewWorktreeTab() *WorktreeTab { return &WorktreeTab{} }
+
+// Update replaces the tab state with the latest coding-session snapshot.
+func (t *WorktreeTab) Update(state contracts.CodingWorktreeState) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	state.History = append([]contracts.CodingWorktreeEvent(nil), state.History...)
+	t.state = state
+}
+
+// State returns a defensive copy for native frontends.
+func (t *WorktreeTab) State() contracts.CodingWorktreeState {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	out := t.state
+	out.History = append([]contracts.CodingWorktreeEvent(nil), t.state.History...)
+	return out
+}
+
+// View returns the text body used by lightweight GUI tests and fallback panes.
+func (t *WorktreeTab) View() string {
+	state := t.State()
+	if state.SessionID == "" {
+		return "Worktree\nNo coding session attached."
+	}
+
+	var sb strings.Builder
+	sb.WriteString("Worktree\n")
+	fmt.Fprintf(&sb, "Session: %s\n", state.SessionID)
+	if state.WorktreeActive {
+		fmt.Fprintf(&sb, "Status: active on %s\n", fallback(state.WorktreeBranch, "-"))
+		fmt.Fprintf(&sb, "Path: %s\n", fallback(state.WorktreePath, "-"))
+	} else {
+		fmt.Fprintf(&sb, "Status: repository on %s\n", fallback(state.Branch, "-"))
+	}
+	fmt.Fprintf(&sb, "CWD: %s\n", fallback(state.CWD, "-"))
+	if len(state.History) == 0 {
+		sb.WriteString("History: none")
+		return sb.String()
+	}
+	sb.WriteString("History:\n")
+	for _, ev := range state.History {
+		fmt.Fprintf(&sb, "- %s %s %s\n", ev.At.Format("15:04:05"), ev.Action, fallback(ev.Branch, ev.Path))
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func fallback(v, alt string) string {
+	if v == "" {
+		return alt
+	}
+	return v
+}

--- a/internal/gui/worktree_test.go
+++ b/internal/gui/worktree_test.go
@@ -1,0 +1,33 @@
+package gui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestWorktreeTabViewIncludesStatusAndHistory(t *testing.T) {
+	tab := NewWorktreeTab()
+	tab.Update(contracts.CodingWorktreeState{
+		SessionID:      "code-1",
+		CWD:            "/repo-wt",
+		Branch:         "main",
+		WorktreePath:   "/repo-wt",
+		WorktreeBranch: "feature/x",
+		WorktreeActive: true,
+		History: []contracts.CodingWorktreeEvent{{
+			At:     time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC),
+			Action: "enter",
+			Branch: "feature/x",
+		}},
+	})
+
+	out := tab.View()
+	for _, want := range []string{"Worktree", "Session: code-1", "Status: active on feature/x", "Path: /repo-wt", "enter feature/x"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("View() missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/keybindings/keybindings.go
+++ b/internal/keybindings/keybindings.go
@@ -45,6 +45,7 @@ type Command string
 
 const (
 	CommandChatNew              Command = "chat.new"
+	CommandChatNewLocal         Command = "chat.newLocal"
 	CommandChatFork             Command = "chat.fork"
 	CommandSessionLoad          Command = "session.load"
 	CommandSessionFork          Command = "session.fork"
@@ -71,6 +72,7 @@ const (
 // rendering help screens and for deterministic test output.
 var AllCommands = []Command{
 	CommandChatNew,
+	CommandChatNewLocal,
 	CommandChatFork,
 	CommandSessionLoad,
 	CommandSessionFork,
@@ -116,6 +118,7 @@ func Defaults() []Binding {
 	return []Binding{
 		{Key: "alt+space", Command: CommandConduitSummon},
 		{Key: "mod+n", Command: CommandChatNew},
+		{Key: "mod+shift+n", Command: CommandChatNewLocal},
 		{Key: "mod+k", Command: CommandCommandPaletteToggle},
 		{Key: "mod+j", Command: CommandTerminalToggle},
 		{Key: "mod+r", Command: CommandWorkflowRun, When: "workflowSelected"},

--- a/internal/keybindings/keybindings_test.go
+++ b/internal/keybindings/keybindings_test.go
@@ -14,6 +14,7 @@ func TestDefaultKeymapBindsAllPRDCommands(t *testing.T) {
 	// must have at least one default binding so the TUI ships usable.
 	required := []Command{
 		CommandChatNew,
+		CommandChatNewLocal,
 		CommandChatFork,
 		CommandSessionLoad,
 		CommandSessionFork,


### PR DESCRIPTION
## Summary
- Add coding session git context, cwd/branch/worktree state, and reload recovery from persisted turns.
- Add `NewLocalSession`, `worktree_enter`, and `worktree_exit` for isolated managed git worktrees with mid-session cwd switching.
- Add `chat.newLocal` keybinding support and a GUI Worktree tab view-model for status/history.

## Validation
- `go test ./internal/coding ./internal/gui ./internal/keybindings`
- `go test ./...` currently fails in `internal/core` on pre-existing sandbox test/build issues outside this PR scope (`containsFold` undefined and `SandboxArchitecture` fields missing).

Closes #70
