### PR TITLE
feat(#63): nested agent delegation

### DIFF
--- a/internal/coding/delegate.go
+++ b/internal/coding/delegate.go
@@ -1,0 +1,266 @@
+package coding
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DelegateTask describes one nested-agent invocation in a delegation
+// batch. Tasks form a DAG: each task may DependsOn the IDs of others in
+// the same batch and the manager runs them in topological waves —
+// independent tasks in a wave run in parallel; the next wave waits for
+// all current-wave tasks to finish.
+type DelegateTask struct {
+	ID        string   // unique within the batch
+	Agent     string   // name of the agent profile to run (informational)
+	Prompt    string   // the prompt the child agent receives
+	DependsOn []string // task IDs in the same batch that must finish first
+}
+
+// DelegateResult is the outcome of one nested task. The Lineage field
+// records the chain of (parent_session_id, parent_task_id) so audit
+// surfaces can reconstruct who delegated what.
+type DelegateResult struct {
+	TaskID     string
+	Agent      string
+	SessionID  string
+	Output     string
+	Error      string
+	StartedAt  time.Time
+	FinishedAt time.Time
+	Lineage    []DelegateLineageStep
+}
+
+// DelegateLineageStep is one ancestor entry in a child session's lineage.
+type DelegateLineageStep struct {
+	ParentSessionID string
+	ParentTaskID    string
+}
+
+// DelegateRunner is the contract the AgentManager uses to actually run
+// a child task. Production wiring injects a Streamer-backed runner;
+// tests inject a fake. Keeping this small means the manager itself is
+// purely orchestration logic.
+type DelegateRunner interface {
+	Run(ctx context.Context, task DelegateTask, lineage []DelegateLineageStep) (DelegateResult, error)
+}
+
+// AgentManager runs delegated tasks with dependency-aware topological
+// batching, lineage tracking, and per-batch summaries.
+type AgentManager struct {
+	Runner DelegateRunner
+
+	mu       sync.Mutex
+	children map[string][]DelegateLineageStep // session_id -> lineage
+}
+
+// NewAgentManager wires a manager around a runner.
+func NewAgentManager(runner DelegateRunner) *AgentManager {
+	return &AgentManager{Runner: runner, children: map[string][]DelegateLineageStep{}}
+}
+
+// DelegateBatch runs tasks in dependency order. Independent tasks run
+// in parallel; a task fails the batch only if its dependents cannot
+// proceed — failed tasks still appear in the returned result list with
+// their Error set, so callers can surface partial progress.
+func (m *AgentManager) DelegateBatch(ctx context.Context, parentSessionID string, tasks []DelegateTask) ([]DelegateResult, error) {
+	if m.Runner == nil {
+		return nil, errors.New("delegate: runner required")
+	}
+	waves, err := topoWaves(tasks)
+	if err != nil {
+		return nil, err
+	}
+
+	resultsByID := make(map[string]DelegateResult, len(tasks))
+	skipped := map[string]bool{}
+
+	for _, wave := range waves {
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		for _, task := range wave {
+			task := task
+
+			// Skip if any dependency failed or was skipped.
+			skip := false
+			for _, dep := range task.DependsOn {
+				if r, ok := resultsByID[dep]; ok && r.Error != "" {
+					skip = true
+					break
+				}
+				if skipped[dep] {
+					skip = true
+					break
+				}
+			}
+			if skip {
+				skipped[task.ID] = true
+				resultsByID[task.ID] = DelegateResult{
+					TaskID: task.ID, Agent: task.Agent,
+					Error:      "skipped: upstream dependency failed",
+					StartedAt:  time.Now().UTC(),
+					FinishedAt: time.Now().UTC(),
+				}
+				continue
+			}
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				lineage := []DelegateLineageStep{{ParentSessionID: parentSessionID, ParentTaskID: task.ID}}
+				started := time.Now().UTC()
+				res, err := m.Runner.Run(ctx, task, lineage)
+				if err != nil {
+					res.Error = err.Error()
+				}
+				if res.TaskID == "" {
+					res.TaskID = task.ID
+				}
+				if res.Agent == "" {
+					res.Agent = task.Agent
+				}
+				if res.StartedAt.IsZero() {
+					res.StartedAt = started
+				}
+				if res.FinishedAt.IsZero() {
+					res.FinishedAt = time.Now().UTC()
+				}
+				if len(res.Lineage) == 0 {
+					res.Lineage = lineage
+				}
+				if res.SessionID != "" {
+					m.mu.Lock()
+					m.children[res.SessionID] = res.Lineage
+					m.mu.Unlock()
+				}
+				mu.Lock()
+				resultsByID[task.ID] = res
+				mu.Unlock()
+			}()
+		}
+		wg.Wait()
+	}
+
+	out := make([]DelegateResult, 0, len(tasks))
+	for _, t := range tasks {
+		if r, ok := resultsByID[t.ID]; ok {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+// SummarizeBatch returns a stable, human-readable summary of one batch
+// run: counts by status, then per-task one-liners. Used by the parent
+// agent to fold the nested results back into its own context.
+func SummarizeBatch(results []DelegateResult) string {
+	if len(results) == 0 {
+		return "(no delegated tasks)"
+	}
+	var ok, failed, skipped int
+	for _, r := range results {
+		switch {
+		case r.Error == "":
+			ok++
+		case strings.HasPrefix(r.Error, "skipped"):
+			skipped++
+		default:
+			failed++
+		}
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "delegated %d task(s): ok=%d failed=%d skipped=%d\n", len(results), ok, failed, skipped)
+	for _, r := range results {
+		status := "ok"
+		switch {
+		case r.Error == "":
+			// keep
+		case strings.HasPrefix(r.Error, "skipped"):
+			status = "skip"
+		default:
+			status = "fail"
+		}
+		first := r.Output
+		if i := strings.IndexByte(first, '\n'); i >= 0 {
+			first = first[:i]
+		}
+		if len(first) > 120 {
+			first = first[:120]
+		}
+		fmt.Fprintf(&b, "  [%s] %s (%s): %s\n", status, r.TaskID, r.Agent, first)
+		if r.Error != "" {
+			fmt.Fprintf(&b, "        error: %s\n", r.Error)
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// LineageOf returns the recorded lineage chain for a child session, or
+// nil if the manager has never seen that id.
+func (m *AgentManager) LineageOf(sessionID string) []DelegateLineageStep {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if got, ok := m.children[sessionID]; ok {
+		out := make([]DelegateLineageStep, len(got))
+		copy(out, got)
+		return out
+	}
+	return nil
+}
+
+// topoWaves groups tasks into topologically ordered waves so the
+// manager can run independent tasks in parallel. Returns an error if
+// the task list contains a cycle or a missing dependency reference.
+func topoWaves(tasks []DelegateTask) ([][]DelegateTask, error) {
+	byID := map[string]DelegateTask{}
+	indeg := map[string]int{}
+	dependents := map[string][]string{}
+	for _, t := range tasks {
+		if _, dup := byID[t.ID]; dup {
+			return nil, fmt.Errorf("delegate: duplicate task id %q", t.ID)
+		}
+		byID[t.ID] = t
+		indeg[t.ID] = 0
+	}
+	for _, t := range tasks {
+		for _, dep := range t.DependsOn {
+			if _, ok := byID[dep]; !ok {
+				return nil, fmt.Errorf("delegate: task %q depends on unknown id %q", t.ID, dep)
+			}
+			indeg[t.ID]++
+			dependents[dep] = append(dependents[dep], t.ID)
+		}
+	}
+
+	var waves [][]DelegateTask
+	remaining := len(tasks)
+	for remaining > 0 {
+		var wave []DelegateTask
+		var ids []string
+		for id, d := range indeg {
+			if d == 0 {
+				ids = append(ids, id)
+			}
+		}
+		if len(ids) == 0 {
+			return nil, errors.New("delegate: cycle detected in task DAG")
+		}
+		// Stable order within a wave for deterministic execution.
+		sort.Strings(ids)
+		for _, id := range ids {
+			wave = append(wave, byID[id])
+			delete(indeg, id)
+			for _, child := range dependents[id] {
+				indeg[child]--
+			}
+		}
+		waves = append(waves, wave)
+		remaining -= len(wave)
+	}
+	return waves, nil
+}

--- a/internal/coding/delegate_test.go
+++ b/internal/coding/delegate_test.go
@@ -1,0 +1,162 @@
+package coding
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type recordingRunner struct {
+	mu       sync.Mutex
+	order    []string
+	parallel atomic.Int32
+	maxPar   atomic.Int32
+	failOn   map[string]bool
+	delay    time.Duration
+}
+
+func (r *recordingRunner) Run(ctx context.Context, t DelegateTask, lineage []DelegateLineageStep) (DelegateResult, error) {
+	cur := r.parallel.Add(1)
+	for {
+		old := r.maxPar.Load()
+		if cur <= old || r.maxPar.CompareAndSwap(old, cur) {
+			break
+		}
+	}
+	defer r.parallel.Add(-1)
+	if r.delay > 0 {
+		time.Sleep(r.delay)
+	}
+	r.mu.Lock()
+	r.order = append(r.order, t.ID)
+	r.mu.Unlock()
+	if r.failOn[t.ID] {
+		return DelegateResult{TaskID: t.ID, Lineage: lineage}, errors.New("forced failure")
+	}
+	return DelegateResult{
+		TaskID:    t.ID,
+		Agent:     t.Agent,
+		SessionID: "child-" + t.ID,
+		Output:    "out:" + t.Prompt,
+		Lineage:   lineage,
+	}, nil
+}
+
+func TestDelegateBatchRunsInTopologicalOrder(t *testing.T) {
+	r := &recordingRunner{}
+	m := NewAgentManager(r)
+	results, err := m.DelegateBatch(context.Background(), "parent-1", []DelegateTask{
+		{ID: "c", DependsOn: []string{"a", "b"}, Prompt: "C"},
+		{ID: "a", Prompt: "A"},
+		{ID: "b", Prompt: "B"},
+		{ID: "d", DependsOn: []string{"c"}, Prompt: "D"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(results))
+	}
+	// a and b come before c which comes before d.
+	posOf := map[string]int{}
+	for i, id := range r.order {
+		posOf[id] = i
+	}
+	if !(posOf["a"] < posOf["c"] && posOf["b"] < posOf["c"] && posOf["c"] < posOf["d"]) {
+		t.Errorf("topo order broken: %v", r.order)
+	}
+}
+
+func TestDelegateBatchParallelInWave(t *testing.T) {
+	r := &recordingRunner{delay: 50 * time.Millisecond}
+	m := NewAgentManager(r)
+	_, err := m.DelegateBatch(context.Background(), "parent", []DelegateTask{
+		{ID: "a", Prompt: "A"},
+		{ID: "b", Prompt: "B"},
+		{ID: "c", Prompt: "C"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.maxPar.Load() < 2 {
+		t.Errorf("expected parallel execution, max was %d", r.maxPar.Load())
+	}
+}
+
+func TestDelegateBatchSkipsDownstreamOnFailure(t *testing.T) {
+	r := &recordingRunner{failOn: map[string]bool{"a": true}}
+	m := NewAgentManager(r)
+	results, err := m.DelegateBatch(context.Background(), "parent", []DelegateTask{
+		{ID: "a", Prompt: "A"},
+		{ID: "b", DependsOn: []string{"a"}, Prompt: "B"},
+		{ID: "c", DependsOn: []string{"b"}, Prompt: "C"},
+		{ID: "d", Prompt: "D"}, // independent — should still run
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]DelegateResult{}
+	for _, r := range results {
+		byID[r.TaskID] = r
+	}
+	if byID["a"].Error == "" {
+		t.Errorf("a should have failed")
+	}
+	if !strings.Contains(byID["b"].Error, "skipped") || !strings.Contains(byID["c"].Error, "skipped") {
+		t.Errorf("b/c should be skipped: %+v %+v", byID["b"], byID["c"])
+	}
+	if byID["d"].Error != "" {
+		t.Errorf("d should have run: %+v", byID["d"])
+	}
+}
+
+func TestDelegateCycleDetected(t *testing.T) {
+	m := NewAgentManager(&recordingRunner{})
+	_, err := m.DelegateBatch(context.Background(), "p", []DelegateTask{
+		{ID: "a", DependsOn: []string{"b"}},
+		{ID: "b", DependsOn: []string{"a"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("expected cycle error, got %v", err)
+	}
+}
+
+func TestDelegateUnknownDependency(t *testing.T) {
+	m := NewAgentManager(&recordingRunner{})
+	_, err := m.DelegateBatch(context.Background(), "p", []DelegateTask{
+		{ID: "a", DependsOn: []string{"missing"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown") {
+		t.Errorf("expected unknown-dep error, got %v", err)
+	}
+}
+
+func TestDelegateLineageRecorded(t *testing.T) {
+	m := NewAgentManager(&recordingRunner{})
+	_, err := m.DelegateBatch(context.Background(), "parent-X", []DelegateTask{{ID: "a", Prompt: "p"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lin := m.LineageOf("child-a")
+	if len(lin) != 1 || lin[0].ParentSessionID != "parent-X" || lin[0].ParentTaskID != "a" {
+		t.Errorf("lineage missing or wrong: %+v", lin)
+	}
+}
+
+func TestSummarizeBatch(t *testing.T) {
+	results := []DelegateResult{
+		{TaskID: "a", Agent: "writer", Output: "first line\nsecond"},
+		{TaskID: "b", Agent: "writer", Error: "boom"},
+		{TaskID: "c", Agent: "writer", Error: "skipped: upstream dependency failed"},
+	}
+	out := SummarizeBatch(results)
+	for _, want := range []string{"ok=1", "failed=1", "skipped=1", "[ok] a", "[fail] b", "[skip] c", "first line", "boom"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary missing %q:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- \`AgentManager\` runs delegated tasks in topological waves: independent tasks parallel, later waves serialize.
- Lineage tracking: every child session id maps back to its (parent_session, parent_task) chain.
- Failure handling: downstream tasks skip with a clear marker; independent siblings still run.
- \`SummarizeBatch\` produces a stable per-batch summary the parent agent folds into its own context (PRD §6.24.6).

Closes #63

## Test plan
- [x] \`make lint && make test\`
- [x] Coverage: topo order, parallel execution within a wave, downstream skip on failure, cycle / unknown-dep validation, lineage retrieval, summary formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)