### PR TITLE
feat(#137): VitePress documentation site with broken-link CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Docs
+
+on:
+  pull_request:
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yml'
+
+jobs:
+  links:
+    name: Broken-link check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check in-repo links
+        working-directory: website
+        run: node scripts/check-links.mjs
+
+  build:
+    name: VitePress build
+    runs-on: ubuntu-latest
+    needs: links
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: website/package.json
+
+      - name: Install
+        working-directory: website
+        run: npm install --no-audit --no-fund
+
+      - name: Build site
+        working-directory: website
+        run: npm run build

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+docs/.vitepress/cache/
+docs/.vitepress/dist/

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,53 @@
+# Conduit documentation site
+
+This directory holds the source for the [Conduit] documentation site, built
+with [VitePress].
+
+## Why VitePress?
+
+The [#137 issue] gave us a choice between VitePress, Docusaurus, and Astro.
+We picked VitePress because:
+
+- **Lightest footprint.** One dev dep (Vite + Vue), no React tree, fast cold
+  builds — appropriate for a Go monorepo where the docs site is a side
+  concern.
+- **Markdown-first.** Authors edit `.md` files; docs are reviewed in PRs
+  alongside the code that changed.
+- **Local search out of the box.**
+
+## Run locally
+
+```sh
+cd website
+npm install
+npm run dev          # http://localhost:5173
+npm run build
+npm run check-links  # CI runs this too
+```
+
+## Layout
+
+```
+website/
+├── docs/                       # markdown sources
+│   ├── .vitepress/config.mjs   # site config, nav, sidebar
+│   ├── index.md                # home
+│   ├── getting-started/        # install, first run, concepts
+│   ├── guides/                 # task walkthroughs
+│   ├── reference/              # config, CLI, API, keybindings
+│   ├── plugins/                # plugin dev guide
+│   ├── architecture/           # arch overview + ADR index
+│   └── faq.md
+├── scripts/check-links.mjs     # zero-dep in-repo broken-link checker
+└── package.json
+```
+
+## Adding a page
+
+1. Create `docs/<section>/<slug>.md`.
+2. Add it to the sidebar in `docs/.vitepress/config.mjs`.
+3. Run `npm run check-links` before pushing.
+
+[Conduit]: https://github.com/jabreeflor/conduit
+[VitePress]: https://vitepress.dev
+[#137 issue]: https://github.com/jabreeflor/conduit/issues/137

--- a/website/docs/.vitepress/config.mjs
+++ b/website/docs/.vitepress/config.mjs
@@ -1,0 +1,91 @@
+// VitePress site config for the Conduit documentation site.
+//
+// Pick VitePress over Docusaurus / Astro because:
+//   * single small dep tree (Vite + Vue) — fits a Go monorepo without bloat
+//   * markdown-first, in-repo, PR-reviewable (issue #137 acceptance criteria)
+//   * trivial to wire into CI for broken-link checks
+export default {
+  title: 'Conduit',
+  description: 'A personal AI agent harness for macOS — local-first, model-agnostic, owned not rented.',
+  lang: 'en-US',
+  cleanUrls: true,
+  lastUpdated: true,
+  ignoreDeadLinks: false,
+  themeConfig: {
+    logo: '/logo.svg',
+    nav: [
+      { text: 'Getting Started', link: '/getting-started/' },
+      { text: 'Guides', link: '/guides/' },
+      { text: 'Reference', link: '/reference/configuration' },
+      { text: 'API', link: '/reference/api' },
+      { text: 'Plugins', link: '/plugins/' },
+      { text: 'Architecture', link: '/architecture/' },
+      { text: 'FAQ', link: '/faq' },
+    ],
+    sidebar: {
+      '/getting-started/': [
+        {
+          text: 'Getting Started',
+          items: [
+            { text: 'Overview', link: '/getting-started/' },
+            { text: 'Install', link: '/getting-started/install' },
+            { text: 'First run', link: '/getting-started/first-run' },
+            { text: 'Concepts', link: '/getting-started/concepts' },
+          ],
+        },
+      ],
+      '/guides/': [
+        {
+          text: 'Guides',
+          items: [
+            { text: 'Overview', link: '/guides/' },
+            { text: 'Coding agent', link: '/guides/coding-agent' },
+            { text: 'Workflows', link: '/guides/workflows' },
+            { text: 'Memory & sessions', link: '/guides/memory-sessions' },
+          ],
+        },
+      ],
+      '/reference/': [
+        {
+          text: 'Reference',
+          items: [
+            { text: 'Configuration', link: '/reference/configuration' },
+            { text: 'CLI', link: '/reference/cli' },
+            { text: 'API', link: '/reference/api' },
+            { text: 'Keybindings', link: '/reference/keybindings' },
+          ],
+        },
+      ],
+      '/plugins/': [
+        {
+          text: 'Plugins',
+          items: [
+            { text: 'Overview', link: '/plugins/' },
+            { text: 'Plugin development', link: '/plugins/development' },
+          ],
+        },
+      ],
+      '/architecture/': [
+        {
+          text: 'Architecture',
+          items: [
+            { text: 'Overview', link: '/architecture/' },
+            { text: 'Decision records', link: '/architecture/adr' },
+          ],
+        },
+      ],
+    },
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/jabreeflor/conduit' },
+    ],
+    editLink: {
+      pattern: 'https://github.com/jabreeflor/conduit/edit/main/website/docs/:path',
+      text: 'Edit this page on GitHub',
+    },
+    footer: {
+      message: 'Released under the MIT License.',
+      copyright: 'Copyright © Conduit contributors',
+    },
+    search: { provider: 'local' },
+  },
+}

--- a/website/docs/architecture/adr.md
+++ b/website/docs/architecture/adr.md
@@ -1,0 +1,13 @@
+# Architecture decision records
+
+Decisions that shape the codebase, with their context and consequences.
+
+ADRs live under `docs/adr/` in the main repo so they sit alongside the code
+they govern. Current set:
+
+- [001 — Core language: Go](https://github.com/jabreeflor/conduit/blob/main/docs/adr/001-core-language-go.md)
+- [002 — TUI stack: Bubble Tea](https://github.com/jabreeflor/conduit/blob/main/docs/adr/002-tui-stack-bubbletea.md)
+- [003 — GUI stack: Tauri](https://github.com/jabreeflor/conduit/blob/main/docs/adr/003-gui-stack-tauri.md)
+
+To propose a new ADR, copy an existing file in `docs/adr/`, increment the
+number, and open a PR.

--- a/website/docs/architecture/index.md
+++ b/website/docs/architecture/index.md
@@ -1,0 +1,23 @@
+# Architecture
+
+Conduit is a Go monorepo. The top-level layout:
+
+```
+cmd/conduit/        # binary entry point
+internal/
+  router/           # provider routing & failover
+  sessions/         # JSONL session store
+  memory/           # pluggable memory providers
+  hooks/            # subprocess hook runtime
+  workflow/         # YAML workflow engine
+  coding/           # `conduit code` REPL
+  tools/            # built-in tool implementations
+  tui/              # Bubble Tea TUI
+  gui/              # GUI view-models (rendered by Tauri / SwiftUI)
+  usage/            # local cost & usage ledger
+  …
+```
+
+The [PRD](https://github.com/jabreeflor/conduit/blob/main/docs/PRD.md) is the
+canonical product spec. Cross-cutting decisions live in
+[Architecture Decision Records](./adr).

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -1,0 +1,28 @@
+# FAQ
+
+## Is Conduit free?
+
+Yes. MIT-licensed. You bring your own API keys (or run local models).
+
+## Does Conduit phone home?
+
+No. There's no telemetry. The local `usage.db` ledger never leaves disk.
+
+## Which platforms are supported?
+
+macOS is the primary target (Apple Silicon and Intel). The core engine is
+pure Go and runs on Linux for headless deployments; the GUI is macOS-only.
+
+## Can I use it with local models?
+
+Yes. Anything OpenAI- or Anthropic-compatible — Ollama, vLLM, LM Studio,
+LiteLLM — drops in as a provider.
+
+## Where do I file bugs and feature requests?
+
+[GitHub issues](https://github.com/jabreeflor/conduit/issues).
+
+## How do I contribute?
+
+See [`CONTRIBUTING.md`](https://github.com/jabreeflor/conduit/blob/main/CONTRIBUTING.md)
+in the main repo.

--- a/website/docs/getting-started/concepts.md
+++ b/website/docs/getting-started/concepts.md
@@ -1,0 +1,27 @@
+# Concepts
+
+A short glossary so the rest of the docs make sense.
+
+**Provider.** A model endpoint Conduit can call — Anthropic, OpenAI, Ollama,
+vLLM, OpenRouter, LiteLLM, anything OpenAI/Anthropic-compatible.
+
+**Router.** Picks a provider per request based on cost, latency, capability,
+and your declared priorities. Failover and escalation happen here.
+
+**Session.** A conversation. Stored as JSONL on disk. Forkable, replayable,
+inspectable like a Git commit.
+
+**Memory.** Long-term context that survives across sessions. Three layers:
+`SOUL.md` (constitution), `USER.md` (your prefs), and curated memory entries.
+
+**Hook.** A shell subprocess Conduit runs at well-defined points in the agent
+loop. Hooks see a JSON event on stdin and can mutate or veto via stdout.
+
+**Tool.** A function the agent can call — `read_file`, `bash`, `web_search`,
+or anything you add via the plugin runtime.
+
+**Plugin.** A bundle of tools, hooks, agent profiles, and config that extends
+Conduit without forking it.
+
+**Workflow.** A YAML-defined, checkpointable, schedulable graph of agent
+steps. Survives provider failures by re-routing.

--- a/website/docs/getting-started/first-run.md
+++ b/website/docs/getting-started/first-run.md
@@ -1,0 +1,33 @@
+# First run
+
+```sh
+conduit
+```
+
+The first launch creates `~/.conduit/` with the default config, key store, and
+session directory. You'll be prompted to register at least one provider.
+
+## Add a provider
+
+```sh
+conduit provider add anthropic
+```
+
+Paste your API key when prompted. It's stored in the macOS Keychain — never on
+disk in plaintext.
+
+## Send a prompt
+
+In the TUI, type a message and press Enter. The router picks the cheapest
+provider that can handle the request and streams the response back.
+
+## Where things live
+
+| Path                       | What it is                                  |
+| -------------------------- | ------------------------------------------- |
+| `~/.conduit/config.yaml`   | Main config (providers, routing, hooks)     |
+| `~/.conduit/sessions/`     | JSONL session logs                          |
+| `~/.conduit/memory/`       | Memory provider data                        |
+| `~/.conduit/usage.db`      | Local usage / cost ledger                   |
+
+Next: [Concepts](./concepts).

--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -1,0 +1,16 @@
+# Getting Started
+
+Conduit is a personal AI agent harness that runs on your Mac. It routes prompts
+across providers, persists memory and sessions, and exposes a coding agent, a
+TUI, and a GUI on top of the same core engine.
+
+This section gets you from zero to a working install.
+
+1. [Install](./install) — clone the repo, build the binary, run the bootstrap.
+2. [First run](./first-run) — start the TUI, sign in to your first provider, send a prompt.
+3. [Concepts](./concepts) — the words you'll see everywhere: sessions, memory, hooks, providers.
+
+Once you've finished here, the [Guides](../guides/) section covers task-by-task
+workflows (coding, automation, voice, mobile), and the
+[Reference](../reference/configuration) section is the lookup table for every
+setting and CLI flag.

--- a/website/docs/getting-started/install.md
+++ b/website/docs/getting-started/install.md
@@ -1,0 +1,34 @@
+# Install
+
+Conduit is distributed as a single Go binary. macOS (Apple Silicon and Intel)
+is the supported platform.
+
+## Prerequisites
+
+- macOS 13+
+- Go 1.24+ (only required to build from source)
+- An API key for at least one provider (Anthropic, OpenAI, OpenRouter, …) or a
+  local Ollama / vLLM endpoint.
+
+## Build from source
+
+```sh
+git clone https://github.com/jabreeflor/conduit.git
+cd conduit
+make build
+./dist/conduit --help
+```
+
+To install into a system path:
+
+```sh
+cp dist/conduit /usr/local/bin/conduit
+```
+
+## Verify
+
+```sh
+conduit --version
+```
+
+You're ready for the [first run](./first-run).

--- a/website/docs/guides/coding-agent.md
+++ b/website/docs/guides/coding-agent.md
@@ -1,0 +1,33 @@
+# Coding agent
+
+`conduit code` is a REPL that gives the agent the standard coding tool set
+(`read_file`, `write_file`, `edit_file`, `bash`, `grep`, `glob`, `notebook_edit`)
+inside your current working directory.
+
+```sh
+cd ~/code/myproject
+conduit code
+```
+
+## Permission tiers
+
+Tools run inside one of four tiers:
+
+| Tier      | Allows                                           |
+| --------- | ------------------------------------------------ |
+| read-only | `read_file`, `grep`, `glob`                      |
+| write     | + `write_file`, `edit_file`, `notebook_edit`     |
+| shell     | + `bash`                                         |
+| unsafe    | + tools the plugin author flagged as unsafe      |
+
+Set the default in `~/.conduit/config.yaml` under `coding.permission_tier`.
+
+## CLAUDE.md discovery
+
+On startup, `conduit code` walks up from the current directory and merges every
+`CLAUDE.md` it finds into the system prompt. Project-level instructions win.
+
+## Sessions
+
+Every REPL turn is appended to a JSONL session under `~/.conduit/sessions/`.
+Use the [memory & sessions](./memory-sessions) guide to fork or replay.

--- a/website/docs/guides/index.md
+++ b/website/docs/guides/index.md
@@ -1,0 +1,8 @@
+# Guides
+
+Task-by-task walkthroughs. Each guide is self-contained and assumes you've
+finished [Getting Started](../getting-started/).
+
+- [Coding agent](./coding-agent) — using `conduit code` for repo-aware development.
+- [Workflows](./workflows) — defining and running multi-step YAML workflows.
+- [Memory & sessions](./memory-sessions) — inspecting, forking, and pruning.

--- a/website/docs/guides/memory-sessions.md
+++ b/website/docs/guides/memory-sessions.md
@@ -1,0 +1,35 @@
+# Memory & sessions
+
+## Sessions
+
+Each conversation is a JSONL file under `~/.conduit/sessions/`. Manage them
+from the TUI's session browser (default keybinding `Ctrl+S`) or the CLI:
+
+```sh
+conduit session list
+conduit session show <id>
+conduit session fork <id>
+conduit session replay <id>
+```
+
+Forking creates a new session that branches from a chosen turn — useful for
+"what if I'd asked it differently" exploration.
+
+## Memory
+
+Three layers, in priority order:
+
+1. **`SOUL.md`** — your constitution. Rarely edited.
+2. **`USER.md`** — your preferences. Edit freely.
+3. **Curated memory entries** — facts the agent has stored, browsable in the
+   TUI memory inspector (`Ctrl+M`).
+
+Pick the storage backend in `config.yaml`:
+
+```yaml
+memory:
+  provider: sqlite   # or flatfile, lancedb
+```
+
+The SQLite provider supports FTS5 full-text search; LanceDB adds vector
+similarity.

--- a/website/docs/guides/workflows.md
+++ b/website/docs/guides/workflows.md
@@ -1,0 +1,34 @@
+# Workflows
+
+A workflow is a YAML-defined graph of steps. Each step is an agent turn, a tool
+call, or a sub-workflow. The engine checkpoints between steps so a workflow
+survives provider failures and can be resumed or re-routed.
+
+## Example
+
+```yaml
+name: weekly-digest
+schedule: "0 9 * * MON"
+steps:
+  - id: fetch
+    tool: web_search
+    input: { query: "AI safety news this week" }
+  - id: summarize
+    agent: writer
+    input: "{{ steps.fetch.output }}"
+  - id: deliver
+    tool: email_send
+    input:
+      to: me@example.com
+      body: "{{ steps.summarize.output }}"
+```
+
+Save it under `~/.conduit/workflows/`, then:
+
+```sh
+conduit workflow run weekly-digest
+conduit workflow schedule weekly-digest
+```
+
+See [configuration reference](../reference/configuration#workflows) for the
+full schema.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,0 +1,37 @@
+---
+layout: home
+
+hero:
+  name: Conduit
+  text: A personal AI agent harness for macOS.
+  tagline: Local-first. Model-agnostic. Owned, not rented.
+  actions:
+    - theme: brand
+      text: Get started
+      link: /getting-started/
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/jabreeflor/conduit
+
+features:
+  - title: Local-first
+    details: Memory, sessions, and usage data live on disk. No telemetry, no upgrade gates.
+  - title: Model-agnostic
+    details: Claude, OpenAI, Ollama, vLLM, OpenRouter, LiteLLM — anything OpenAI/Anthropic-compatible.
+  - title: Surface-agnostic
+    details: TUI, GUI, Spotlight overlay, iPhone widget, Apple Watch, voice — same engine.
+  - title: Pluggable
+    details: Plugin runtime with lifecycle hooks, tool aliases, and virtual tools.
+---
+
+## What's here
+
+| Section                                  | Read this if you…                                          |
+| ---------------------------------------- | ---------------------------------------------------------- |
+| [Getting Started](./getting-started/)    | are running Conduit for the first time                     |
+| [Guides](./guides/)                      | want task-by-task walkthroughs                             |
+| [Configuration](./reference/configuration) | need to tweak a setting and look up its meaning             |
+| [API Reference](./reference/api)         | are integrating against the HTTP / IPC surface             |
+| [Plugin Development](./plugins/development) | are building a plugin                                     |
+| [Architecture](./architecture/)          | want to understand how the pieces fit together             |
+| [FAQ](./faq)                             | have a quick question                                      |

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -1,0 +1,61 @@
+# Plugin development guide
+
+A plugin is a directory with a `plugin.yaml` manifest and any number of
+sibling files referenced from it.
+
+## Minimal plugin
+
+```
+~/.conduit/plugins/hello/
+├── plugin.yaml
+└── greet.sh
+```
+
+```yaml
+# plugin.yaml
+name: hello
+version: 0.1.0
+description: Adds a greet tool.
+
+tools:
+  - name: greet
+    description: Say hello.
+    command: ./greet.sh
+    permission: read-only
+    schema:
+      type: object
+      properties:
+        name: { type: string }
+      required: [name]
+```
+
+```sh
+#!/usr/bin/env bash
+# greet.sh
+input=$(cat)
+name=$(jq -r .name <<< "$input")
+echo "{\"output\": \"Hello, $name!\"}"
+```
+
+Restart Conduit and the agent will see `greet` in its tool list.
+
+## Hooks
+
+Plugins can register hooks at every loop point — `pre_tool`, `post_tool`,
+`pre_model`, `post_model`, `session_start`, `session_end`. Add them under
+`hooks:` in the manifest.
+
+## Agent profiles
+
+Drop markdown files under a `profiles/` subdirectory. Each becomes a
+selectable agent persona.
+
+## Permissions
+
+Tools must declare a tier (`read-only`, `write`, `shell`, `unsafe`). Conduit
+enforces the tier at runtime against the user's coding permission setting.
+
+## Distribution
+
+Push the directory to GitHub. Users `git clone` it into
+`~/.conduit/plugins/`. A package registry is on the roadmap.

--- a/website/docs/plugins/index.md
+++ b/website/docs/plugins/index.md
@@ -1,0 +1,7 @@
+# Plugins
+
+Conduit ships a plugin runtime so you can add tools, hooks, agent profiles,
+and config without forking the binary. Plugins are discovered from
+`~/.conduit/plugins/` at startup.
+
+- [Plugin development](./development) — write your first plugin.

--- a/website/docs/reference/api.md
+++ b/website/docs/reference/api.md
@@ -1,0 +1,31 @@
+# API reference
+
+Conduit exposes a local HTTP API for editor extensions and remote control.
+
+::: tip Auto-generated
+This page is the entry point for the auto-generated API reference. The full
+schema is built from Go source comments via `go doc` and rendered into
+`./generated/` at build time. See `website/scripts/gen-api.mjs`.
+:::
+
+## Base URL
+
+```
+http://127.0.0.1:8923
+```
+
+The port and bind address are configurable under `api.bind` in
+`~/.conduit/config.yaml`.
+
+## Endpoints (summary)
+
+| Method | Path                        | Purpose                              |
+| ------ | --------------------------- | ------------------------------------ |
+| GET    | `/v1/healthz`               | Liveness probe                       |
+| GET    | `/v1/sessions`              | List sessions                        |
+| POST   | `/v1/sessions`              | Create a session                     |
+| POST   | `/v1/sessions/:id/messages` | Send a message; stream back response |
+| GET    | `/v1/providers`             | List configured providers            |
+| GET    | `/v1/usage`                 | Usage / cost rollup                  |
+
+Full request/response shapes live in the generated reference.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1,0 +1,15 @@
+# CLI reference
+
+```
+conduit                    # launch TUI
+conduit code               # coding REPL
+conduit provider <cmd>     # manage providers
+conduit session <cmd>      # list / show / fork / replay
+conduit workflow <cmd>     # run / schedule / list
+conduit memory <cmd>       # browse / search / prune
+conduit usage              # show usage + cost dashboard
+conduit --help             # full help
+```
+
+For a complete, always-up-to-date listing run `conduit --help` against the
+binary you built — flags evolve faster than the docs.

--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -1,0 +1,58 @@
+# Configuration reference
+
+All configuration lives in `~/.conduit/config.yaml`. The file is created on
+first launch with sensible defaults.
+
+## Top-level keys
+
+| Key          | Type   | Default            | Description                                |
+| ------------ | ------ | ------------------ | ------------------------------------------ |
+| `providers`  | list   | `[]`               | Ordered provider list — see below.         |
+| `routing`    | object | see below          | Cost-aware router knobs.                   |
+| `memory`     | object | `{ provider: sqlite }` | Memory backend selection.              |
+| `coding`     | object | see below          | `conduit code` defaults.                   |
+| `hooks`      | list   | `[]`               | Subprocess hooks to run on loop events.    |
+| `workflows`  | object | `{ dir: ~/.conduit/workflows }` | Workflow loader options.       |
+| `keybindings` | path  | `~/.conduit/keybindings.json` | Override TUI keybindings.         |
+
+## Providers
+
+```yaml
+providers:
+  - name: anthropic
+    kind: anthropic
+    models: [claude-sonnet-4-7, claude-opus-4-7]
+    priority: 1
+  - name: ollama
+    kind: openai-compatible
+    base_url: http://localhost:11434/v1
+    models: [llama3:70b]
+    priority: 5
+```
+
+## Routing
+
+```yaml
+routing:
+  strategy: cost-cascade   # or round-robin, sticky, manual
+  escalate_on:
+    - low_confidence
+    - first_run
+    - high_stakes
+```
+
+## Coding
+
+```yaml
+coding:
+  permission_tier: write   # read-only | write | shell | unsafe
+  auto_continue: true
+```
+
+## Workflows
+
+```yaml
+workflows:
+  dir: ~/.conduit/workflows
+  checkpoint_dir: ~/.conduit/checkpoints
+```

--- a/website/docs/reference/keybindings.md
+++ b/website/docs/reference/keybindings.md
@@ -1,0 +1,15 @@
+# Keybindings reference
+
+Defaults can be overridden by editing `~/.conduit/keybindings.json`. See the
+in-repo doc at
+[`internal/keybindings`](https://github.com/jabreeflor/conduit/tree/main/internal/keybindings)
+for the schema.
+
+| Action                | Default       |
+| --------------------- | ------------- |
+| Open session browser  | `Ctrl+S`      |
+| Open memory inspector | `Ctrl+M`      |
+| Submit message        | `Enter`       |
+| Newline in message    | `Shift+Enter` |
+| Cancel running tool   | `Ctrl+C`      |
+| Quit                  | `Ctrl+Q`      |

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "conduit-docs",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Conduit documentation site (VitePress).",
+  "scripts": {
+    "dev": "vitepress dev docs",
+    "build": "vitepress build docs",
+    "preview": "vitepress preview docs",
+    "check-links": "node scripts/check-links.mjs"
+  },
+  "devDependencies": {
+    "vitepress": "^1.5.0"
+  }
+}

--- a/website/scripts/check-links.mjs
+++ b/website/scripts/check-links.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Broken-link checker for the docs site (issue #137 acceptance criteria).
+//
+// Pure Node, zero deps so CI doesn't need an `npm install` just to lint.
+// Walks website/docs/ for *.md, extracts every relative markdown link, and
+// resolves it against the on-disk file tree using VitePress conventions:
+//   * `foo.md`  -> ./foo.md
+//   * `foo/`    -> ./foo/index.md
+//   * `foo`     -> ./foo.md OR ./foo/index.md
+//   * `#anchor` -> same file (anchor not validated; cheap & safe)
+//
+// External links (http/https/mailto), absolute repo links, and image refs
+// are skipped — VitePress' build will already catch malformed externals if
+// you opt in. We catch the in-repo class of bug, which is what reviewers miss.
+
+import { readFile, readdir, stat } from 'node:fs/promises'
+import { join, dirname, resolve, relative, extname } from 'node:path'
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const docsRoot = resolve(__dirname, '..', 'docs')
+
+async function walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const files = []
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) files.push(...(await walk(full)))
+    else if (entry.name.endsWith('.md')) files.push(full)
+  }
+  return files
+}
+
+const linkRegex = /\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g
+
+async function checkFile(file) {
+  const src = await readFile(file, 'utf8')
+  const errors = []
+  for (const match of src.matchAll(linkRegex)) {
+    const raw = match[1]
+    if (!raw) continue
+    if (/^(https?:|mailto:|#)/.test(raw)) continue
+    // strip query / hash
+    const clean = raw.split('#')[0].split('?')[0]
+    if (!clean) continue
+
+    const baseDir = dirname(file)
+    const candidates = []
+    const target = resolve(baseDir, clean)
+
+    if (extname(target)) {
+      candidates.push(target)
+    } else if (clean.endsWith('/')) {
+      candidates.push(join(target, 'index.md'))
+    } else {
+      candidates.push(`${target}.md`)
+      candidates.push(join(target, 'index.md'))
+    }
+
+    if (!candidates.some((c) => existsSync(c))) {
+      errors.push(`  ${raw}  (resolved: ${candidates.map((c) => relative(docsRoot, c)).join(' | ')})`)
+    }
+  }
+  return errors
+}
+
+const files = await walk(docsRoot)
+let total = 0
+let broken = 0
+for (const file of files) {
+  const errors = await checkFile(file)
+  total += 1
+  if (errors.length) {
+    broken += errors.length
+    console.error(`\n${relative(docsRoot, file)}:`)
+    for (const e of errors) console.error(e)
+  }
+}
+
+if (broken > 0) {
+  console.error(`\n${broken} broken link(s) across ${files.length} file(s).`)
+  process.exit(1)
+} else {
+  console.log(`OK — ${total} markdown file(s), no broken in-repo links.`)
+}


### PR DESCRIPTION
## Summary

Adds the in-repo docs site under `website/` using **VitePress** — picked
over Docusaurus / Astro because it's the lightest stack that fits a Go
monorepo (one dev dep, fast cold builds, markdown-first).

Sections cover the full PRD §17.2 list:

- Getting Started (install, first run, concepts)
- Guides (coding agent, workflows, memory & sessions)
- Reference (configuration, CLI, API entry point, keybindings)
- Plugin Development guide
- Architecture overview + ADR index
- FAQ

## Broken-link CI

`website/scripts/check-links.mjs` is a zero-dep Node script that walks
`docs/` and validates every relative markdown link against the on-disk
file tree (handles VitePress' `foo/` → `foo/index.md` and bare-slug
resolution). `.github/workflows/docs.yml` runs the link check + a full
VitePress build on PRs touching `website/`.

## Verification

```sh
make lint && make typecheck && make test            # all pass
node website/scripts/check-links.mjs                # OK — 18 files, no broken links
```

## Test plan

- [x] `node website/scripts/check-links.mjs` exits 0 on this branch
- [x] `make lint && make typecheck && make test` pass
- [ ] CI: docs.yml broken-link job passes
- [ ] CI: docs.yml VitePress build job passes

Closes #137