### PR TITLE
feat(#62): plugin runtime — manifest, lifecycle hooks, virtual tools

### DIFF
--- a/internal/plugins/dispatcher.go
+++ b/internal/plugins/dispatcher.go
@@ -1,0 +1,300 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// HookContext is the payload passed into every lifecycle handler. The exact
+// fields populated depend on the event:
+//
+//   - beforePrompt / afterTurn / onResume / beforePersist:
+//     SessionID, CWD, Prompt (beforePrompt only), TurnOutput (afterTurn only)
+//   - beforeDelegate / afterDelegate: SessionID, ToolName, ToolInput,
+//     ToolOutput (afterDelegate only)
+//
+// Plugins read what they need and ignore the rest. State is the
+// session-scoped key/value bag persisted across turns when the manifest
+// declares a state binding; mutations made by the handler are flushed by the
+// dispatcher when Dispatch returns.
+type HookContext struct {
+	Event      LifecycleHook
+	SessionID  string
+	CWD        string
+	Prompt     string
+	TurnOutput string
+	ToolName   string
+	ToolInput  map[string]any
+	ToolOutput string
+	State      map[string]any
+}
+
+// HookDecision is what a handler returns to influence runtime behaviour.
+// All fields are optional. Block short-circuits the surrounding action.
+// Inject contributes additional context the agent should see (the surface
+// decides where — typically appended to the system prompt for beforePrompt).
+type HookDecision struct {
+	Block        bool
+	BlockReason  string
+	Inject       string
+	StateUpdates map[string]any
+}
+
+// Handler is the in-process callback invoked when a lifecycle event fires.
+// Implementations should treat the context as read-only except for State,
+// which is the dispatcher-managed persisted bag.
+type Handler func(ctx context.Context, hc HookContext) (HookDecision, error)
+
+// Runtime is the live plugin host. It owns the manifest registry, the
+// in-process handler table, and per-plugin per-session state files.
+type Runtime struct {
+	mu        sync.RWMutex
+	manifests []Manifest
+	handlers  map[string]Handler
+	stateRoot string
+}
+
+// NewRuntime constructs a runtime backed by stateRoot for state persistence.
+// stateRoot may be empty to disable state I/O (in-memory only).
+func NewRuntime(stateRoot string) *Runtime {
+	return &Runtime{handlers: map[string]Handler{}, stateRoot: stateRoot}
+}
+
+// Load installs the supplied manifests as the active plugin set.
+func (r *Runtime) Load(manifests []Manifest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.manifests = append(r.manifests[:0:0], manifests...)
+}
+
+// RegisterHandler binds an in-process function to the global name a manifest
+// references via HookBinding.Handler. Handlers are shared across plugins; a
+// single function can serve multiple manifests.
+func (r *Runtime) RegisterHandler(name string, h Handler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.handlers[name] = h
+}
+
+// Manifests returns a copy of the loaded manifest list, useful for
+// surfaces that enumerate plugins.
+func (r *Runtime) Manifests() []Manifest {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Manifest, len(r.manifests))
+	copy(out, r.manifests)
+	return out
+}
+
+// Dispatch fires every registered handler for the named event in manifest
+// order. The first handler to return Block stops the chain; the cumulative
+// Inject text is concatenated and returned in the final decision.
+//
+// Handler errors do NOT abort the chain — they are joined into the returned
+// error so a single broken plugin cannot silently disable the rest.
+func (r *Runtime) Dispatch(ctx context.Context, event LifecycleHook, hc HookContext) (HookDecision, error) {
+	r.mu.RLock()
+	manifests := append([]Manifest(nil), r.manifests...)
+	handlers := make(map[string]Handler, len(r.handlers))
+	for k, v := range r.handlers {
+		handlers[k] = v
+	}
+	r.mu.RUnlock()
+
+	final := HookDecision{}
+	var injects []string
+	var errs []error
+
+	for _, m := range manifests {
+		state, _ := r.loadState(m, hc.SessionID)
+		hc.State = state
+		fired := false
+		for _, binding := range m.Hooks {
+			if binding.Event != event {
+				continue
+			}
+			if binding.Matcher != "" && !matches(binding.Matcher, hc) {
+				continue
+			}
+			h, ok := handlers[binding.Handler]
+			if !ok {
+				errs = append(errs, fmt.Errorf("plugins: %s: handler %q not registered", m.Name, binding.Handler))
+				continue
+			}
+			dec, err := h(ctx, hc)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("plugins: %s/%s: %w", m.Name, binding.Handler, err))
+				continue
+			}
+			fired = true
+			if dec.Inject != "" {
+				injects = append(injects, dec.Inject)
+			}
+			for k, v := range dec.StateUpdates {
+				if hc.State == nil {
+					hc.State = map[string]any{}
+				}
+				hc.State[k] = v
+			}
+			if dec.Block {
+				final.Block = true
+				final.BlockReason = dec.BlockReason
+				_ = r.saveState(m, hc.SessionID, hc.State)
+				final.Inject = strings.Join(injects, "\n")
+				if len(errs) > 0 {
+					return final, joinErrs(errs)
+				}
+				return final, nil
+			}
+		}
+		if fired {
+			_ = r.saveState(m, hc.SessionID, hc.State)
+		}
+	}
+
+	final.Inject = strings.Join(injects, "\n")
+	if len(errs) > 0 {
+		return final, joinErrs(errs)
+	}
+	return final, nil
+}
+
+func matches(matcher string, hc HookContext) bool {
+	matcher = strings.ToLower(matcher)
+	candidates := []string{hc.ToolName, hc.Prompt}
+	for _, c := range candidates {
+		if c != "" && strings.Contains(strings.ToLower(c), matcher) {
+			return true
+		}
+	}
+	return false
+}
+
+func joinErrs(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	parts := make([]string, len(errs))
+	for i, e := range errs {
+		parts[i] = e.Error()
+	}
+	return fmt.Errorf("%s", strings.Join(parts, "; "))
+}
+
+// VirtualTools returns every virtual tool declared by the loaded manifests in
+// stable order. The host tool layer registers these as Runners that delegate
+// to RenderVirtualTool.
+func (r *Runtime) VirtualTools() []VirtualTool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []VirtualTool
+	for _, m := range r.manifests {
+		out = append(out, m.VirtualTools...)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// ToolAliases returns the union of every plugin's renames in load order so
+// later plugins can override earlier ones if they bind the same source.
+func (r *Runtime) ToolAliases() []ToolAlias {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []ToolAlias
+	for _, m := range r.manifests {
+		out = append(out, m.ToolAliases...)
+	}
+	return out
+}
+
+// BlockedTools returns the union of every plugin's tool block list.
+func (r *Runtime) BlockedTools() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	seen := map[string]struct{}{}
+	var out []string
+	for _, m := range r.manifests {
+		for _, name := range m.BlockedTools {
+			if _, dup := seen[name]; dup {
+				continue
+			}
+			seen[name] = struct{}{}
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// RenderVirtualTool produces the response body for a virtual tool call by
+// substituting {{.input.X}} and {{.session_id}} markers. The substitution
+// is deliberately tiny — virtual tools are for canned responses, not full
+// templating; plugins that need logic should bind a real handler instead.
+func RenderVirtualTool(vt VirtualTool, sessionID string, input map[string]any) string {
+	body := vt.Response
+	body = strings.ReplaceAll(body, "{{.session_id}}", sessionID)
+	for k, v := range input {
+		marker := "{{.input." + k + "}}"
+		body = strings.ReplaceAll(body, marker, fmt.Sprintf("%v", v))
+	}
+	return body
+}
+
+// loadState reads the per-session state file for a plugin. Missing files are
+// returned as empty maps so handlers see a consistent zero value.
+func (r *Runtime) loadState(m Manifest, sessionID string) (map[string]any, error) {
+	if r.stateRoot == "" || m.State == nil || m.State.Path == "" || sessionID == "" {
+		return map[string]any{}, nil
+	}
+	path := r.stateFilePath(m, sessionID)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]any{}, nil
+		}
+		return map[string]any{}, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return map[string]any{}, err
+	}
+	if out == nil {
+		out = map[string]any{}
+	}
+	return out, nil
+}
+
+func (r *Runtime) saveState(m Manifest, sessionID string, state map[string]any) error {
+	if r.stateRoot == "" || m.State == nil || m.State.Path == "" || sessionID == "" {
+		return nil
+	}
+	if state == nil {
+		state = map[string]any{}
+	}
+	path := r.stateFilePath(m, sessionID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func (r *Runtime) stateFilePath(m Manifest, sessionID string) string {
+	// Sanitise sessionID to a single path segment so callers cannot
+	// accidentally escape the state root via a "../" id.
+	safe := strings.ReplaceAll(sessionID, string(os.PathSeparator), "_")
+	safe = strings.ReplaceAll(safe, "..", "_")
+	return filepath.Join(r.stateRoot, m.Name, safe+".json")
+}

--- a/internal/plugins/manifest.go
+++ b/internal/plugins/manifest.go
@@ -1,0 +1,232 @@
+// Package plugins implements Conduit's plugin runtime — manifest discovery,
+// lifecycle hook dispatch, virtual tools, tool aliases/blocks, and
+// per-session state persistence. PRD §6.24.5.
+//
+// A plugin is a directory under one of the discovery roots whose top-level
+// `plugin.json` describes its name, version, lifecycle hooks, and any tool
+// transforms it wants to perform. The runtime stays intentionally
+// declarative: hooks are referenced by name and resolved by the host
+// (initially in-process Go callbacks; out-of-process executables are a
+// future extension that does not change the manifest shape).
+package plugins
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// LifecycleHook identifies one of the six manifest-declared lifecycle points.
+// They mirror the PRD §6.24.5 vocabulary exactly so plugin authors can copy
+// docs into manifests without translation.
+type LifecycleHook string
+
+const (
+	HookBeforePrompt   LifecycleHook = "beforePrompt"
+	HookAfterTurn      LifecycleHook = "afterTurn"
+	HookOnResume       LifecycleHook = "onResume"
+	HookBeforePersist  LifecycleHook = "beforePersist"
+	HookBeforeDelegate LifecycleHook = "beforeDelegate"
+	HookAfterDelegate  LifecycleHook = "afterDelegate"
+)
+
+// AllLifecycleHooks lists every supported hook in spec order. Used by the
+// dispatcher to validate manifests and by surfaces that enumerate hook points.
+var AllLifecycleHooks = []LifecycleHook{
+	HookBeforePrompt,
+	HookAfterTurn,
+	HookOnResume,
+	HookBeforePersist,
+	HookBeforeDelegate,
+	HookAfterDelegate,
+}
+
+// ToolAlias renames an existing host tool when exposed to the model. The
+// underlying Runner is unchanged; the alias affects discovery and prompt
+// surfaces only.
+type ToolAlias struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// VirtualTool is a plugin-defined tool that, when invoked, returns a static
+// templated response without dispatching to a Runner. The template body is
+// rendered with the call's input map via Go's text/template-style {{.field}}
+// substitution (implemented in dispatcher.go to keep this file declarative).
+type VirtualTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Schema      map[string]any `json:"schema,omitempty"`
+	// Response is the raw text returned to the model. Supports {{.input.foo}}
+	// and {{.session_id}} substitutions handled by RenderVirtualTool.
+	Response string `json:"response"`
+}
+
+// Manifest is the parsed `plugin.json`. It is intentionally JSON (not YAML)
+// to mirror the Codex/Claude plugin convention referenced in the PRD.
+type Manifest struct {
+	Name         string         `json:"name"`
+	Version      string         `json:"version"`
+	Description  string         `json:"description,omitempty"`
+	Hooks        []HookBinding  `json:"hooks,omitempty"`
+	ToolAliases  []ToolAlias    `json:"tool_aliases,omitempty"`
+	BlockedTools []string       `json:"blocked_tools,omitempty"`
+	VirtualTools []VirtualTool  `json:"virtual_tools,omitempty"`
+	State        *StateBinding  `json:"state,omitempty"`
+	Metadata     map[string]any `json:"metadata,omitempty"`
+	// Path is filled in by Discover; it is the absolute path to the plugin
+	// root directory so callers can resolve plugin-relative state files.
+	Path string `json:"-"`
+}
+
+// HookBinding is one entry in Manifest.Hooks. Handler is the in-process
+// callback name registered via Runtime.RegisterHandler. Manifests that
+// reference an unknown handler load successfully but the dispatcher reports
+// the gap so plugin authors see what's missing.
+type HookBinding struct {
+	Event   LifecycleHook `json:"event"`
+	Handler string        `json:"handler"`
+	// Matcher is an optional substring filter applied to the contextual
+	// payload (e.g. tool name for delegate events). Empty matches everything.
+	Matcher string `json:"matcher,omitempty"`
+}
+
+// StateBinding declares where session-scoped plugin state is persisted.
+// Path is interpreted relative to the plugin root and namespaced per session
+// id by the runtime. Format defaults to JSON.
+type StateBinding struct {
+	Path   string `json:"path"`
+	Format string `json:"format,omitempty"`
+}
+
+// Validate checks the manifest for shape errors that would crash the
+// dispatcher. It is intentionally strict so a typo in `event:` surfaces at
+// discovery time, not when the user is mid-conversation.
+func (m Manifest) Validate() error {
+	if strings.TrimSpace(m.Name) == "" {
+		return errors.New("plugin manifest: name is required")
+	}
+	if strings.TrimSpace(m.Version) == "" {
+		return errors.New("plugin manifest: version is required")
+	}
+	for i, h := range m.Hooks {
+		if !isKnownHook(h.Event) {
+			return fmt.Errorf("plugin manifest: hooks[%d]: unknown event %q", i, h.Event)
+		}
+		if strings.TrimSpace(h.Handler) == "" {
+			return fmt.Errorf("plugin manifest: hooks[%d]: handler is required", i)
+		}
+	}
+	seen := map[string]struct{}{}
+	for i, vt := range m.VirtualTools {
+		if strings.TrimSpace(vt.Name) == "" {
+			return fmt.Errorf("plugin manifest: virtual_tools[%d]: name is required", i)
+		}
+		if _, dup := seen[vt.Name]; dup {
+			return fmt.Errorf("plugin manifest: virtual_tools[%d]: duplicate name %q", i, vt.Name)
+		}
+		seen[vt.Name] = struct{}{}
+	}
+	for i, a := range m.ToolAliases {
+		if strings.TrimSpace(a.From) == "" || strings.TrimSpace(a.To) == "" {
+			return fmt.Errorf("plugin manifest: tool_aliases[%d]: both from and to are required", i)
+		}
+	}
+	return nil
+}
+
+func isKnownHook(e LifecycleHook) bool {
+	for _, k := range AllLifecycleHooks {
+		if k == e {
+			return true
+		}
+	}
+	return false
+}
+
+// LoadManifest parses a single plugin.json file from disk. The Path field on
+// the returned manifest is set to the directory containing the manifest.
+func LoadManifest(path string) (Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("plugins: read manifest %q: %w", path, err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return Manifest{}, fmt.Errorf("plugins: parse manifest %q: %w", path, err)
+	}
+	if err := m.Validate(); err != nil {
+		return Manifest{}, err
+	}
+	m.Path = filepath.Dir(path)
+	return m, nil
+}
+
+// Discover walks each root for `<root>/<plugin>/plugin.json` and returns the
+// loaded manifests in alphabetical order by name. Missing roots are normal on
+// first run and silently skipped. Per-plugin parse errors are returned in a
+// joined error so a single bad manifest does not hide the others.
+func Discover(roots []string) ([]Manifest, error) {
+	var manifests []Manifest
+	var errs []error
+	seen := map[string]struct{}{}
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("plugins: read root %q: %w", root, err))
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			manifestPath := filepath.Join(root, e.Name(), "plugin.json")
+			if _, statErr := os.Stat(manifestPath); statErr != nil {
+				continue
+			}
+			m, err := LoadManifest(manifestPath)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			// Earlier roots win on name collision (workspace before user, by
+			// caller convention). Skip with a recorded conflict error so the
+			// surface can show the loser path.
+			if _, dup := seen[m.Name]; dup {
+				errs = append(errs, fmt.Errorf("plugins: duplicate plugin name %q at %s (shadowed)", m.Name, m.Path))
+				continue
+			}
+			seen[m.Name] = struct{}{}
+			manifests = append(manifests, m)
+		}
+	}
+	sort.Slice(manifests, func(i, j int) bool { return manifests[i].Name < manifests[j].Name })
+	if len(errs) > 0 {
+		return manifests, errors.Join(errs...)
+	}
+	return manifests, nil
+}
+
+// DefaultRoots returns the canonical lookup hierarchy: workspace plugins
+// override user plugins. Either argument may be empty when the caller has no
+// workspace or no home directory.
+func DefaultRoots(home, workspace string) []string {
+	var roots []string
+	if workspace != "" {
+		roots = append(roots, filepath.Join(workspace, ".conduit", "plugins"))
+	}
+	if home != "" {
+		roots = append(roots, filepath.Join(home, ".conduit", "plugins"))
+	}
+	return roots
+}

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -1,0 +1,253 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeManifest(t *testing.T, dir, name string, m Manifest) {
+	t.Helper()
+	pdir := filepath.Join(dir, name)
+	if err := os.MkdirAll(pdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pdir, "plugin.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestManifestValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		m       Manifest
+		wantErr string
+	}{
+		{"missing name", Manifest{Version: "1"}, "name is required"},
+		{"missing version", Manifest{Name: "p"}, "version is required"},
+		{"bad hook", Manifest{Name: "p", Version: "1", Hooks: []HookBinding{{Event: "boom", Handler: "x"}}}, "unknown event"},
+		{"missing handler", Manifest{Name: "p", Version: "1", Hooks: []HookBinding{{Event: HookBeforePrompt}}}, "handler is required"},
+		{"dup virtual tool", Manifest{Name: "p", Version: "1", VirtualTools: []VirtualTool{{Name: "t", Response: "x"}, {Name: "t", Response: "y"}}}, "duplicate name"},
+		{"alias missing field", Manifest{Name: "p", Version: "1", ToolAliases: []ToolAlias{{From: "a"}}}, "from and to"},
+		{"ok", Manifest{Name: "p", Version: "1"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.m.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestDiscoverAndShadowing(t *testing.T) {
+	workspace := t.TempDir()
+	user := t.TempDir()
+	// Workspace has a "alpha" plugin; user also defines "alpha" (shadowed) and "beta".
+	writeManifest(t, workspace, "alpha", Manifest{Name: "alpha", Version: "1.0.0"})
+	writeManifest(t, user, "alpha", Manifest{Name: "alpha", Version: "0.9.0"})
+	writeManifest(t, user, "beta", Manifest{Name: "beta", Version: "1.0.0"})
+
+	manifests, err := Discover([]string{workspace, user})
+	if err == nil || !strings.Contains(err.Error(), "shadowed") {
+		t.Fatalf("expected shadow conflict, got %v", err)
+	}
+	if len(manifests) != 2 {
+		t.Fatalf("want 2 manifests, got %d", len(manifests))
+	}
+	if manifests[0].Name != "alpha" || manifests[0].Version != "1.0.0" {
+		t.Fatalf("workspace alpha should win, got %+v", manifests[0])
+	}
+	if manifests[1].Name != "beta" {
+		t.Fatalf("expected beta, got %+v", manifests[1])
+	}
+}
+
+func TestDiscoverMissingRoot(t *testing.T) {
+	manifests, err := Discover([]string{filepath.Join(t.TempDir(), "nope")})
+	if err != nil {
+		t.Fatalf("missing root should not error, got %v", err)
+	}
+	if len(manifests) != 0 {
+		t.Fatalf("want 0 manifests, got %d", len(manifests))
+	}
+}
+
+func TestDispatchOrderInjectAndBlock(t *testing.T) {
+	rt := NewRuntime("")
+	rt.Load([]Manifest{
+		{Name: "a", Version: "1", Hooks: []HookBinding{{Event: HookBeforePrompt, Handler: "inject"}}},
+		{Name: "b", Version: "1", Hooks: []HookBinding{{Event: HookBeforePrompt, Handler: "block"}}},
+		{Name: "c", Version: "1", Hooks: []HookBinding{{Event: HookBeforePrompt, Handler: "inject"}}},
+	})
+	rt.RegisterHandler("inject", func(_ context.Context, hc HookContext) (HookDecision, error) {
+		return HookDecision{Inject: "from-" + hc.SessionID}, nil
+	})
+	rt.RegisterHandler("block", func(_ context.Context, hc HookContext) (HookDecision, error) {
+		return HookDecision{Block: true, BlockReason: "no", Inject: "stop"}, nil
+	})
+
+	dec, err := rt.Dispatch(context.Background(), HookBeforePrompt, HookContext{SessionID: "s1"})
+	if err != nil {
+		t.Fatalf("dispatch err: %v", err)
+	}
+	if !dec.Block || dec.BlockReason != "no" {
+		t.Fatalf("expected block decision, got %+v", dec)
+	}
+	if !strings.Contains(dec.Inject, "from-s1") || !strings.Contains(dec.Inject, "stop") {
+		t.Fatalf("inject should accumulate before block, got %q", dec.Inject)
+	}
+}
+
+func TestDispatchUnknownHandlerSurfacesError(t *testing.T) {
+	rt := NewRuntime("")
+	rt.Load([]Manifest{{Name: "x", Version: "1", Hooks: []HookBinding{{Event: HookAfterTurn, Handler: "ghost"}}}})
+	_, err := rt.Dispatch(context.Background(), HookAfterTurn, HookContext{})
+	if err == nil || !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("expected unknown-handler error, got %v", err)
+	}
+}
+
+func TestDispatchMatcher(t *testing.T) {
+	rt := NewRuntime("")
+	rt.Load([]Manifest{{Name: "p", Version: "1", Hooks: []HookBinding{
+		{Event: HookBeforeDelegate, Handler: "h", Matcher: "bash"},
+	}}})
+	called := 0
+	rt.RegisterHandler("h", func(_ context.Context, hc HookContext) (HookDecision, error) {
+		called++
+		return HookDecision{}, nil
+	})
+	_, _ = rt.Dispatch(context.Background(), HookBeforeDelegate, HookContext{ToolName: "read_file"})
+	_, _ = rt.Dispatch(context.Background(), HookBeforeDelegate, HookContext{ToolName: "bash"})
+	if called != 1 {
+		t.Fatalf("matcher should fire once, got %d", called)
+	}
+}
+
+func TestRenderVirtualTool(t *testing.T) {
+	vt := VirtualTool{Name: "t", Response: "session={{.session_id}} who={{.input.who}}"}
+	out := RenderVirtualTool(vt, "abc", map[string]any{"who": "alice"})
+	if out != "session=abc who=alice" {
+		t.Fatalf("unexpected render: %q", out)
+	}
+}
+
+func TestStatePersistence(t *testing.T) {
+	root := t.TempDir()
+	rt := NewRuntime(root)
+	rt.Load([]Manifest{{
+		Name:    "p",
+		Version: "1",
+		Hooks:   []HookBinding{{Event: HookAfterTurn, Handler: "bump"}},
+		State:   &StateBinding{Path: "state.json"},
+	}})
+	rt.RegisterHandler("bump", func(_ context.Context, hc HookContext) (HookDecision, error) {
+		n, _ := hc.State["count"].(float64)
+		return HookDecision{StateUpdates: map[string]any{"count": n + 1}}, nil
+	})
+
+	for i := 0; i < 3; i++ {
+		if _, err := rt.Dispatch(context.Background(), HookAfterTurn, HookContext{SessionID: "s1"}); err != nil {
+			t.Fatalf("dispatch: %v", err)
+		}
+	}
+	data, err := os.ReadFile(filepath.Join(root, "p", "s1.json"))
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out["count"].(float64) != 3 {
+		t.Fatalf("want count=3, got %v", out["count"])
+	}
+}
+
+func TestStateSessionIsolation(t *testing.T) {
+	root := t.TempDir()
+	rt := NewRuntime(root)
+	rt.Load([]Manifest{{
+		Name: "p", Version: "1",
+		Hooks: []HookBinding{{Event: HookAfterTurn, Handler: "set"}},
+		State: &StateBinding{Path: "s.json"},
+	}})
+	rt.RegisterHandler("set", func(_ context.Context, hc HookContext) (HookDecision, error) {
+		return HookDecision{StateUpdates: map[string]any{"id": hc.SessionID}}, nil
+	})
+	_, _ = rt.Dispatch(context.Background(), HookAfterTurn, HookContext{SessionID: "alpha"})
+	_, _ = rt.Dispatch(context.Background(), HookAfterTurn, HookContext{SessionID: "beta"})
+	a, _ := os.ReadFile(filepath.Join(root, "p", "alpha.json"))
+	b, _ := os.ReadFile(filepath.Join(root, "p", "beta.json"))
+	if !strings.Contains(string(a), `"alpha"`) || !strings.Contains(string(b), `"beta"`) {
+		t.Fatalf("state not isolated: a=%s b=%s", a, b)
+	}
+}
+
+func TestStateRejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	rt := NewRuntime(root)
+	m := Manifest{Name: "p", State: &StateBinding{Path: "s.json"}}
+	got := rt.stateFilePath(m, "../escape")
+	if strings.Contains(got, "..") {
+		t.Fatalf("traversal not sanitised: %s", got)
+	}
+}
+
+func TestVirtualToolsAndAliasesAggregation(t *testing.T) {
+	rt := NewRuntime("")
+	rt.Load([]Manifest{
+		{Name: "a", Version: "1",
+			VirtualTools: []VirtualTool{{Name: "z", Response: "z"}, {Name: "a", Response: "a"}},
+			ToolAliases:  []ToolAlias{{From: "bash", To: "shell"}},
+			BlockedTools: []string{"rm"},
+		},
+		{Name: "b", Version: "1",
+			BlockedTools: []string{"rm", "curl"},
+		},
+	})
+	vts := rt.VirtualTools()
+	if len(vts) != 2 || vts[0].Name != "a" || vts[1].Name != "z" {
+		t.Fatalf("virtual tools not sorted: %+v", vts)
+	}
+	if blocked := rt.BlockedTools(); len(blocked) != 2 || blocked[0] != "curl" || blocked[1] != "rm" {
+		t.Fatalf("blocked tools wrong: %+v", blocked)
+	}
+	if a := rt.ToolAliases(); len(a) != 1 || a[0].From != "bash" {
+		t.Fatalf("aliases: %+v", a)
+	}
+}
+
+func TestLoadManifestRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "p", Manifest{
+		Name: "p", Version: "1",
+		Hooks:        []HookBinding{{Event: HookBeforePrompt, Handler: "h"}},
+		VirtualTools: []VirtualTool{{Name: "echo", Response: "hi"}},
+	})
+	m, err := LoadManifest(filepath.Join(dir, "p", "plugin.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Path != filepath.Join(dir, "p") {
+		t.Fatalf("path not set: %s", m.Path)
+	}
+	if len(m.Hooks) != 1 || m.Hooks[0].Event != HookBeforePrompt {
+		t.Fatalf("hooks lost: %+v", m.Hooks)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/plugins` implementing PRD §6.24.5: manifest-based discovery, six lifecycle hooks, virtual tools with templated responses, tool aliases/blocks, and per-session plugin state persistence.
- Discovery walks workspace-then-user roots with shadowing; manifest validation is strict so typos surface at load time.
- Dispatcher fires handlers in manifest order, accumulates injects, short-circuits on Block, and isolates handler errors so one broken plugin can't disable the rest.
- State files are namespaced per-plugin per-session and traversal-sanitised.

## Test plan
- [x] `go test ./internal/plugins/...` covers validation, discovery + shadowing, dispatch ordering, matchers, virtual-tool rendering, state persistence, session isolation, and traversal rejection.
- [x] Full repo `make test` and `make lint` pass.

Closes #62