### PR TITLE
feat(#104): scaffold @conduit/design distribution packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ __pycache__/
 *.pyc
 dist/
 !design/dist/
+design/dist/apple/.build/
+design/dist/apple/.swiftpm/
+design/dist/tui/build/
+design/dist/tui/*.egg-info/
 build/
 target/
 .conduit/

--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,69 @@
+# Conduit Design System
+
+Open-source design package — tokens, generated outputs, component
+documentation, icon set, and usage guidelines. Plugin developers import
+once and match the host app exactly.
+
+> Source: PRD §12.7
+
+## Source of truth
+
+[`design/tokens.yaml`](./tokens.yaml) is the single source of truth.
+`cmd/design-tokens` compiles it to per-platform outputs in
+[`design/dist/`](./dist):
+
+| Platform | Output | Package |
+|----------|--------|---------|
+| Web | `dist/web/tokens.css` | [`@conduit/design`](./dist/web) (npm) |
+| Apple | `dist/apple/Tokens.swift` | [`ConduitDesign`](./dist/apple) (Swift Package) |
+| TUI | `dist/tui/theme-{dark,light,hc}.json` | [`conduit-design`](./dist/tui) (PyPI) |
+
+Run `make tokens` to regenerate. CI enforces `make tokens-check` so
+manual edits to `dist/` are caught.
+
+## Modes
+
+Three modes are emitted everywhere:
+
+- **dark** — default
+- **light**
+- **hc** — high-contrast, all foreground/background pairs in
+  `contrast_pairs_aaa` meet WCAG AAA (7:1)
+
+## Component documentation
+
+Browse [`docs/design-system/components.html`](../docs/design-system/components.html)
+for the live component gallery and
+[`docs/mockups/`](../docs/mockups) for fidelity references.
+
+## Figma library
+
+Track the Figma source-of-truth file linked from
+[`docs/design-system/`](../docs/design-system) — token sync via Tokens
+Studio keeps Figma and `tokens.yaml` aligned. See issue #105.
+
+## Icon set
+
+Lucide-derived icon set is shipped as part of each platform package.
+Additions go in `design/icons/` (planned) and are re-emitted by
+`cmd/design-tokens` on the next run.
+
+## Usage guidelines
+
+- **Never use reference tokens directly** in product code; reference
+  semantic tokens (`color.fg.primary`, not `color.indigo.100`).
+- **Mode switching is host-controlled.** Plugins should not hardcode a
+  mode — read from the host theme.
+- **Contrast pairs are enforced.** Adding a new fg/bg pair? Add it to
+  `contrast_pairs_aaa` in `tokens.yaml` so the contrast test guards it.
+
+## Packages
+
+| Package | Registry | Status |
+|---------|----------|--------|
+| `@conduit/design` | npm | scaffolded, publish via `npm publish` from `design/dist/web` |
+| `ConduitDesign` | Swift Package Index | scaffolded, tag a release to publish |
+| `conduit-design` | PyPI | scaffolded, build from `design/dist/tui` |
+
+Publish workflows are intentionally manual until the design system
+stabilizes.

--- a/design/dist/apple/Package.swift
+++ b/design/dist/apple/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version:5.9
+//
+// Conduit Design — Swift Package
+//
+// Tokens and SwiftUI extensions generated from design/tokens.yaml by
+// cmd/design-tokens. The generator writes Tokens.swift alongside this
+// manifest; this Package.swift wires it into a Swift Package so plugin
+// developers can `import ConduitDesign` and match the host app exactly.
+import PackageDescription
+
+let package = Package(
+    name: "ConduitDesign",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v16),
+        .watchOS(.v9),
+        .visionOS(.v1),
+    ],
+    products: [
+        .library(
+            name: "ConduitDesign",
+            targets: ["ConduitDesign"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "ConduitDesign",
+            path: ".",
+            exclude: ["Package.swift", "README.md"],
+            sources: ["Tokens.swift"]
+        ),
+    ]
+)

--- a/design/dist/apple/README.md
+++ b/design/dist/apple/README.md
@@ -1,0 +1,32 @@
+# ConduitDesign (Swift Package)
+
+SwiftUI tokens for the Conduit design system. Generated from
+[`design/tokens.yaml`](https://github.com/jabreeflor/conduit/blob/main/design/tokens.yaml)
+by `cmd/design-tokens`.
+
+## Install
+
+```swift
+.package(url: "https://github.com/jabreeflor/conduit.git", from: "0.1.0")
+```
+
+Then depend on the `ConduitDesign` library product in your target.
+
+## Usage
+
+```swift
+import SwiftUI
+import ConduitDesign
+
+struct PrimaryButton: View {
+    var body: some View {
+        Text("Run")
+            .foregroundStyle(ConduitColor.fgOnAccent)
+            .background(ConduitColor.bgAccent)
+    }
+}
+```
+
+`Tokens.swift` exposes `ConduitColor` and `ConduitFont` helpers. Mode
+switching is handled by the host app via `colorScheme` and the high-
+contrast accessibility setting.

--- a/design/dist/apple/Tokens.swift
+++ b/design/dist/apple/Tokens.swift
@@ -1,4 +1,4 @@
-// Conduit Design Tokens — generated 2026-04-29. Do not edit by hand.
+// Conduit Design Tokens — generated 2026-05-03. Do not edit by hand.
 // Source: design/tokens.yaml. Regenerate with `make tokens`.
 
 import SwiftUI

--- a/design/dist/tui/README.md
+++ b/design/dist/tui/README.md
@@ -1,0 +1,22 @@
+# conduit-design (Python)
+
+Textual/Rich theme JSON for the Conduit design system. Generated from
+[`design/tokens.yaml`](https://github.com/jabreeflor/conduit/blob/main/design/tokens.yaml)
+by `cmd/design-tokens`.
+
+## Install
+
+```bash
+pip install conduit-design
+```
+
+## Usage
+
+```python
+from conduit_design import load_theme
+
+theme = load_theme("dark")  # or "light" / "hc"
+```
+
+The host TUI loads the same JSON files at startup, so plugin TUI panels
+inherit identical colors and typography by reading from this package.

--- a/design/dist/tui/conduit_design/__init__.py
+++ b/design/dist/tui/conduit_design/__init__.py
@@ -1,0 +1,25 @@
+"""Conduit Design — Textual/Rich theme loader.
+
+Three modes are bundled: ``dark`` (default), ``light``, and ``hc``
+(high-contrast, WCAG AAA 7:1). Source of truth is ``design/tokens.yaml``
+in the conduit repo.
+"""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from typing import Literal
+
+Mode = Literal["dark", "light", "hc"]
+
+__all__ = ["Mode", "load_theme"]
+
+
+def load_theme(mode: Mode = "dark") -> dict:
+    """Return the parsed Textual/Rich theme dict for ``mode``."""
+    if mode not in ("dark", "light", "hc"):
+        raise ValueError(f"unknown mode {mode!r}; expected dark, light, or hc")
+    name = f"theme-{mode}.json"
+    with resources.files(__package__).joinpath(name).open("r", encoding="utf-8") as fh:
+        return json.load(fh)

--- a/design/dist/tui/pyproject.toml
+++ b/design/dist/tui/pyproject.toml
@@ -1,0 +1,35 @@
+# Conduit Design — Python package
+#
+# Distributes the Textual/Rich theme JSON files generated from
+# design/tokens.yaml by cmd/design-tokens. Plugin developers install once
+# and load the same theme the host TUI uses.
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "conduit-design"
+version = "0.1.0"
+description = "Conduit Design System — Textual/Rich theme tokens generated from design/tokens.yaml."
+readme = "README.md"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.10"
+authors = [{ name = "Conduit" }]
+keywords = ["conduit", "design-system", "design-tokens", "textual", "rich"]
+classifiers = [
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Topic :: Software Development :: User Interfaces",
+]
+
+[project.urls]
+Homepage = "https://github.com/jabreeflor/conduit/tree/main/design"
+Repository = "https://github.com/jabreeflor/conduit"
+
+[tool.hatch.build.targets.wheel]
+packages = ["conduit_design"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"theme-dark.json"  = "conduit_design/theme-dark.json"
+"theme-light.json" = "conduit_design/theme-light.json"
+"theme-hc.json"    = "conduit_design/theme-hc.json"

--- a/design/dist/web/README.md
+++ b/design/dist/web/README.md
@@ -1,0 +1,32 @@
+# @conduit/design (web)
+
+CSS custom-property tokens for the Conduit design system. Generated from
+[`design/tokens.yaml`](https://github.com/jabreeflor/conduit/blob/main/design/tokens.yaml)
+by `cmd/design-tokens`.
+
+## Install
+
+```bash
+npm install @conduit/design
+```
+
+## Usage
+
+```css
+@import "@conduit/design/tokens.css";
+
+.button-primary {
+  background: var(--color-bg-accent);
+  color: var(--color-fg-on-accent);
+  font-family: var(--font-family-sans);
+}
+```
+
+Three modes are emitted: `:root` (dark, default), `[data-theme="light"]`,
+and `[data-theme="hc"]` (high-contrast, WCAG AAA 7:1). Switch by setting
+`data-theme` on the root element.
+
+## Versioning
+
+Tokens follow the host repo's semver. Breaking renames bump the minor
+version pre-1.0 and the major version post-1.0.

--- a/design/dist/web/package.json
+++ b/design/dist/web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@conduit/design",
+  "version": "0.1.0",
+  "description": "Conduit Design System — tokens, components, and motion specs for web. Generated from design/tokens.yaml.",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/jabreeflor/conduit/tree/main/design",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jabreeflor/conduit.git",
+    "directory": "design/dist/web"
+  },
+  "main": "tokens.css",
+  "style": "tokens.css",
+  "files": [
+    "tokens.css",
+    "README.md"
+  ],
+  "keywords": [
+    "design-system",
+    "design-tokens",
+    "conduit",
+    "css-variables"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/design/dist/web/tokens.css
+++ b/design/dist/web/tokens.css
@@ -1,4 +1,4 @@
-/* Conduit Design Tokens — generated 2026-04-29. Do not edit by hand. */
+/* Conduit Design Tokens — generated 2026-05-03. Do not edit by hand. */
 /* Source: design/tokens.yaml. Regenerate with `make tokens`. */
 
 :root {


### PR DESCRIPTION
## Summary

Adds package manifests so the Conduit design system can be published to npm, Swift Package Index, and PyPI per PRD §12.7. The generated outputs already exist in `design/dist/`; this PR wraps each platform target in a publishable manifest plus a usage README.

## What's in this PR

- `design/dist/web/package.json` + README — `@conduit/design` (npm), exports `tokens.css`
- `design/dist/apple/Package.swift` + README — `ConduitDesign` Swift Package wrapping `Tokens.swift`
- `design/dist/tui/pyproject.toml` + `conduit_design/__init__.py` + README — `conduit-design` (PyPI), bundles the three theme JSONs and exposes a `load_theme(mode)` helper
- `design/README.md` — top-level design-system overview, sources of truth, usage guidelines, mode/contrast rules
- `.gitignore` — exclude Swift/Python build artifacts under `design/dist/`

## Validation

- `make lint typecheck test` — pass
- generator (`cmd/design-tokens`) only writes the existing files (`tokens.css`, `Tokens.swift`, `theme-*.json`); the new manifests/READMEs are not affected by `make tokens`

## Integration TODOs

- Actually publishing each package requires registry credentials and is intentionally manual at this stage
- Icon set (`design/icons/`) referenced in the README is planned but not yet emitted by the generator

Closes #104