### PR TITLE
feat(#133): cost-aware cascading inference

### DIFF
--- a/internal/cascade/cascade.go
+++ b/internal/cascade/cascade.go
@@ -1,0 +1,376 @@
+package cascade
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Tier names a model rung in the cascade. Lower Cost values are tried first.
+type Tier struct {
+	// Name is a router model/provider name (passed through to Inferer).
+	Name string
+	// Handles is the set of complexities this tier should handle without
+	// further escalation. A request whose Complexity is in this set will skip
+	// cheaper tiers below it on the way up; a request whose complexity is
+	// strictly greater than every entry will still try this tier on the way to
+	// a stronger one.
+	Handles []Complexity
+	// Cost is a relative cost weight (USD per 1k tokens, or any monotonically
+	// increasing scalar) used to order tiers cheapest-to-most-expensive.
+	Cost float64
+	// MinConfidence is the minimum acceptable Quality score for a result
+	// produced by this tier. Results below the threshold trigger escalation.
+	MinConfidence float64
+}
+
+// Result is the outcome of a single tier attempt, supplied by the caller.
+type Result struct {
+	// Text is the generated content (used by default Quality scorer).
+	Text string
+	// Confidence is an optional caller-supplied confidence in [0,1]. When
+	// non-zero it overrides the default heuristic Quality scorer.
+	Confidence float64
+	// Provider/Model are passed through to the final returned Outcome.
+	Provider string
+	Model    string
+	// Extra is opaque metadata attached to the final outcome.
+	Extra map[string]string
+}
+
+// Inferer runs one tier and returns its Result. Implementations should respect
+// ctx and return ctx.Err() promptly.
+type Inferer func(ctx context.Context, tier Tier) (Result, error)
+
+// QualityFn scores a Result in [0,1]. Returning a value below tier.MinConfidence
+// triggers escalation.
+type QualityFn func(Tier, Result) float64
+
+// BudgetGate is consulted before each tier attempt. Returning false halts
+// escalation (the caller has hit a budget warning/critical threshold and wants
+// to degrade rather than escalate further).
+type BudgetGate func(tier Tier) bool
+
+// Outcome is the final cascading verdict returned to the caller.
+type Outcome struct {
+	Result        Result
+	Tier          Tier
+	Complexity    Complexity
+	Attempts      []Attempt
+	Escalated     bool
+	BudgetStopped bool
+}
+
+// Attempt records one tier invocation for transparency in session logs.
+type Attempt struct {
+	Tier       string
+	Quality    float64
+	Err        string
+	Escalated  bool
+	BudgetStop bool
+}
+
+// Cascader orchestrates the try-cheap-first / escalate-on-miss loop.
+type Cascader struct {
+	tiers      []Tier
+	quality    QualityFn
+	budget     BudgetGate
+	classifier func(string, Signals) Classification
+}
+
+// Option customizes a Cascader.
+type Option func(*Cascader)
+
+// WithQualityFn overrides the default text-based heuristic quality scorer.
+func WithQualityFn(fn QualityFn) Option { return func(c *Cascader) { c.quality = fn } }
+
+// WithBudgetGate halts escalation when the gate returns false.
+func WithBudgetGate(fn BudgetGate) Option { return func(c *Cascader) { c.budget = fn } }
+
+// WithClassifier overrides the default heuristic classifier.
+func WithClassifier(fn func(string, Signals) Classification) Option {
+	return func(c *Cascader) { c.classifier = fn }
+}
+
+// New builds a Cascader from a set of tiers. Tiers are sorted ascending by
+// Cost so that the cheapest tier is always tried first.
+func New(tiers []Tier, opts ...Option) (*Cascader, error) {
+	if len(tiers) == 0 {
+		return nil, errors.New("cascade: at least one tier is required")
+	}
+	for i, t := range tiers {
+		if t.Name == "" {
+			return nil, fmt.Errorf("cascade: tier %d has empty Name", i)
+		}
+	}
+	sorted := append([]Tier(nil), tiers...)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Cost < sorted[j].Cost })
+
+	c := &Cascader{
+		tiers:      sorted,
+		quality:    defaultQuality,
+		classifier: Classify,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, nil
+}
+
+// Tiers returns the tier list sorted cheapest-first.
+func (c *Cascader) Tiers() []Tier { return append([]Tier(nil), c.tiers...) }
+
+// Run cascades through tiers for a single prompt. The starting tier is the
+// cheapest one whose Handles set covers the classified complexity (or the
+// cheapest tier overall if no tier explicitly handles the complexity). Each
+// tier's Result is scored; if the score is below MinConfidence the next more
+// expensive tier is tried.
+func (c *Cascader) Run(ctx context.Context, prompt string, signals Signals, infer Inferer) (Outcome, error) {
+	if infer == nil {
+		return Outcome{}, errors.New("cascade: infer is required")
+	}
+	cls := c.classifier(prompt, signals)
+	start := c.startIndex(cls.Complexity)
+
+	var attempts []Attempt
+	var lastErr error
+	for i := start; i < len(c.tiers); i++ {
+		tier := c.tiers[i]
+
+		if c.budget != nil && !c.budget(tier) {
+			attempts = append(attempts, Attempt{Tier: tier.Name, BudgetStop: true})
+			// Degrade: return the last non-error attempt if we have one,
+			// otherwise surface a budget error.
+			if last, ok := lastSuccessful(attempts); ok {
+				return Outcome{
+					Result:        Result{}, // caller-side context dropped, but we surface the last attempt's tier
+					Tier:          tierByName(c.tiers, last.Tier),
+					Complexity:    cls.Complexity,
+					Attempts:      attempts,
+					BudgetStopped: true,
+				}, nil
+			}
+			return Outcome{
+				Complexity:    cls.Complexity,
+				Attempts:      attempts,
+				BudgetStopped: true,
+			}, fmt.Errorf("cascade: budget gate halted escalation before %s", tier.Name)
+		}
+
+		res, err := infer(ctx, tier)
+		if err != nil {
+			attempts = append(attempts, Attempt{Tier: tier.Name, Err: err.Error()})
+			lastErr = err
+			// Hard errors escalate to the next tier immediately.
+			continue
+		}
+
+		quality := c.quality(tier, res)
+		escalate := quality < tier.MinConfidence
+		// If this tier handles the classified complexity exactly, don't
+		// escalate just because of a low-confidence threshold — the tier was
+		// chosen to be sufficient.
+		if tierHandles(tier, cls.Complexity) && quality > 0 {
+			escalate = false
+		}
+		if i == len(c.tiers)-1 {
+			escalate = false // already at the strongest tier
+		}
+
+		attempts = append(attempts, Attempt{
+			Tier:      tier.Name,
+			Quality:   quality,
+			Escalated: escalate,
+		})
+		if escalate {
+			continue
+		}
+		return Outcome{
+			Result:     res,
+			Tier:       tier,
+			Complexity: cls.Complexity,
+			Attempts:   attempts,
+			Escalated:  i > start,
+		}, nil
+	}
+
+	if lastErr != nil {
+		return Outcome{Complexity: cls.Complexity, Attempts: attempts}, fmt.Errorf("cascade: all tiers failed: %w", lastErr)
+	}
+	return Outcome{Complexity: cls.Complexity, Attempts: attempts}, errors.New("cascade: no tier produced a usable result")
+}
+
+// Batch runs Run for each prompt concurrently and returns outcomes in input
+// order. Concurrency is bounded by maxParallel (defaults to len(prompts) if 0).
+func (c *Cascader) Batch(ctx context.Context, prompts []string, signals []Signals, maxParallel int, infer Inferer) []BatchResult {
+	out := make([]BatchResult, len(prompts))
+	if len(prompts) == 0 {
+		return out
+	}
+	if maxParallel <= 0 || maxParallel > len(prompts) {
+		maxParallel = len(prompts)
+	}
+
+	sem := make(chan struct{}, maxParallel)
+	var wg sync.WaitGroup
+	for i, p := range prompts {
+		sig := Signals{}
+		if i < len(signals) {
+			sig = signals[i]
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, prompt string, sig Signals) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			outcome, err := c.Run(ctx, prompt, sig, infer)
+			out[idx] = BatchResult{Outcome: outcome, Err: err}
+		}(i, p, sig)
+	}
+	wg.Wait()
+	return out
+}
+
+// BatchResult is one element of the parallel Batch output.
+type BatchResult struct {
+	Outcome Outcome
+	Err     error
+}
+
+// startIndex picks the first tier index whose Handles covers complexity. If no
+// tier explicitly handles it, returns the index of the cheapest tier whose
+// Handles contains an equal-or-greater complexity, falling back to 0.
+func (c *Cascader) startIndex(complexity Complexity) int {
+	for i, tier := range c.tiers {
+		if tierHandles(tier, complexity) {
+			return i
+		}
+	}
+	// No tier explicitly claims this complexity — find the first whose
+	// declared complexities are all "harder" than the request, otherwise 0.
+	for i, tier := range c.tiers {
+		if len(tier.Handles) == 0 {
+			return i
+		}
+		if anyAtLeast(tier.Handles, complexity) {
+			return i
+		}
+	}
+	return 0
+}
+
+func tierHandles(tier Tier, complexity Complexity) bool {
+	for _, h := range tier.Handles {
+		if h == complexity {
+			return true
+		}
+	}
+	return false
+}
+
+func tierByName(tiers []Tier, name string) Tier {
+	for _, t := range tiers {
+		if t.Name == name {
+			return t
+		}
+	}
+	return Tier{Name: name}
+}
+
+func lastSuccessful(attempts []Attempt) (Attempt, bool) {
+	for i := len(attempts) - 1; i >= 0; i-- {
+		if attempts[i].Err == "" && !attempts[i].BudgetStop {
+			return attempts[i], true
+		}
+	}
+	return Attempt{}, false
+}
+
+// complexityRank maps complexities onto an ascending integer scale.
+func complexityRank(c Complexity) int {
+	switch c {
+	case ComplexityTrivial:
+		return 0
+	case ComplexitySimple:
+		return 1
+	case ComplexityModerate:
+		return 2
+	case ComplexityComplex:
+		return 3
+	}
+	return 1
+}
+
+func anyAtLeast(handles []Complexity, target Complexity) bool {
+	want := complexityRank(target)
+	for _, h := range handles {
+		if complexityRank(h) >= want {
+			return true
+		}
+	}
+	return false
+}
+
+// defaultQuality is a deterministic content-based heuristic — it has no model
+// access. Callers that have a real confidence signal should pass WithQualityFn.
+//
+// The score is in [0,1]:
+//   - explicit Result.Confidence wins when set.
+//   - empty/whitespace-only text scores 0.
+//   - very short text (<20 chars) scores 0.4.
+//   - text containing a refusal stub ("I cannot", "I don't know") scores 0.3.
+//   - otherwise 0.85.
+func defaultQuality(_ Tier, r Result) float64 {
+	if r.Confidence > 0 {
+		if r.Confidence > 1 {
+			return 1
+		}
+		return r.Confidence
+	}
+	text := r.Text
+	stripped := ""
+	for _, r := range text {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			continue
+		}
+		stripped += string(r)
+	}
+	if stripped == "" {
+		return 0
+	}
+	if len(text) < 20 {
+		return 0.4
+	}
+	lower := ""
+	for _, r := range text {
+		if r < 128 {
+			if r >= 'A' && r <= 'Z' {
+				r = r + 32
+			}
+			lower += string(r)
+		}
+	}
+	for _, stub := range []string{"i cannot", "i can't", "i don't know", "i'm not sure", "i am not sure"} {
+		if contains(lower, stub) {
+			return 0.3
+		}
+	}
+	return 0.85
+}
+
+func contains(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	if len(needle) > len(haystack) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cascade/cascade_test.go
+++ b/internal/cascade/cascade_test.go
@@ -1,0 +1,222 @@
+package cascade
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestClassifyTrivialAndComplex(t *testing.T) {
+	trivial := Classify("define dependency injection", Signals{})
+	if trivial.Complexity != ComplexityTrivial {
+		t.Fatalf("trivial classification = %s (signals=%v score=%d), want trivial", trivial.Complexity, trivial.Signals, trivial.Score)
+	}
+
+	complex := Classify("Refactor internal/router to support speculative decoding and analyze the trade-offs across cmd/conduit/main.go and internal/router/router.go step by step.", Signals{TurnCount: 12})
+	if complex.Complexity != ComplexityComplex {
+		t.Fatalf("complex classification = %s (signals=%v score=%d), want complex", complex.Complexity, complex.Signals, complex.Score)
+	}
+}
+
+func TestClassifyCodeBlockBumpsToModerate(t *testing.T) {
+	prompt := "Here is the snippet:\n```go\nfunc add(a, b int) int { return a + b }\n```\nWhat does it do?"
+	c := Classify(prompt, Signals{})
+	if c.Complexity != ComplexityModerate && c.Complexity != ComplexitySimple {
+		t.Fatalf("classification = %s, want moderate or simple", c.Complexity)
+	}
+	hasCode := false
+	for _, s := range c.Signals {
+		if s == "code_block" {
+			hasCode = true
+		}
+	}
+	if !hasCode {
+		t.Fatalf("expected code_block signal, got %v", c.Signals)
+	}
+}
+
+func TestCascadeStartsAtCheapestHandlingTier(t *testing.T) {
+	tiers := []Tier{
+		{Name: "tiny", Handles: []Complexity{ComplexityTrivial}, Cost: 0.1, MinConfidence: 0.5},
+		{Name: "small", Handles: []Complexity{ComplexitySimple}, Cost: 0.5, MinConfidence: 0.5},
+		{Name: "big", Handles: []Complexity{ComplexityModerate, ComplexityComplex}, Cost: 5, MinConfidence: 0.5},
+	}
+	c, err := New(tiers)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	called := []string{}
+	infer := func(_ context.Context, t Tier) (Result, error) {
+		called = append(called, t.Name)
+		return Result{Text: strings.Repeat("good answer ", 5)}, nil
+	}
+
+	out, err := c.Run(context.Background(), "define cascading inference", Signals{}, infer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Tier.Name != "tiny" {
+		t.Fatalf("Tier = %s, want tiny", out.Tier.Name)
+	}
+	if len(called) != 1 || called[0] != "tiny" {
+		t.Fatalf("called = %v, want [tiny]", called)
+	}
+	if out.Escalated {
+		t.Fatalf("Escalated = true, want false")
+	}
+}
+
+func TestCascadeEscalatesOnLowQuality(t *testing.T) {
+	tiers := []Tier{
+		{Name: "tiny", Handles: nil, Cost: 0.1, MinConfidence: 0.6},
+		{Name: "big", Handles: nil, Cost: 5, MinConfidence: 0.6},
+	}
+	c, err := New(tiers, WithQualityFn(func(t Tier, r Result) float64 {
+		if t.Name == "tiny" {
+			return 0.2
+		}
+		return 0.9
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	called := []string{}
+	infer := func(_ context.Context, t Tier) (Result, error) {
+		called = append(called, t.Name)
+		return Result{Text: "ok"}, nil
+	}
+
+	out, err := c.Run(context.Background(), "anything", Signals{}, infer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Tier.Name != "big" {
+		t.Fatalf("Tier = %s, want big", out.Tier.Name)
+	}
+	if !out.Escalated {
+		t.Fatalf("Escalated = false, want true")
+	}
+	if len(called) != 2 {
+		t.Fatalf("called = %v, want [tiny big]", called)
+	}
+	if len(out.Attempts) != 2 || !out.Attempts[0].Escalated {
+		t.Fatalf("Attempts = %#v, want first escalated", out.Attempts)
+	}
+}
+
+func TestCascadeEscalatesOnError(t *testing.T) {
+	tiers := []Tier{
+		{Name: "tiny", Cost: 0.1, MinConfidence: 0.5},
+		{Name: "big", Cost: 5, MinConfidence: 0.5},
+	}
+	c, err := New(tiers)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	infer := func(_ context.Context, t Tier) (Result, error) {
+		if t.Name == "tiny" {
+			return Result{}, errors.New("provider down")
+		}
+		return Result{Text: strings.Repeat("answer ", 5)}, nil
+	}
+	out, err := c.Run(context.Background(), "anything", Signals{}, infer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Tier.Name != "big" {
+		t.Fatalf("Tier = %s, want big", out.Tier.Name)
+	}
+	if out.Attempts[0].Err == "" {
+		t.Fatalf("Attempts[0].Err is empty, want provider error")
+	}
+}
+
+func TestCascadeBudgetGateHaltsEscalation(t *testing.T) {
+	tiers := []Tier{
+		{Name: "tiny", Cost: 0.1, MinConfidence: 0.99},
+		{Name: "big", Cost: 5, MinConfidence: 0.5},
+	}
+	c, err := New(tiers,
+		WithBudgetGate(func(t Tier) bool { return t.Cost < 1 }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	infer := func(_ context.Context, _ Tier) (Result, error) {
+		return Result{Text: strings.Repeat("ok ", 30)}, nil
+	}
+	out, err := c.Run(context.Background(), "anything", Signals{}, infer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.BudgetStopped {
+		t.Fatalf("BudgetStopped = false, want true")
+	}
+	// degraded — last successful was tiny
+	if out.Tier.Name != "tiny" {
+		t.Fatalf("Tier = %s, want tiny (degraded)", out.Tier.Name)
+	}
+}
+
+func TestCascadeBatchFansOut(t *testing.T) {
+	tiers := []Tier{{Name: "tiny", Cost: 0.1, MinConfidence: 0.1}}
+	c, err := New(tiers)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var inflight, peak int32
+	infer := func(_ context.Context, _ Tier) (Result, error) {
+		cur := atomic.AddInt32(&inflight, 1)
+		for {
+			p := atomic.LoadInt32(&peak)
+			if cur <= p || atomic.CompareAndSwapInt32(&peak, p, cur) {
+				break
+			}
+		}
+		atomic.AddInt32(&inflight, -1)
+		return Result{Text: "answer text long enough"}, nil
+	}
+
+	results := c.Batch(context.Background(), []string{"a", "b", "c", "d"}, nil, 2, infer)
+	if len(results) != 4 {
+		t.Fatalf("results = %d, want 4", len(results))
+	}
+	for i, r := range results {
+		if r.Err != nil {
+			t.Fatalf("results[%d] err = %v", i, r.Err)
+		}
+		if r.Outcome.Tier.Name != "tiny" {
+			t.Fatalf("results[%d] tier = %s", i, r.Outcome.Tier.Name)
+		}
+	}
+}
+
+func TestNewRequiresAtLeastOneTier(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Fatal("expected error for empty tiers")
+	}
+	if _, err := New([]Tier{{Cost: 1}}); err == nil {
+		t.Fatal("expected error for unnamed tier")
+	}
+}
+
+func TestDefaultQualityRefusalScoreLow(t *testing.T) {
+	q := defaultQuality(Tier{}, Result{Text: "I cannot help with that, sorry."})
+	if q >= 0.5 {
+		t.Fatalf("quality = %v, want low (refusal)", q)
+	}
+}
+
+func TestDefaultQualityHonorsExplicitConfidence(t *testing.T) {
+	q := defaultQuality(Tier{}, Result{Text: "x", Confidence: 0.42})
+	if q != 0.42 {
+		t.Fatalf("quality = %v, want 0.42", q)
+	}
+}

--- a/internal/cascade/classify.go
+++ b/internal/cascade/classify.go
@@ -1,0 +1,166 @@
+// Package cascade implements cost-aware cascading inference: classify each
+// request by complexity using free local heuristics, try the cheapest model
+// tier first, and escalate to a stronger tier only when confidence or quality
+// thresholds are missed. The classifier is deliberately heuristic — no model
+// call is required to pick a starting tier.
+package cascade
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// Complexity classifies how hard a request likely is to satisfy.
+//
+// The four tiers follow PRD §16.4: trivial requests can usually be answered by
+// the smallest local model; simple requests fit a small chat model; moderate
+// requests benefit from a mid-tier model; complex requests need the strongest
+// available model.
+type Complexity string
+
+const (
+	ComplexityTrivial  Complexity = "trivial"
+	ComplexitySimple   Complexity = "simple"
+	ComplexityModerate Complexity = "moderate"
+	ComplexityComplex  Complexity = "complex"
+)
+
+// Classification is the heuristic verdict for a single request.
+type Classification struct {
+	Complexity Complexity
+	Score      int      // raw heuristic score, useful for logging/tuning
+	Signals    []string // human-readable signals that drove the verdict
+}
+
+// Signals captures pre-computed metadata that callers can supply when they
+// already know things about the request (turn count, prior tool failures, etc).
+// All fields are optional; the classifier degrades gracefully without them.
+type Signals struct {
+	TurnCount      int  // conversation depth so far
+	PriorEscalated bool // true if a prior turn already escalated
+	HasAttachments bool // image/PDF/screenshot present
+}
+
+var (
+	codeFenceRE = regexp.MustCompile("(?s)```")
+	fileRefRE   = regexp.MustCompile(`(?:[A-Za-z0-9_./-]+\.(?:go|py|js|ts|tsx|jsx|rs|java|rb|c|h|cpp|hpp|cs|swift|kt|md|yaml|yml|json|toml|sh))`)
+	urlRE       = regexp.MustCompile(`https?://\S+`)
+)
+
+// complexKeywords are reasoning-heavy verbs and phrases that almost always
+// warrant a stronger model. Hits add to the heuristic score.
+var complexKeywords = []string{
+	"refactor", "design", "architect", "optimi", "debug", "diagnose",
+	"prove", "derive", "analy", "compare", "trade-off", "tradeoff",
+	"explain why", "step by step", "step-by-step", "plan",
+}
+
+// trivialKeywords are short, lookup-style requests safely served by the
+// cheapest tier.
+var trivialKeywords = []string{
+	"what is", "define", "list", "rename", "translate",
+	"yes or no", "y/n", "tldr", "tl;dr", "summari",
+}
+
+// Classify returns a heuristic verdict for prompt with optional signals.
+//
+// Scoring is intentionally simple and deterministic so that tuning is
+// transparent: callers can log Score and Signals to understand a verdict.
+func Classify(prompt string, signals Signals) Classification {
+	lower := strings.ToLower(prompt)
+	trimmed := strings.TrimSpace(prompt)
+	score := 0
+	hits := []string{}
+
+	// Length signal — very short prompts skew trivial, very long ones complex.
+	wordCount := len(strings.FieldsFunc(trimmed, func(r rune) bool {
+		return unicode.IsSpace(r)
+	}))
+	switch {
+	case wordCount == 0:
+		// Empty prompt — treat as trivial; caller likely has tool inputs only.
+		hits = append(hits, "empty")
+	case wordCount <= 12:
+		score--
+		hits = append(hits, "short")
+	case wordCount >= 60:
+		score++
+		hits = append(hits, "long")
+	case wordCount >= 200:
+		score += 2
+		hits = append(hits, "very_long")
+	}
+
+	// Code presence — fenced blocks indicate the model will be reading or
+	// writing code, which is more demanding than prose.
+	if codeFenceRE.MatchString(prompt) {
+		score++
+		hits = append(hits, "code_block")
+	}
+	if fileRefs := fileRefRE.FindAllString(prompt, -1); len(fileRefs) > 0 {
+		score++
+		hits = append(hits, "file_ref")
+		if len(fileRefs) >= 3 {
+			score++
+			hits = append(hits, "many_file_refs")
+		}
+	}
+
+	// External URLs hint at synthesis or fetching; modest bump.
+	if urlRE.MatchString(prompt) {
+		score++
+		hits = append(hits, "url")
+	}
+
+	// Keyword scanning.
+	for _, kw := range complexKeywords {
+		if strings.Contains(lower, kw) {
+			score++
+			hits = append(hits, "kw:"+kw)
+			break
+		}
+	}
+	for _, kw := range trivialKeywords {
+		if strings.Contains(lower, kw) {
+			score--
+			hits = append(hits, "trivial_kw")
+			break
+		}
+	}
+
+	// Conversation depth — long sessions accumulate state that warrants more
+	// reasoning capacity.
+	switch {
+	case signals.TurnCount >= 20:
+		score += 2
+		hits = append(hits, "deep_turn")
+	case signals.TurnCount >= 8:
+		score++
+		hits = append(hits, "many_turns")
+	}
+	if signals.PriorEscalated {
+		score++
+		hits = append(hits, "prior_escalated")
+	}
+	if signals.HasAttachments {
+		score++
+		hits = append(hits, "attachments")
+	}
+
+	complexity := bucket(score)
+	return Classification{Complexity: complexity, Score: score, Signals: hits}
+}
+
+func bucket(score int) Complexity {
+	switch {
+	case score <= -1:
+		return ComplexityTrivial
+	case score == 0:
+		return ComplexitySimple
+	case score <= 2:
+		return ComplexityModerate
+	default:
+		return ComplexityComplex
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/cascade` package: heuristic complexity classifier (trivial / simple / moderate / complex) using length, code fences, file refs, URLs, keywords, and conversation depth — no model call needed to pick a starting tier.
- `Cascader` orchestrates cheapest-tier-first inference with quality-threshold escalation, hard-error escalation, parallel `Batch`, and a budget gate that degrades to the last successful tier instead of escalating further.
- Pluggable `QualityFn` and `Classifier` so callers can wire real confidence signals (e.g. logprobs) without changing the orchestration.

Closes #133

## Test plan
- [x] `go test ./internal/cascade/...`
- [x] `make lint`
- [x] `make test`