### PR TITLE
Implement inference and tool caching

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,78 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLRUEvictsLeastRecentlyUsedAndExpires(t *testing.T) {
+	now := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	c := NewLRU[string, string](2)
+	c.SetClock(func() time.Time { return now })
+
+	c.Put("a", "A", time.Minute)
+	c.Put("b", "B", time.Minute)
+	if _, ok := c.Get("a"); !ok {
+		t.Fatal("expected a before eviction")
+	}
+	c.Put("c", "C", time.Minute)
+	if _, ok := c.Get("b"); ok {
+		t.Fatal("b should have been LRU-evicted")
+	}
+
+	now = now.Add(time.Minute)
+	if _, ok := c.Get("a"); ok {
+		t.Fatal("a should expire at ttl boundary")
+	}
+}
+
+func TestToolResultCacheInvalidatesWhenFileChanges(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "readme.txt")
+	if err := os.WriteFile(path, []byte("one"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dep, ok := SnapshotFile(path)
+	if !ok {
+		t.Fatal("expected file snapshot")
+	}
+
+	c := NewToolResultCache[string](4, time.Hour)
+	c.Put("read", "one", []FileDependency{dep})
+	if got, ok := c.Get("read"); !ok || got != "one" {
+		t.Fatalf("cached value = %q/%v, want one/true", got, ok)
+	}
+
+	time.Sleep(time.Millisecond)
+	if err := os.WriteFile(path, []byte("two"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := c.Get("read"); ok {
+		t.Fatal("cache should miss after file mutation")
+	}
+}
+
+func TestSemanticCacheFindsSimilarEmbedding(t *testing.T) {
+	c := NewSemanticCache[string](4, time.Hour, 0.95)
+	c.Put("auth", []float64{1, 0, 0}, "cached response")
+
+	got, key, score, ok := c.Lookup([]float64{0.99, 0.01, 0})
+	if !ok {
+		t.Fatalf("expected semantic hit, score=%f", score)
+	}
+	if key != "auth" || got != "cached response" {
+		t.Fatalf("hit = %q/%q, want auth/cached response", key, got)
+	}
+}
+
+func TestPlanPrefixReturnsStableKey(t *testing.T) {
+	a := PlanPrefix([]string{"system", "tools"}, "message")
+	b := PlanPrefix([]string{"system", "tools"}, "different")
+	if a.PrefixKey != b.PrefixKey {
+		t.Fatal("volatile prompt content should not alter prefix key")
+	}
+	if a.Prefix != "systemtools" || a.Volatile != "message" {
+		t.Fatalf("plan = %#v", a)
+	}
+}

--- a/internal/cache/keys.go
+++ b/internal/cache/keys.go
@@ -1,0 +1,26 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// Key returns a stable SHA256 cache key for a namespace plus JSON payload.
+func Key(namespace string, payload any) (string, error) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(append([]byte(namespace+"\x00"), data...))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func MustKey(namespace string, payload any) string {
+	key, err := Key(namespace, payload)
+	if err != nil {
+		panic(fmt.Sprintf("cache key: %v", err))
+	}
+	return key
+}

--- a/internal/cache/lru.go
+++ b/internal/cache/lru.go
@@ -1,0 +1,106 @@
+// Package cache contains reusable cache primitives for model and tool calls.
+package cache
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+type clock func() time.Time
+
+// LRU is a small concurrency-safe in-memory cache with optional TTL support.
+type LRU[K comparable, V any] struct {
+	mu       sync.Mutex
+	maxItems int
+	now      clock
+	ll       *list.List
+	items    map[K]*list.Element
+}
+
+type entry[K comparable, V any] struct {
+	key       K
+	value     V
+	expiresAt time.Time
+}
+
+// NewLRU creates a cache capped at maxItems. maxItems <= 0 disables storage.
+func NewLRU[K comparable, V any](maxItems int) *LRU[K, V] {
+	return &LRU[K, V]{
+		maxItems: maxItems,
+		now:      func() time.Time { return time.Now().UTC() },
+		ll:       list.New(),
+		items:    make(map[K]*list.Element),
+	}
+}
+
+func (c *LRU[K, V]) SetClock(now func() time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if now != nil {
+		c.now = now
+	}
+}
+
+func (c *LRU[K, V]) Get(key K) (V, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var zero V
+	el, ok := c.items[key]
+	if !ok {
+		return zero, false
+	}
+	ent := el.Value.(entry[K, V])
+	if !ent.expiresAt.IsZero() && !c.now().Before(ent.expiresAt) {
+		c.ll.Remove(el)
+		delete(c.items, key)
+		return zero, false
+	}
+	c.ll.MoveToFront(el)
+	return ent.value, true
+}
+
+func (c *LRU[K, V]) Put(key K, value V, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.maxItems <= 0 {
+		return
+	}
+
+	expiresAt := time.Time{}
+	if ttl > 0 {
+		expiresAt = c.now().Add(ttl)
+	}
+	if el, ok := c.items[key]; ok {
+		el.Value = entry[K, V]{key: key, value: value, expiresAt: expiresAt}
+		c.ll.MoveToFront(el)
+		return
+	}
+
+	c.items[key] = c.ll.PushFront(entry[K, V]{key: key, value: value, expiresAt: expiresAt})
+	for len(c.items) > c.maxItems {
+		back := c.ll.Back()
+		if back == nil {
+			return
+		}
+		ent := back.Value.(entry[K, V])
+		delete(c.items, ent.key)
+		c.ll.Remove(back)
+	}
+}
+
+func (c *LRU[K, V]) Delete(key K) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.items[key]; ok {
+		c.ll.Remove(el)
+		delete(c.items, key)
+	}
+}
+
+func (c *LRU[K, V]) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.items)
+}

--- a/internal/cache/prefix.go
+++ b/internal/cache/prefix.go
@@ -1,0 +1,47 @@
+package cache
+
+import "time"
+
+// PrefixPlan separates stable prompt content from volatile request content so
+// providers with prompt caching can attach their cache hints to the prefix.
+type PrefixPlan struct {
+	Prefix       string
+	Volatile     string
+	PrefixKey    string
+	CacheControl string
+}
+
+func PlanPrefix(stableParts []string, volatile string) PrefixPlan {
+	prefix := ""
+	for _, part := range stableParts {
+		prefix += part
+	}
+	return PrefixPlan{
+		Prefix:       prefix,
+		Volatile:     volatile,
+		PrefixKey:    MustKey("prompt-prefix", prefix),
+		CacheControl: "cacheable-prefix",
+	}
+}
+
+// KVCache tracks warm local-model contexts with LRU eviction.
+type KVCache[V any] struct {
+	lru *LRU[string, V]
+	ttl time.Duration
+}
+
+func NewKVCache[V any](maxItems int, ttl time.Duration) *KVCache[V] {
+	return &KVCache[V]{lru: NewLRU[string, V](maxItems), ttl: ttl}
+}
+
+func (c *KVCache[V]) SetClock(now func() time.Time) {
+	c.lru.SetClock(now)
+}
+
+func (c *KVCache[V]) Get(prefixKey string) (V, bool) {
+	return c.lru.Get(prefixKey)
+}
+
+func (c *KVCache[V]) Put(prefixKey string, handle V) {
+	c.lru.Put(prefixKey, handle, c.ttl)
+}

--- a/internal/cache/response.go
+++ b/internal/cache/response.go
@@ -1,0 +1,25 @@
+package cache
+
+import "time"
+
+// ResponseCache stores exact-match model responses keyed by full request hash.
+type ResponseCache[V any] struct {
+	lru *LRU[string, V]
+	ttl time.Duration
+}
+
+func NewResponseCache[V any](maxItems int, ttl time.Duration) *ResponseCache[V] {
+	return &ResponseCache[V]{lru: NewLRU[string, V](maxItems), ttl: ttl}
+}
+
+func (c *ResponseCache[V]) SetClock(now func() time.Time) {
+	c.lru.SetClock(now)
+}
+
+func (c *ResponseCache[V]) Get(key string) (V, bool) {
+	return c.lru.Get(key)
+}
+
+func (c *ResponseCache[V]) Put(key string, value V) {
+	c.lru.Put(key, value, c.ttl)
+}

--- a/internal/cache/semantic.go
+++ b/internal/cache/semantic.go
@@ -1,0 +1,89 @@
+package cache
+
+import (
+	"math"
+	"time"
+)
+
+// SemanticEntry stores an embedding and response for near-duplicate prompts.
+type SemanticEntry[V any] struct {
+	Key       string
+	Embedding []float64
+	Value     V
+}
+
+type SemanticCache[V any] struct {
+	lru       *LRU[string, SemanticEntry[V]]
+	ttl       time.Duration
+	threshold float64
+}
+
+func NewSemanticCache[V any](maxItems int, ttl time.Duration, threshold float64) *SemanticCache[V] {
+	if threshold <= 0 {
+		threshold = 0.95
+	}
+	return &SemanticCache[V]{
+		lru:       NewLRU[string, SemanticEntry[V]](maxItems),
+		ttl:       ttl,
+		threshold: threshold,
+	}
+}
+
+func (c *SemanticCache[V]) SetClock(now func() time.Time) {
+	c.lru.SetClock(now)
+}
+
+func (c *SemanticCache[V]) Put(key string, embedding []float64, value V) {
+	c.lru.Put(key, SemanticEntry[V]{
+		Key:       key,
+		Embedding: append([]float64(nil), embedding...),
+		Value:     value,
+	}, c.ttl)
+}
+
+func (c *SemanticCache[V]) Lookup(embedding []float64) (V, string, float64, bool) {
+	var zero V
+	bestKey := ""
+	bestScore := -1.0
+	var best V
+
+	c.lru.mu.Lock()
+	keys := make([]string, 0, len(c.lru.items))
+	for key := range c.lru.items {
+		keys = append(keys, key)
+	}
+	c.lru.mu.Unlock()
+
+	for _, key := range keys {
+		entry, ok := c.lru.Get(key)
+		if !ok {
+			continue
+		}
+		score := CosineSimilarity(embedding, entry.Embedding)
+		if score > bestScore {
+			bestScore = score
+			bestKey = entry.Key
+			best = entry.Value
+		}
+	}
+	if bestScore < c.threshold {
+		return zero, "", bestScore, false
+	}
+	return best, bestKey, bestScore, true
+}
+
+func CosineSimilarity(a, b []float64) float64 {
+	if len(a) == 0 || len(a) != len(b) {
+		return 0
+	}
+	var dot, normA, normB float64
+	for i := range a {
+		dot += a[i] * b[i]
+		normA += a[i] * a[i]
+		normB += b[i] * b[i]
+	}
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
+}

--- a/internal/cache/tool.go
+++ b/internal/cache/tool.go
@@ -1,0 +1,71 @@
+package cache
+
+import (
+	"os"
+	"time"
+)
+
+type FileDependency struct {
+	Path    string
+	ModTime time.Time
+	Size    int64
+}
+
+type ToolResult[V any] struct {
+	Value        V
+	Files        []FileDependency
+	StoredAt     time.Time
+	Invalidation string
+}
+
+type ToolResultCache[V any] struct {
+	lru *LRU[string, ToolResult[V]]
+	ttl time.Duration
+}
+
+func NewToolResultCache[V any](maxItems int, ttl time.Duration) *ToolResultCache[V] {
+	return &ToolResultCache[V]{lru: NewLRU[string, ToolResult[V]](maxItems), ttl: ttl}
+}
+
+func (c *ToolResultCache[V]) SetClock(now func() time.Time) {
+	c.lru.SetClock(now)
+}
+
+func (c *ToolResultCache[V]) Get(key string) (V, bool) {
+	var zero V
+	result, ok := c.lru.Get(key)
+	if !ok {
+		return zero, false
+	}
+	if result.filesChanged() {
+		c.lru.Delete(key)
+		return zero, false
+	}
+	return result.Value, true
+}
+
+func (c *ToolResultCache[V]) Put(key string, value V, files []FileDependency) {
+	c.lru.Put(key, ToolResult[V]{
+		Value:    value,
+		Files:    append([]FileDependency(nil), files...),
+		StoredAt: c.lru.now(),
+	}, c.ttl)
+}
+
+func SnapshotFile(path string) (FileDependency, bool) {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return FileDependency{}, false
+	}
+	return FileDependency{Path: path, ModTime: info.ModTime(), Size: info.Size()}, true
+}
+
+func (r ToolResult[V]) filesChanged() bool {
+	for _, dep := range r.Files {
+		info, err := os.Stat(dep.Path)
+		if err != nil || info.IsDir() || !info.ModTime().Equal(dep.ModTime) || info.Size() != dep.Size {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/core/sandbox.go
+++ b/internal/core/sandbox.go
@@ -3,6 +3,7 @@ package core
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -49,7 +50,11 @@ func DefaultSandboxArchitecture() contracts.SandboxArchitecture {
 		WarmStartBudget:           warmSandboxStartupBudget,
 		MaxMemoryOverheadMB:       sandboxMaxMemoryOverheadMB,
 		Shells:                    []string{"bash", "zsh", "sh"},
-		PreinstalledRuntimes:      []string{"go", "node", "python"},
+		PreinstalledRuntimes:      []string{"go", "node", "python", "rust"},
+		RuntimeVersions:           map[string]string{"go": "1.22", "node": "20", "python": "3.12", "rust": "stable"},
+		PackageManagers:           []string{"pip", "npm", "yarn", "pnpm", "cargo"},
+		PreinstalledTools:         []string{"git", "curl", "jq", "rg", "fd", "vim", "nano", "sqlite3"},
+		AllowlistedRegistries:     []string{"pypi.org", "registry.npmjs.org", "proxy.golang.org", "crates.io"},
 		NetworkPolicy:             contracts.SandboxNetworkPolicyControlledEgress,
 		DenyHostFilesystem:        true,
 		DenyHostNetwork:           true,
@@ -132,6 +137,18 @@ func (m *SandboxManager) Validate() error {
 	}
 	if len(m.architecture.PreinstalledRuntimes) == 0 {
 		problems = append(problems, "at least one runtime must be pre-installed")
+	}
+	if len(m.architecture.RuntimeVersions) == 0 {
+		problems = append(problems, "runtime versions are required")
+	}
+	if len(m.architecture.PackageManagers) == 0 {
+		problems = append(problems, "at least one package manager must be pre-installed")
+	}
+	if len(m.architecture.PreinstalledTools) == 0 {
+		problems = append(problems, "at least one developer tool must be pre-installed")
+	}
+	if len(m.architecture.AllowlistedRegistries) == 0 {
+		problems = append(problems, "at least one package registry must be allowlisted")
 	}
 	if m.architecture.NetworkPolicy == "" {
 		problems = append(problems, "network policy is required")
@@ -283,6 +300,10 @@ func isSupportedMountMode(mode contracts.SandboxMountMode) bool {
 func copySandboxArchitecture(architecture contracts.SandboxArchitecture) contracts.SandboxArchitecture {
 	architecture.Shells = append([]string(nil), architecture.Shells...)
 	architecture.PreinstalledRuntimes = append([]string(nil), architecture.PreinstalledRuntimes...)
+	architecture.RuntimeVersions = maps.Clone(architecture.RuntimeVersions)
+	architecture.PackageManagers = append([]string(nil), architecture.PackageManagers...)
+	architecture.PreinstalledTools = append([]string(nil), architecture.PreinstalledTools...)
+	architecture.AllowlistedRegistries = append([]string(nil), architecture.AllowlistedRegistries...)
 	architecture.Mounts = append([]contracts.SandboxMount(nil), architecture.Mounts...)
 	return architecture
 }

--- a/internal/core/sandbox_test.go
+++ b/internal/core/sandbox_test.go
@@ -46,6 +46,15 @@ func TestDefaultSandboxArchitectureMatchesPRDGuarantees(t *testing.T) {
 	}
 }
 
+func containsFold(values []string, want string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, want) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestSandboxArchitectureReturnsCopies(t *testing.T) {
 	engine := New("test")
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jabreeflor/conduit/internal/cache"
 	"github.com/jabreeflor/conduit/internal/contextassembler"
 	conduiterrors "github.com/jabreeflor/conduit/internal/errors"
 )
@@ -120,6 +121,7 @@ type Router struct {
 	checkpoints   CheckpointStore
 	usage         UsageSink
 	failovers     FailoverSink
+	responses     *cache.ResponseCache[Response]
 	assembler     ContextAssembler
 	optimizations OptimizationSink
 	now           func() time.Time
@@ -146,6 +148,14 @@ func WithUsageSink(sink UsageSink) Option {
 func WithFailoverSink(sink FailoverSink) Option {
 	return func(r *Router) {
 		r.failovers = sink
+	}
+}
+
+// WithResponseCache enables exact-match response caching for identical
+// inference requests.
+func WithResponseCache(c *cache.ResponseCache[Response]) Option {
+	return func(r *Router) {
+		r.responses = c
 	}
 }
 
@@ -192,6 +202,12 @@ func (r *Router) Infer(ctx context.Context, req Request) (Response, error) {
 	if len(chain) == 0 {
 		return Response{}, errors.New("no providers configured")
 	}
+	cacheKey, cacheable := r.responseCacheKey(req, chain)
+	if cacheable {
+		if resp, ok := r.responses.Get(cacheKey); ok {
+			return resp, nil
+		}
+	}
 
 	var failures []error
 	for i, name := range chain {
@@ -232,6 +248,9 @@ func (r *Router) Infer(ctx context.Context, req Request) (Response, error) {
 		}
 		resp.Usage.CostUSD = r.costFor(name, resp.Usage)
 		r.recordUsage(ctx, req, resp, totalLatency)
+		if cacheable {
+			r.responses.Put(cacheKey, resp)
+		}
 		return resp, nil
 	}
 
@@ -286,6 +305,20 @@ func routerContextItems(req Request) []contextassembler.Item {
 		items = append(items, item)
 	}
 	return items
+}
+
+func (r *Router) responseCacheKey(req Request, chain []string) (string, bool) {
+	if r.responses == nil {
+		return "", false
+	}
+	key, err := cache.Key("router-response", struct {
+		Request Request
+		Chain   []string
+	}{Request: req, Chain: chain})
+	if err != nil {
+		return "", false
+	}
+	return key, true
 }
 
 func (r *Router) contextForProvider(ctx context.Context, name string) (context.Context, context.CancelFunc) {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jabreeflor/conduit/internal/cache"
 	"github.com/jabreeflor/conduit/internal/contextassembler"
 )
 
@@ -48,6 +49,38 @@ func TestRouterAssemblesContextBeforeProviderCall(t *testing.T) {
 	}
 	if len(sink.summaries) != 1 {
 		t.Fatalf("optimization summaries = %d, want 1", len(sink.summaries))
+	}
+}
+
+func TestRouterReturnsExactResponseCacheHit(t *testing.T) {
+	cfg := Config{Models: ModelConfig{
+		Primary: "openai",
+		Providers: []ProviderConfig{
+			{Name: "openai", Model: "gpt-4o"},
+		},
+	}}
+	openai := &fakeProvider{name: "openai", response: Response{Text: "cached", Usage: Usage{InputTokens: 10}}}
+
+	r, err := New(cfg, []Provider{openai}, WithResponseCache(cache.NewResponseCache[Response](8, time.Hour)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := Request{TaskType: TaskGeneral, Prompt: "same prompt"}
+	first, err := r.Infer(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := r.Infer(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if first.Text != second.Text {
+		t.Fatalf("responses differ: %#v vs %#v", first, second)
+	}
+	if len(openai.requests) != 1 {
+		t.Fatalf("provider calls = %d, want 1", len(openai.requests))
 	}
 }
 

--- a/internal/tools/pipeline.go
+++ b/internal/tools/pipeline.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/jabreeflor/conduit/internal/cache"
 	toolerrors "github.com/jabreeflor/conduit/internal/errors"
 	"github.com/jabreeflor/conduit/internal/hooks"
 	"gopkg.in/yaml.v3"
@@ -111,6 +112,7 @@ type Pipeline struct {
 	hooks     *hooks.Dispatcher
 	sessionID string
 	cwd       string
+	cache     *cache.ToolResultCache[Result]
 }
 
 // NewPipeline creates a policy pipeline from base tools and policy config.
@@ -126,6 +128,13 @@ func (p *Pipeline) WithHooks(d *hooks.Dispatcher, sessionID, cwd string) *Pipeli
 	p.hooks = d
 	p.sessionID = sessionID
 	p.cwd = cwd
+	return p
+}
+
+// WithToolResultCache enables TTL/file-change-aware caching for deterministic
+// tool calls.
+func (p *Pipeline) WithToolResultCache(c *cache.ToolResultCache[Result]) *Pipeline {
+	p.cache = c
 	return p
 }
 
@@ -232,6 +241,12 @@ func (p *Pipeline) Execute(ctx context.Context, call Call, overrides AgentOverri
 	if err != nil {
 		return Result{}, decision, err
 	}
+	cacheKey, cacheable := p.toolCacheKey(call)
+	if cacheable {
+		if result, ok := p.cache.Get(cacheKey); ok {
+			return result, decision, nil
+		}
+	}
 	result, err := p.WrapRunner(decision.Tool.Run)(ctx, input)
 
 	hookInput.Event = hooks.EventPostToolCall
@@ -242,7 +257,38 @@ func (p *Pipeline) Execute(ctx context.Context, call Call, overrides AgentOverri
 		typed := toolerrors.Wrap(classified, err)
 		return Result{Text: err.Error(), IsError: true}, decision, typed
 	}
+	if cacheable && !result.IsError {
+		p.cache.Put(cacheKey, result, fileDependencies(call.Input))
+	}
 	return result, decision, nil
+}
+
+func (p *Pipeline) toolCacheKey(call Call) (string, bool) {
+	if p.cache == nil {
+		return "", false
+	}
+	key, err := cache.Key("tool-result", struct {
+		ToolName string
+		Input    map[string]any
+	}{ToolName: call.ToolName, Input: call.Input})
+	if err != nil {
+		return "", false
+	}
+	return key, true
+}
+
+func fileDependencies(input map[string]any) []cache.FileDependency {
+	var deps []cache.FileDependency
+	for _, name := range []string{"path", "file", "filepath"} {
+		value, ok := input[name].(string)
+		if !ok || value == "" {
+			continue
+		}
+		if dep, ok := cache.SnapshotFile(value); ok {
+			deps = append(deps, dep)
+		}
+	}
+	return deps
 }
 
 // PolicyConfig mirrors ~/.conduit/policies.yaml.

--- a/internal/tools/pipeline_test.go
+++ b/internal/tools/pipeline_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/jabreeflor/conduit/internal/cache"
 	toolerrors "github.com/jabreeflor/conduit/internal/errors"
 )
 
@@ -216,5 +218,58 @@ func TestExecuteClassifiesRunnerErrorAndSetsIsError(t *testing.T) {
 	}
 	if te.Recovery() != toolerrors.RecoveryExponentialBackoff {
 		t.Errorf("Recovery = %s, want exponential_backoff", te.Recovery())
+	}
+}
+
+func TestExecuteCachesToolResultAndInvalidatesOnFileChange(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notes.txt")
+	if err := os.WriteFile(path, []byte("one"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	pipeline := NewPipeline([]Tool{
+		{
+			Name: "read_file",
+			Run: func(_ context.Context, input json.RawMessage) (Result, error) {
+				calls++
+				var args struct {
+					Path string `json:"path"`
+				}
+				if err := json.Unmarshal(input, &args); err != nil {
+					return Result{}, err
+				}
+				data, err := os.ReadFile(args.Path)
+				if err != nil {
+					return Result{}, err
+				}
+				return Result{Text: string(data)}, nil
+			},
+		},
+	}, PolicyConfig{}).WithToolResultCache(cache.NewToolResultCache[Result](8, time.Hour))
+
+	call := Call{ToolName: "read_file", Input: map[string]any{"path": path}}
+	first, _, err := pipeline.Execute(context.Background(), call, AgentOverrides{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := pipeline.Execute(context.Background(), call, AgentOverrides{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Text != "one" || second.Text != "one" || calls != 1 {
+		t.Fatalf("first=%q second=%q calls=%d, want cached second call", first.Text, second.Text, calls)
+	}
+
+	time.Sleep(time.Millisecond)
+	if err := os.WriteFile(path, []byte("two"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	third, _, err := pipeline.Execute(context.Background(), call, AgentOverrides{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if third.Text != "two" || calls != 2 {
+		t.Fatalf("third=%q calls=%d, want invalidated read", third.Text, calls)
 	}
 }


### PR DESCRIPTION
Closes #132.\n\n## Summary\n- add reusable LRU, exact response, semantic, tool-result, prefix, and KV cache primitives\n- wire exact response caching into the model router\n- wire TTL and file-change-aware tool result caching into the tool pipeline\n- add context assembly transparency and sandbox metadata needed by the current router/core tests\n\n## Tests\n- go test ./...