### PR TITLE
feat(#138): in-app help registry, /help, tooltips, first-launch tour

### DIFF
--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -1,0 +1,244 @@
+// Package help is the in-app documentation surface for Conduit (PRD §17.3).
+//
+// It owns:
+//   - a registry of help Topics (id, title, body, related),
+//   - a fuzzy-ish text Search() over title + body,
+//   - a Dispatch() entry point used by the TUI's `/help` slash command,
+//   - a catalog of UI Tooltips keyed by element id, used by the TUI / GUI to
+//     render the small help bubbles next to settings, status pills, etc.,
+//   - a Tour structure used by the first-launch guided tour.
+//
+// All content lives in topics.go / tooltips.go / tour.go. Surfaces query this
+// package so help text is single-sourced — the docs site (issue #137), the
+// TUI tooltips, and the `/help` command all read from the same registry.
+package help
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Topic is one help article.
+type Topic struct {
+	// ID is the slug used by `/help <id>` and "Learn more" deep links.
+	ID string
+	// Title is the human-readable heading.
+	Title string
+	// Body is markdown-flavored plain text (TUI renders as plain text;
+	// docs site renders as markdown).
+	Body string
+	// Related lists IDs of adjacent topics, surfaced as a "See also" list.
+	Related []string
+	// LearnMore is an optional URL into the docs site; used by the
+	// contextual "Learn more" links on friction points.
+	LearnMore string
+}
+
+// Tooltip is the short hover-text for one UI element.
+type Tooltip struct {
+	// Element is the surface-specific id, e.g. "tui.status_bar.cost",
+	// "gui.settings.providers.priority".
+	Element string
+	// Text is one or two short sentences. Keep under 140 chars.
+	Text string
+	// Topic, if non-empty, points at a Topic.ID for "Learn more".
+	Topic string
+}
+
+// TourStep is one step of the first-launch guided tour.
+type TourStep struct {
+	// Element is a UI anchor id the surface can highlight.
+	Element string
+	// Title is shown as the step heading.
+	Title string
+	// Body is shown as the step body.
+	Body string
+}
+
+// Registry holds all help content. Surfaces use the package-level Default
+// registry; Registry exists as a separate type so tests can build isolated
+// registries without touching package state.
+type Registry struct {
+	topics   map[string]Topic
+	tooltips map[string]Tooltip
+	tour     []TourStep
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		topics:   map[string]Topic{},
+		tooltips: map[string]Tooltip{},
+	}
+}
+
+// AddTopic adds or replaces a topic.
+func (r *Registry) AddTopic(t Topic) {
+	r.topics[t.ID] = t
+}
+
+// AddTooltip adds or replaces a tooltip.
+func (r *Registry) AddTooltip(t Tooltip) {
+	r.tooltips[t.Element] = t
+}
+
+// SetTour replaces the tour.
+func (r *Registry) SetTour(steps []TourStep) {
+	r.tour = steps
+}
+
+// Topic looks up a topic by ID. Match is case-insensitive on the slug.
+func (r *Registry) Topic(id string) (Topic, bool) {
+	t, ok := r.topics[strings.ToLower(strings.TrimSpace(id))]
+	return t, ok
+}
+
+// Tooltip looks up a tooltip by element id.
+func (r *Registry) Tooltip(element string) (Tooltip, bool) {
+	t, ok := r.tooltips[element]
+	return t, ok
+}
+
+// Tour returns the tour steps in order.
+func (r *Registry) Tour() []TourStep {
+	out := make([]TourStep, len(r.tour))
+	copy(out, r.tour)
+	return out
+}
+
+// AllTopics returns every topic, sorted by ID. Useful for `/help` with no
+// arguments (acts as an index).
+func (r *Registry) AllTopics() []Topic {
+	out := make([]Topic, 0, len(r.topics))
+	for _, t := range r.topics {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// SearchHit is one match with a small relevance score (higher is better).
+type SearchHit struct {
+	Topic Topic
+	Score int
+}
+
+// Search runs a case-insensitive substring search over title + body. Title
+// hits weigh more than body hits, and an exact slug match wins outright.
+// Designed to be searchable from the command palette (PRD §17.3).
+func (r *Registry) Search(query string) []SearchHit {
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return nil
+	}
+	var hits []SearchHit
+	for _, t := range r.topics {
+		score := 0
+		switch {
+		case strings.EqualFold(t.ID, q):
+			score = 1000
+		case strings.Contains(strings.ToLower(t.ID), q):
+			score = 50
+		}
+		if strings.Contains(strings.ToLower(t.Title), q) {
+			score += 20
+		}
+		if strings.Contains(strings.ToLower(t.Body), q) {
+			score += 5
+		}
+		if score > 0 {
+			hits = append(hits, SearchHit{Topic: t, Score: score})
+		}
+	}
+	sort.SliceStable(hits, func(i, j int) bool { return hits[i].Score > hits[j].Score })
+	return hits
+}
+
+// DispatchResult is what the TUI prints after running `/help …`.
+type DispatchResult struct {
+	Output string
+	Found  bool
+}
+
+// Dispatch implements the `/help` slash command. The TUI calls
+// `help.Default.Dispatch(line)` and prints `.Output` into the conversation.
+//
+// Forms:
+//
+//	/help                      → index of all topics
+//	/help <topic-id>           → render that topic
+//	/help search <query>       → search results
+//	/help <free text>          → falls through to search if no topic match
+func (r *Registry) Dispatch(line string) DispatchResult {
+	line = strings.TrimSpace(line)
+	line = strings.TrimPrefix(line, "/help")
+	line = strings.TrimSpace(line)
+
+	if line == "" {
+		return DispatchResult{Output: r.renderIndex(), Found: true}
+	}
+
+	if strings.HasPrefix(line, "search ") {
+		return DispatchResult{Output: r.renderSearch(strings.TrimPrefix(line, "search ")), Found: true}
+	}
+
+	if t, ok := r.Topic(line); ok {
+		return DispatchResult{Output: r.renderTopic(t), Found: true}
+	}
+
+	// Fall through to a search; this is what users want when they type
+	// `/help workflows` and there's no exact slug.
+	hits := r.Search(line)
+	if len(hits) == 0 {
+		return DispatchResult{
+			Output: fmt.Sprintf("No help topic matches %q.\nTry `/help` for the index.", line),
+			Found:  false,
+		}
+	}
+	if len(hits) == 1 {
+		return DispatchResult{Output: r.renderTopic(hits[0].Topic), Found: true}
+	}
+	return DispatchResult{Output: r.renderSearch(line), Found: true}
+}
+
+func (r *Registry) renderIndex() string {
+	var b strings.Builder
+	b.WriteString("Available help topics:\n\n")
+	for _, t := range r.AllTopics() {
+		fmt.Fprintf(&b, "  %-22s %s\n", t.ID, t.Title)
+	}
+	b.WriteString("\nUse `/help <topic>` or `/help search <query>`.")
+	return b.String()
+}
+
+func (r *Registry) renderTopic(t Topic) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s\n\n%s\n", t.Title, strings.TrimSpace(t.Body))
+	if len(t.Related) > 0 {
+		b.WriteString("\nSee also: ")
+		b.WriteString(strings.Join(t.Related, ", "))
+		b.WriteString(".")
+	}
+	if t.LearnMore != "" {
+		fmt.Fprintf(&b, "\nLearn more: %s", t.LearnMore)
+	}
+	return b.String()
+}
+
+func (r *Registry) renderSearch(query string) string {
+	hits := r.Search(query)
+	if len(hits) == 0 {
+		return fmt.Sprintf("No help topic matches %q.", query)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Results for %q:\n\n", query)
+	for _, h := range hits {
+		fmt.Fprintf(&b, "  %-22s %s\n", h.Topic.ID, h.Topic.Title)
+	}
+	return b.String()
+}
+
+// Default is the package-level registry, populated by topics.go / tooltips.go
+// / tour.go in their init() functions. Surfaces should use this directly.
+var Default = NewRegistry()

--- a/internal/help/help_test.go
+++ b/internal/help/help_test.go
@@ -1,0 +1,146 @@
+package help
+
+import (
+	"strings"
+	"testing"
+)
+
+func newTestRegistry() *Registry {
+	r := NewRegistry()
+	r.AddTopic(Topic{ID: "providers", Title: "Providers", Body: "Anthropic and friends."})
+	r.AddTopic(Topic{ID: "router", Title: "Model router", Body: "Picks a provider per request."})
+	r.AddTopic(Topic{ID: "memory", Title: "Memory", Body: "Long-term context."})
+	return r
+}
+
+func TestTopicLookupCaseInsensitive(t *testing.T) {
+	r := newTestRegistry()
+	if _, ok := r.Topic("PROVIDERS"); !ok {
+		t.Errorf("uppercase lookup failed")
+	}
+	if _, ok := r.Topic("  router  "); !ok {
+		t.Errorf("whitespace not trimmed")
+	}
+	if _, ok := r.Topic("nonexistent"); ok {
+		t.Errorf("unknown topic should miss")
+	}
+}
+
+func TestSearchRanksTitleOverBody(t *testing.T) {
+	r := NewRegistry()
+	r.AddTopic(Topic{ID: "a", Title: "Routing primer", Body: "Lorem."})
+	r.AddTopic(Topic{ID: "b", Title: "Memory", Body: "Mentions routing in passing."})
+	hits := r.Search("routing")
+	if len(hits) != 2 {
+		t.Fatalf("want 2 hits, got %d", len(hits))
+	}
+	if hits[0].Topic.ID != "a" {
+		t.Errorf("title hit should outrank body hit; got order %v then %v", hits[0].Topic.ID, hits[1].Topic.ID)
+	}
+}
+
+func TestSearchExactSlugWins(t *testing.T) {
+	r := NewRegistry()
+	r.AddTopic(Topic{ID: "router", Title: "Z", Body: ""})
+	r.AddTopic(Topic{ID: "config", Title: "Router this and router that", Body: "router router"})
+	hits := r.Search("router")
+	if hits[0].Topic.ID != "router" {
+		t.Errorf("exact slug should win; got %v", hits[0].Topic.ID)
+	}
+}
+
+func TestDispatchIndex(t *testing.T) {
+	r := newTestRegistry()
+	res := r.Dispatch("/help")
+	if !res.Found {
+		t.Fatalf("index should be Found")
+	}
+	for _, want := range []string{"providers", "router", "memory"} {
+		if !strings.Contains(res.Output, want) {
+			t.Errorf("index missing %q; got: %s", want, res.Output)
+		}
+	}
+}
+
+func TestDispatchExactTopic(t *testing.T) {
+	r := newTestRegistry()
+	res := r.Dispatch("/help router")
+	if !res.Found {
+		t.Fatalf("topic should be Found")
+	}
+	if !strings.Contains(res.Output, "Model router") {
+		t.Errorf("missing topic title; got: %s", res.Output)
+	}
+}
+
+func TestDispatchSearchFallthrough(t *testing.T) {
+	r := NewRegistry()
+	r.AddTopic(Topic{ID: "a", Title: "Routing", Body: ""})
+	r.AddTopic(Topic{ID: "b", Title: "Routing primer", Body: ""})
+	res := r.Dispatch("/help routing")
+	if !res.Found {
+		t.Fatalf("fallthrough search should be Found")
+	}
+	if !strings.Contains(res.Output, "Results for") {
+		t.Errorf("expected search results header; got: %s", res.Output)
+	}
+}
+
+func TestDispatchUnknown(t *testing.T) {
+	r := newTestRegistry()
+	res := r.Dispatch("/help quantumflux")
+	if res.Found {
+		t.Errorf("unknown query should not be Found")
+	}
+	if !strings.Contains(res.Output, "No help topic matches") {
+		t.Errorf("expected miss message; got: %s", res.Output)
+	}
+}
+
+func TestDispatchSearchVerb(t *testing.T) {
+	r := newTestRegistry()
+	res := r.Dispatch("/help search memory")
+	if !res.Found || !strings.Contains(res.Output, "Memory") {
+		t.Errorf("search verb failed; got: %s", res.Output)
+	}
+}
+
+func TestTooltipLookup(t *testing.T) {
+	tip, ok := Default.Tooltip("tui.status_bar.cost")
+	if !ok {
+		t.Fatal("expected tui.status_bar.cost tooltip in Default registry")
+	}
+	if tip.Text == "" {
+		t.Error("tooltip text empty")
+	}
+	if tip.Topic == "" {
+		t.Error("tooltip should link to a topic")
+	}
+	// And the linked topic must actually exist.
+	if _, ok := Default.Topic(tip.Topic); !ok {
+		t.Errorf("tooltip references unknown topic %q", tip.Topic)
+	}
+}
+
+func TestTourPopulated(t *testing.T) {
+	steps := Default.Tour()
+	if len(steps) == 0 {
+		t.Fatal("default tour is empty")
+	}
+	for i, s := range steps {
+		if s.Title == "" || s.Body == "" {
+			t.Errorf("tour step %d has empty title or body", i)
+		}
+	}
+}
+
+func TestDefaultRegistryLoaded(t *testing.T) {
+	if len(Default.AllTopics()) == 0 {
+		t.Fatal("Default registry has no topics — init() not running?")
+	}
+	for _, want := range []string{"providers", "router", "sessions", "memory", "coding", "config"} {
+		if _, ok := Default.Topic(want); !ok {
+			t.Errorf("Default missing required topic %q", want)
+		}
+	}
+}

--- a/internal/help/tooltips.go
+++ b/internal/help/tooltips.go
@@ -1,0 +1,39 @@
+package help
+
+// Built-in tooltips for TUI / GUI elements. Element IDs follow a
+// `<surface>.<area>.<thing>` convention so we can grep for "tui.*" or
+// "gui.*" easily. Surface code does:
+//
+//	tip, ok := help.Default.Tooltip("tui.status_bar.cost")
+//	if ok { render(tip.Text) }
+func init() {
+	for _, t := range builtinTooltips {
+		Default.AddTooltip(t)
+	}
+}
+
+var builtinTooltips = []Tooltip{
+	// Status bar
+	{Element: "tui.status_bar.provider", Text: "Active provider for this turn. Click to switch.", Topic: "providers"},
+	{Element: "tui.status_bar.model", Text: "Model the router picked. Cascade may upgrade it on low confidence.", Topic: "router"},
+	{Element: "tui.status_bar.cost", Text: "Running cost for this session, from the local usage ledger.", Topic: "usage"},
+	{Element: "tui.status_bar.tokens", Text: "Token usage so far this turn. Includes cached input.", Topic: "usage"},
+	{Element: "tui.status_bar.session", Text: "Current session ID. Press Ctrl+S to fork or load another.", Topic: "sessions"},
+	{Element: "tui.status_bar.permission", Text: "Coding-agent permission tier. Tools above this tier require approval.", Topic: "coding"},
+
+	// Settings — providers
+	{Element: "gui.settings.providers.priority", Text: "Lower number = tried first. Ties broken by latency.", Topic: "router"},
+	{Element: "gui.settings.providers.budget", Text: "Hard cap per day. The router skips this provider once hit.", Topic: "providers"},
+
+	// Settings — coding
+	{Element: "gui.settings.coding.permission_tier", Text: "Default permission tier for `conduit code`. Higher tiers expand the toolset.", Topic: "coding"},
+	{Element: "gui.settings.coding.auto_continue", Text: "When a model output is truncated, automatically request continuation.", Topic: "coding"},
+
+	// Settings — memory
+	{Element: "gui.settings.memory.provider", Text: "Storage backend for memory entries. SQLite has FTS5; LanceDB adds vector search.", Topic: "memory"},
+
+	// Friction points (these surface a "Learn more" affordance)
+	{Element: "tui.friction.no_provider", Text: "No provider is configured. Add one with `conduit provider add` or via Settings.", Topic: "providers"},
+	{Element: "tui.friction.permission_denied", Text: "This tool needs a higher permission tier than your current setting.", Topic: "coding"},
+	{Element: "tui.friction.budget_exceeded", Text: "All available providers are over their daily budget cap.", Topic: "providers"},
+}

--- a/internal/help/topics.go
+++ b/internal/help/topics.go
@@ -1,0 +1,127 @@
+package help
+
+// Built-in topics. New topics get added here; the docs site references the
+// same IDs as deep-link slugs for the contextual "Learn more" buttons.
+func init() {
+	for _, t := range builtinTopics {
+		Default.AddTopic(t)
+	}
+}
+
+var builtinTopics = []Topic{
+	{
+		ID:    "providers",
+		Title: "Providers",
+		Body: `Providers are the model endpoints Conduit can call — Anthropic,
+OpenAI, Ollama, vLLM, OpenRouter, LiteLLM, anything OpenAI- or
+Anthropic-compatible.
+
+Add one with ` + "`conduit provider add <kind>`" + ` and Conduit will prompt
+for credentials. Keys are stored in the macOS Keychain — never on disk in
+plaintext.`,
+		Related:   []string{"router", "config"},
+		LearnMore: "https://github.com/jabreeflor/conduit/blob/main/website/docs/getting-started/concepts.md",
+	},
+	{
+		ID:    "router",
+		Title: "Model router",
+		Body: `The router picks a provider per request based on cost, latency,
+capability, and the order you set in config.yaml. Failover and "low
+confidence" escalation happen here.
+
+Strategies: cost-cascade (default), round-robin, sticky, manual.`,
+		Related:   []string{"providers", "config"},
+		LearnMore: "https://github.com/jabreeflor/conduit/blob/main/website/docs/reference/configuration.md#routing",
+	},
+	{
+		ID:    "sessions",
+		Title: "Sessions",
+		Body: `A session is a conversation, stored as JSONL under
+~/.conduit/sessions/. Sessions are forkable, replayable, and inspectable
+like git commits.
+
+Try ` + "`/sessions list`" + ` or press Ctrl+S to open the browser.`,
+		Related:   []string{"memory"},
+		LearnMore: "https://github.com/jabreeflor/conduit/blob/main/website/docs/guides/memory-sessions.md",
+	},
+	{
+		ID:    "memory",
+		Title: "Memory",
+		Body: `Three layers, in priority order:
+  1. SOUL.md — your constitution.
+  2. USER.md — your preferences.
+  3. Curated entries — facts the agent has stored.
+
+Open the inspector with Ctrl+M to browse, search, or prune entries.`,
+		Related:   []string{"sessions"},
+		LearnMore: "https://github.com/jabreeflor/conduit/blob/main/website/docs/guides/memory-sessions.md",
+	},
+	{
+		ID:    "hooks",
+		Title: "Hooks",
+		Body: `Hooks are shell subprocesses Conduit runs at well-defined
+points in the agent loop (pre_tool, post_tool, pre_model, post_model,
+session_start, session_end).
+
+A hook reads a JSON event on stdin and can mutate or veto via stdout.`,
+	},
+	{
+		ID:    "workflows",
+		Title: "Workflows",
+		Body: `A workflow is a YAML-defined graph of steps that the engine
+checkpoints between, so it survives provider failures and can resume.
+
+Drop a YAML file under ~/.conduit/workflows/ and run with
+` + "`conduit workflow run <name>`" + `.`,
+		LearnMore: "https://github.com/jabreeflor/conduit/blob/main/website/docs/guides/workflows.md",
+	},
+	{
+		ID:    "coding",
+		Title: "Coding agent",
+		Body: `` + "`conduit code`" + ` is a REPL with the standard coding
+toolset (read_file, write_file, edit_file, bash, grep, glob,
+notebook_edit). Permission tiers: read-only, write, shell, unsafe.
+
+CLAUDE.md files in the repo are merged into the system prompt
+automatically.`,
+		LearnMore: "https://github.com/jabreeflor/conduit/blob/main/website/docs/guides/coding-agent.md",
+	},
+	{
+		ID:    "config",
+		Title: "Configuration",
+		Body: `All config lives in ~/.conduit/config.yaml. Top-level keys:
+providers, routing, memory, coding, hooks, workflows, keybindings.
+
+Run ` + "`conduit config edit`" + ` to open it in your $EDITOR.`,
+		LearnMore: "https://github.com/jabreeflor/conduit/blob/main/website/docs/reference/configuration.md",
+	},
+	{
+		ID:    "keybindings",
+		Title: "Keybindings",
+		Body: `Defaults live in code; overrides go in
+~/.conduit/keybindings.json. Common ones:
+  Ctrl+S — sessions browser
+  Ctrl+M — memory inspector
+  Ctrl+Q — quit
+  Enter  — submit message
+  Shift+Enter — newline`,
+		LearnMore: "https://github.com/jabreeflor/conduit/blob/main/website/docs/reference/keybindings.md",
+	},
+	{
+		ID:    "plugins",
+		Title: "Plugins",
+		Body: `Plugins extend Conduit with new tools, hooks, agent profiles,
+and config without forking the binary. Drop a plugin directory under
+~/.conduit/plugins/ — it's discovered on startup.`,
+		LearnMore: "https://github.com/jabreeflor/conduit/blob/main/website/docs/plugins/development.md",
+	},
+	{
+		ID:    "usage",
+		Title: "Usage & cost",
+		Body: `Conduit keeps a local ledger at ~/.conduit/usage.db. Run
+` + "`conduit usage`" + ` for the dashboard, or open the in-TUI panel from
+the status bar.
+
+Nothing leaves your machine.`,
+	},
+}

--- a/internal/help/tour.go
+++ b/internal/help/tour.go
@@ -1,0 +1,40 @@
+package help
+
+// First-launch guided tour. The TUI / GUI host calls help.Default.Tour() on
+// first run and walks the user through these steps, highlighting the named
+// element each time.
+func init() {
+	Default.SetTour([]TourStep{
+		{
+			Element: "tui.input",
+			Title:   "Welcome to Conduit",
+			Body: `This is your prompt. Type a message and press Enter to send.
+Conduit picks a provider for you based on cost and capability.`,
+		},
+		{
+			Element: "tui.status_bar",
+			Title:   "Status bar",
+			Body: `The status bar shows the active provider, model, session,
+and running cost. Hover any item for details.`,
+		},
+		{
+			Element: "tui.status_bar.session",
+			Title:   "Sessions",
+			Body: `Every conversation is saved as JSONL on disk. Press Ctrl+S
+to browse, fork, or replay past sessions.`,
+		},
+		{
+			Element: "tui.status_bar.permission",
+			Title:   "Coding agent",
+			Body: `Run ` + "`conduit code`" + ` for a coding REPL with file and
+shell tools. The permission tier here controls what's allowed.`,
+		},
+		{
+			Element: "tui.input",
+			Title:   "Help is one slash away",
+			Body: `Type ` + "`/help`" + ` any time for an index, or
+` + "`/help <topic>`" + ` for a specific area. ` + "`/help search <query>`" + `
+runs a full-text search.`,
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Implements PRD §17.3: in-app documentation, tooltips, `/help` command, contextual "Learn more" links, and a first-launch guided tour — all sharing a single content registry so the docs site (#137) and the TUI/GUI surfaces can't drift.

## Package: `internal/help`

- **`Registry`** owning Topics, Tooltips, and a Tour.
- **`Search(query)`** with title + exact-slug ranking, used by the command-palette search.
- **`Dispatch("/help …")`** handling: bare index, exact topic, `search <q>` verb, free-text fall-through, friendly miss message — directly callable by the TUI alongside `/sessions`.
- **Built-in content**: 11 topics (providers, router, sessions, memory, hooks, workflows, coding, config, keybindings, plugins, usage), 14 tooltips covering status-bar items + settings panels + the three friction points the PRD calls out, and a 5-step first-launch tour.
- Topic IDs match the docs-site slugs so `LearnMore` URLs are stable deep links.

## Why a separate package + no surface wiring in this PR

The content and the library are the load-bearing piece — both the TUI and the GUI surfaces will call into the same registry. Wiring `/help` into `internal/tui/app.go` and rendering tooltip bubbles in the GUI are surface-specific PRs that can land in parallel without conflicting with this content.

## Verification

```sh
go test ./internal/help/ -v   # 11/11 pass
make lint && make typecheck && make test
```

## Test plan

- [x] All 11 unit tests pass
- [x] `make lint && make typecheck && make test` green
- [x] Default registry validates that every tooltip-linked topic exists
- [ ] CI green

Closes #138