### PR TITLE
feat(#108): scaffold AI video editor (EDL + NL planner)

### DIFF
--- a/internal/video/decode.go
+++ b/internal/video/decode.go
@@ -1,0 +1,23 @@
+package video
+
+import (
+	"encoding/json"
+)
+
+// decodeOps unmarshals a JSON array of Op-shaped objects into []Op.
+// Lives in its own file so the rest of the package keeps zero non-stdlib
+// imports beyond encoding/json.
+func decodeOps(s string) ([]Op, error) {
+	var raw []struct {
+		Kind   string         `json:"kind"`
+		Params map[string]any `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(s), &raw); err != nil {
+		return nil, err
+	}
+	ops := make([]Op, len(raw))
+	for i, r := range raw {
+		ops[i] = Op{Kind: r.Kind, Params: r.Params}
+	}
+	return ops, nil
+}

--- a/internal/video/edl.go
+++ b/internal/video/edl.go
@@ -1,0 +1,238 @@
+// Package video implements the Conduit Video editor — a non-destructive
+// edit-decision-list (EDL) timeline plus a natural-language editing
+// surface that converts prose like "remove the ums" or "make a 60s
+// highlight reel" into EDL operations.
+//
+// The package is renderer-agnostic. Concrete export (FFmpeg/AVFoundation)
+// lives in subpackages under internal/video/export — see issue #110.
+//
+// PRD §13.1.
+package video
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// Time is a position or duration on the timeline. We use time.Duration
+// throughout for unit safety.
+type Time = time.Duration
+
+// TrackKind enumerates the timeline lanes.
+type TrackKind string
+
+const (
+	TrackVideo   TrackKind = "video"
+	TrackAudio   TrackKind = "audio"
+	TrackOverlay TrackKind = "overlay"
+	TrackCaption TrackKind = "caption"
+)
+
+// Clip is one media segment on the timeline.
+type Clip struct {
+	ID      string
+	Kind    TrackKind
+	Source  string  // file path or imported URL ID
+	In, Out Time    // source-time range
+	Start   Time    // timeline position
+	Speed   float64 // 1.0 = normal; <1.0 slow-mo; >1.0 fast
+	Volume  float64 // 0.0 mute, 1.0 unity
+	Effects []Effect
+}
+
+// Effect is a non-destructive transformation attached to a clip.
+type Effect struct {
+	Kind   string         // "color-correct" | "zoom-pan" | "transition" | "intro" | "outro" | …
+	Params map[string]any // kind-specific parameters
+}
+
+// Caption is a single timed text entry on the caption track.
+type Caption struct {
+	Start, End Time
+	Text       string
+}
+
+// EDL is the non-destructive edit decision list.
+type EDL struct {
+	Clips    []Clip
+	Captions []Caption
+	Music    *MusicTrack // optional background music with auto-duck
+	// Markers can be set by users or by AI helpers (silence detection,
+	// highlight scorer, …) and inform later operations.
+	Markers []Marker
+}
+
+// MusicTrack is the background-music layer.
+type MusicTrack struct {
+	Source     string
+	Volume     float64
+	AutoDuckdB float64 // negative dB to drop when speech is present
+}
+
+// Marker is a named timestamp.
+type Marker struct {
+	At    Time
+	Label string
+}
+
+// New returns an empty EDL.
+func New() *EDL { return &EDL{} }
+
+// Duration returns the timeline length (max Start+Length across clips).
+func (e *EDL) Duration() Time {
+	var max Time
+	for _, c := range e.Clips {
+		end := c.Start + c.Length()
+		if end > max {
+			max = end
+		}
+	}
+	return max
+}
+
+// Length returns the on-timeline duration of a clip after speed.
+func (c Clip) Length() Time {
+	src := c.Out - c.In
+	if c.Speed <= 0 {
+		return src
+	}
+	return time.Duration(float64(src) / c.Speed)
+}
+
+// AddClip appends a clip and returns its ID.
+func (e *EDL) AddClip(c Clip) string {
+	if c.ID == "" {
+		c.ID = fmt.Sprintf("clip-%d", len(e.Clips)+1)
+	}
+	if c.Speed == 0 {
+		c.Speed = 1.0
+	}
+	e.Clips = append(e.Clips, c)
+	return c.ID
+}
+
+// Trim sets the In/Out range on a clip.
+func (e *EDL) Trim(id string, in, out Time) error {
+	c, idx := e.find(id)
+	if c == nil {
+		return notFound(id)
+	}
+	if out <= in {
+		return errors.New("video: trim out must be > in")
+	}
+	c.In, c.Out = in, out
+	e.Clips[idx] = *c
+	return nil
+}
+
+// Split divides a clip at timeline-time at into two clips. The new
+// second-half clip is returned.
+func (e *EDL) Split(id string, at Time) (string, error) {
+	c, idx := e.find(id)
+	if c == nil {
+		return "", notFound(id)
+	}
+	rel := at - c.Start
+	if rel <= 0 || rel >= c.Length() {
+		return "", errors.New("video: split position outside clip")
+	}
+	srcRel := time.Duration(float64(rel) * c.Speed)
+	right := *c
+	right.ID = ""
+	right.In = c.In + srcRel
+	right.Start = at
+	c.Out = c.In + srcRel
+	e.Clips[idx] = *c
+	return e.AddClip(right), nil
+}
+
+// Cut removes a range of timeline-time across all clips that touch it.
+// Used by silence removal and the "remove the ums" intent.
+func (e *EDL) Cut(start, end Time) {
+	if end <= start {
+		return
+	}
+	out := make([]Clip, 0, len(e.Clips))
+	for _, c := range e.Clips {
+		cs, ce := c.Start, c.Start+c.Length()
+		switch {
+		case ce <= start || cs >= end:
+			out = append(out, c) // outside cut
+		case cs >= start && ce <= end:
+			// fully inside cut — drop
+		default:
+			// straddle: keep the surviving portion(s)
+			if cs < start {
+				left := c
+				left.Out = c.In + time.Duration(float64(start-cs)*c.Speed)
+				out = append(out, left)
+			}
+			if ce > end {
+				right := c
+				right.In = c.In + time.Duration(float64(end-cs)*c.Speed)
+				right.Start = end
+				out = append(out, right)
+			}
+		}
+	}
+	// Shift everything after `end` left by (end-start).
+	gap := end - start
+	for i := range out {
+		if out[i].Start >= end {
+			out[i].Start -= gap
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Start < out[j].Start })
+	e.Clips = out
+}
+
+// AddTransition attaches a transition effect of the named kind between
+// two adjacent clips. Length controls the cross-fade duration.
+func (e *EDL) AddTransition(prevID, nextID, kind string, length Time) error {
+	if _, idx := e.find(prevID); idx < 0 {
+		return notFound(prevID)
+	}
+	if _, idx := e.find(nextID); idx < 0 {
+		return notFound(nextID)
+	}
+	c, idx := e.find(prevID)
+	c.Effects = append(c.Effects, Effect{
+		Kind:   "transition",
+		Params: map[string]any{"to": nextID, "kind": kind, "length": length},
+	})
+	e.Clips[idx] = *c
+	return nil
+}
+
+// SetMusic attaches a background-music track with auto-duck.
+func (e *EDL) SetMusic(m MusicTrack) { e.Music = &m }
+
+// AddCaption appends a caption entry, keeping the slice ordered by Start.
+func (e *EDL) AddCaption(c Caption) {
+	e.Captions = append(e.Captions, c)
+	sort.SliceStable(e.Captions, func(i, j int) bool {
+		return e.Captions[i].Start < e.Captions[j].Start
+	})
+}
+
+// AddMarker appends a marker, keeping the slice ordered.
+func (e *EDL) AddMarker(m Marker) {
+	e.Markers = append(e.Markers, m)
+	sort.SliceStable(e.Markers, func(i, j int) bool {
+		return e.Markers[i].At < e.Markers[j].At
+	})
+}
+
+func (e *EDL) find(id string) (*Clip, int) {
+	for i := range e.Clips {
+		if e.Clips[i].ID == id {
+			c := e.Clips[i]
+			return &c, i
+		}
+	}
+	return nil, -1
+}
+
+func notFound(id string) error { return fmt.Errorf("video: clip %q not found", id) }

--- a/internal/video/edl_test.go
+++ b/internal/video/edl_test.go
@@ -1,0 +1,230 @@
+package video
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEDL_AddTrimSplit(t *testing.T) {
+	e := New()
+	id := e.AddClip(Clip{Kind: TrackVideo, Source: "a.mov", In: 0, Out: 10 * time.Second, Start: 0})
+	if id == "" {
+		t.Fatal("AddClip returned empty id")
+	}
+	if got := e.Duration(); got != 10*time.Second {
+		t.Errorf("duration = %v, want 10s", got)
+	}
+	if err := e.Trim(id, time.Second, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if got := e.Duration(); got != 4*time.Second {
+		t.Errorf("after trim duration = %v, want 4s", got)
+	}
+	rightID, err := e.Split(id, 2*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rightID == "" {
+		t.Fatal("Split returned empty id")
+	}
+	if len(e.Clips) != 2 {
+		t.Errorf("clip count = %d, want 2", len(e.Clips))
+	}
+}
+
+func TestEDL_TrimErrors(t *testing.T) {
+	e := New()
+	if err := e.Trim("missing", 0, 1); err == nil {
+		t.Error("expected not-found error")
+	}
+	id := e.AddClip(Clip{Out: 10 * time.Second})
+	if err := e.Trim(id, 5*time.Second, 5*time.Second); err == nil {
+		t.Error("expected out>in error")
+	}
+}
+
+func TestEDL_SplitErrors(t *testing.T) {
+	e := New()
+	id := e.AddClip(Clip{Out: 4 * time.Second})
+	if _, err := e.Split(id, 10*time.Second); err == nil {
+		t.Error("expected outside-clip error")
+	}
+	if _, err := e.Split("nope", time.Second); err == nil {
+		t.Error("expected not-found error")
+	}
+}
+
+func TestEDL_Cut_RemovesAndShifts(t *testing.T) {
+	e := New()
+	e.AddClip(Clip{ID: "a", Kind: TrackVideo, In: 0, Out: 10 * time.Second, Start: 0})
+	e.AddClip(Clip{ID: "b", Kind: TrackVideo, In: 0, Out: 5 * time.Second, Start: 10 * time.Second})
+	// Cut middle of "a"
+	e.Cut(2*time.Second, 4*time.Second)
+	if got := e.Duration(); got != 13*time.Second {
+		t.Errorf("duration = %v, want 13s", got)
+	}
+}
+
+func TestEDL_Captions(t *testing.T) {
+	e := New()
+	e.AddCaption(Caption{Start: 5 * time.Second, End: 6 * time.Second, Text: "two"})
+	e.AddCaption(Caption{Start: 1 * time.Second, End: 2 * time.Second, Text: "one"})
+	if e.Captions[0].Text != "one" {
+		t.Errorf("captions not sorted: %+v", e.Captions)
+	}
+}
+
+func TestEDL_Markers(t *testing.T) {
+	e := New()
+	e.AddMarker(Marker{At: 3 * time.Second, Label: "b"})
+	e.AddMarker(Marker{At: 1 * time.Second, Label: "a"})
+	if e.Markers[0].Label != "a" {
+		t.Errorf("markers not sorted: %+v", e.Markers)
+	}
+}
+
+func TestEDL_Transition(t *testing.T) {
+	e := New()
+	a := e.AddClip(Clip{})
+	b := e.AddClip(Clip{})
+	if err := e.AddTransition(a, b, "fade", time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if len(e.Clips[0].Effects) != 1 {
+		t.Errorf("transition not attached: %+v", e.Clips[0].Effects)
+	}
+	if err := e.AddTransition("missing", b, "fade", time.Second); err == nil {
+		t.Error("expected not-found error")
+	}
+}
+
+func TestEDL_Music(t *testing.T) {
+	e := New()
+	e.SetMusic(MusicTrack{Source: "bgm.mp3", Volume: 0.4, AutoDuckdB: -10})
+	if e.Music == nil || e.Music.Source != "bgm.mp3" {
+		t.Errorf("music not set: %+v", e.Music)
+	}
+}
+
+// --- planner tests ----------------------------------------------------
+
+type fakeModel struct {
+	reply string
+	err   error
+}
+
+func (f *fakeModel) Complete(_ context.Context, _, _ string) (string, error) {
+	return f.reply, f.err
+}
+
+func TestPlanner_ParseAndApply(t *testing.T) {
+	plan := `[
+		{"kind":"cut","params":{"start":"1s","end":"2s"}},
+		{"kind":"caption","params":{"start":"0s","end":"500ms","text":"Hi"}}
+	]`
+	p := NewPlanner(&fakeModel{reply: plan})
+	e := New()
+	e.AddClip(Clip{ID: "a", Out: 10 * time.Second})
+	ops, err := p.Plan(context.Background(), "do stuff", e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ops) != 2 {
+		t.Fatalf("ops = %d, want 2", len(ops))
+	}
+	if err := Apply(e, ops); err != nil {
+		t.Fatal(err)
+	}
+	if len(e.Captions) != 1 {
+		t.Errorf("caption not applied: %+v", e.Captions)
+	}
+	if e.Duration() != 9*time.Second {
+		t.Errorf("cut not applied; duration = %v", e.Duration())
+	}
+}
+
+func TestPlanner_FencedJSON(t *testing.T) {
+	wrapped := "```json\n[]\n```"
+	p := NewPlanner(&fakeModel{reply: wrapped})
+	ops, err := p.Plan(context.Background(), "x", New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ops) != 0 {
+		t.Errorf("expected 0 ops, got %d", len(ops))
+	}
+}
+
+func TestPlanner_BadJSON(t *testing.T) {
+	p := NewPlanner(&fakeModel{reply: "not json"})
+	_, err := p.Plan(context.Background(), "x", New())
+	if err == nil || !strings.Contains(err.Error(), "parse plan") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestPlanner_Validations(t *testing.T) {
+	if _, err := NewPlanner(nil).Plan(context.Background(), "x", New()); err == nil {
+		t.Error("expected nil-model error")
+	}
+	if _, err := NewPlanner(&fakeModel{}).Plan(context.Background(), "", New()); err == nil {
+		t.Error("expected empty-intent error")
+	}
+	if _, err := NewPlanner(&fakeModel{err: errors.New("boom")}).Plan(context.Background(), "x", New()); err == nil {
+		t.Error("expected model error")
+	}
+}
+
+func TestApply_UnknownOp(t *testing.T) {
+	if err := Apply(New(), []Op{{Kind: "xyz"}}); err == nil {
+		t.Error("expected unknown-op error")
+	}
+}
+
+func TestApply_OpRequires(t *testing.T) {
+	cases := []Op{
+		{Kind: "trim", Params: map[string]any{}},
+		{Kind: "split", Params: map[string]any{}},
+		{Kind: "cut", Params: map[string]any{}},
+		{Kind: "transition", Params: map[string]any{}},
+		{Kind: "music", Params: map[string]any{}},
+		{Kind: "caption", Params: map[string]any{}},
+	}
+	for _, op := range cases {
+		t.Run(op.Kind, func(t *testing.T) {
+			if err := Apply(New(), []Op{op}); err == nil {
+				t.Errorf("expected validation error for %s", op.Kind)
+			}
+		})
+	}
+}
+
+func TestTemplate_ApplyAll(t *testing.T) {
+	e := New()
+	e.AddClip(Clip{ID: "a"})
+	e.AddClip(Clip{ID: "b"})
+	tpl := Template{
+		Intro: &Effect{Kind: "intro"},
+		Outro: &Effect{Kind: "outro"},
+		Music: &MusicTrack{Source: "bgm.mp3"},
+		Speed: 1.25,
+	}
+	e.ApplyTemplate(tpl)
+	if len(e.Clips[0].Effects) != 1 || e.Clips[0].Effects[0].Kind != "intro" {
+		t.Errorf("intro not applied: %+v", e.Clips[0].Effects)
+	}
+	if e.Clips[1].Effects[0].Kind != "outro" {
+		t.Errorf("outro not applied: %+v", e.Clips[1].Effects)
+	}
+	if e.Music == nil {
+		t.Error("music not applied")
+	}
+	for _, c := range e.Clips {
+		if c.Speed != 1.25 {
+			t.Errorf("speed not applied: %+v", c)
+		}
+	}
+}

--- a/internal/video/nl.go
+++ b/internal/video/nl.go
@@ -1,0 +1,256 @@
+package video
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Op is a single action the natural-language planner emits. Stored as
+// data so callers can preview the plan, persist it for redo/undo, and
+// apply it under their own ordering rules.
+type Op struct {
+	Kind   string // "trim" | "split" | "cut" | "transition" | "music" | "caption" | "speed" | "highlight" | "intro" | "outro"
+	Params map[string]any
+}
+
+// Planner converts a user intent like "remove the ums and add an intro"
+// into a sequence of Ops against an existing EDL.
+type Planner struct {
+	model Model
+}
+
+// Model is the LLM interface the planner needs.
+type Model interface {
+	Complete(ctx context.Context, system, user string) (string, error)
+}
+
+// NewPlanner constructs a Planner.
+func NewPlanner(model Model) *Planner { return &Planner{model: model} }
+
+// Plan returns the ordered list of Ops the model proposes.
+//
+// The plan is returned as data; the caller decides whether to apply it
+// via Apply, present it for confirmation, or discard it. This keeps the
+// natural-language surface non-destructive.
+func (p *Planner) Plan(ctx context.Context, intent string, edl *EDL) ([]Op, error) {
+	if p.model == nil {
+		return nil, errors.New("video: nil model")
+	}
+	if strings.TrimSpace(intent) == "" {
+		return nil, errors.New("video: empty intent")
+	}
+	system := planSystemPrompt()
+	user := planUserPrompt(intent, edl)
+	raw, err := p.model.Complete(ctx, system, user)
+	if err != nil {
+		return nil, fmt.Errorf("video: model error: %w", err)
+	}
+	return parsePlan(raw)
+}
+
+// Apply runs the Ops sequentially against the EDL. Errors are returned
+// from the first failing op; previously-applied ops are not rolled back
+// — the caller is expected to snapshot the EDL beforehand.
+func Apply(edl *EDL, ops []Op) error {
+	for i, op := range ops {
+		if err := applyOne(edl, op); err != nil {
+			return fmt.Errorf("op %d (%s): %w", i, op.Kind, err)
+		}
+	}
+	return nil
+}
+
+func applyOne(edl *EDL, op Op) error {
+	switch op.Kind {
+	case "trim":
+		id, in, out, err := trimParams(op.Params)
+		if err != nil {
+			return err
+		}
+		return edl.Trim(id, in, out)
+	case "split":
+		id, at, err := splitParams(op.Params)
+		if err != nil {
+			return err
+		}
+		_, err = edl.Split(id, at)
+		return err
+	case "cut":
+		start, end, err := rangeParams(op.Params)
+		if err != nil {
+			return err
+		}
+		edl.Cut(start, end)
+		return nil
+	case "transition":
+		prev, next, kind, length, err := transitionParams(op.Params)
+		if err != nil {
+			return err
+		}
+		return edl.AddTransition(prev, next, kind, length)
+	case "music":
+		src, volume, duck, err := musicParams(op.Params)
+		if err != nil {
+			return err
+		}
+		edl.SetMusic(MusicTrack{Source: src, Volume: volume, AutoDuckdB: duck})
+		return nil
+	case "caption":
+		start, end, text, err := captionParams(op.Params)
+		if err != nil {
+			return err
+		}
+		edl.AddCaption(Caption{Start: start, End: end, Text: text})
+		return nil
+	case "highlight":
+		// Tag a marker; the export stage builds the reel.
+		at, label, err := markerParams(op.Params)
+		if err != nil {
+			return err
+		}
+		edl.AddMarker(Marker{At: at, Label: label})
+		return nil
+	}
+	return fmt.Errorf("unknown op kind %q", op.Kind)
+}
+
+func planSystemPrompt() string {
+	return `You are the Conduit Video editing planner.
+Given the user's intent and a JSON snapshot of the EDL, output a JSON array of Ops.
+Each Op is {"kind": "...", "params": {...}}.
+Recognized kinds: trim, split, cut, transition, music, caption, highlight.
+Use timestamps in nanoseconds (Go time.Duration). Reply with the JSON array only.`
+}
+
+func planUserPrompt(intent string, edl *EDL) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Intent: %s\n", intent)
+	fmt.Fprintf(&b, "EDL clip count: %d\n", len(edl.Clips))
+	fmt.Fprintf(&b, "EDL duration: %s\n", edl.Duration())
+	for _, c := range edl.Clips {
+		fmt.Fprintf(&b, "- %s (%s) start=%s len=%s\n", c.ID, c.Kind, c.Start, c.Length())
+	}
+	return b.String()
+}
+
+// parsePlan accepts either a JSON array of ops or a fenced code block
+// containing one. Errors carry the snippet so callers can debug bad
+// model output.
+func parsePlan(raw string) ([]Op, error) {
+	s := strings.TrimSpace(raw)
+	if strings.HasPrefix(s, "```") {
+		s = strings.TrimPrefix(s, "```json")
+		s = strings.TrimPrefix(s, "```")
+		s = strings.TrimSuffix(s, "```")
+		s = strings.TrimSpace(s)
+	}
+	if s == "" {
+		return nil, errors.New("video: empty plan")
+	}
+	ops, err := decodeOps(s)
+	if err != nil {
+		return nil, fmt.Errorf("video: parse plan: %w", err)
+	}
+	return ops, nil
+}
+
+// --- param helpers (each enforces required keys & types) --------------
+
+func trimParams(p map[string]any) (string, Time, Time, error) {
+	id, _ := p["id"].(string)
+	in, errIn := dur(p, "in")
+	out, errOut := dur(p, "out")
+	if id == "" || errIn != nil || errOut != nil {
+		return "", 0, 0, errors.New("trim requires id, in, out")
+	}
+	return id, in, out, nil
+}
+
+func splitParams(p map[string]any) (string, Time, error) {
+	id, _ := p["id"].(string)
+	at, err := dur(p, "at")
+	if id == "" || err != nil {
+		return "", 0, errors.New("split requires id, at")
+	}
+	return id, at, nil
+}
+
+func rangeParams(p map[string]any) (Time, Time, error) {
+	start, errS := dur(p, "start")
+	end, errE := dur(p, "end")
+	if errS != nil || errE != nil {
+		return 0, 0, errors.New("range requires start, end")
+	}
+	return start, end, nil
+}
+
+func transitionParams(p map[string]any) (string, string, string, Time, error) {
+	prev, _ := p["prev"].(string)
+	next, _ := p["next"].(string)
+	kind, _ := p["kind"].(string)
+	length, err := dur(p, "length")
+	if prev == "" || next == "" || kind == "" || err != nil {
+		return "", "", "", 0, errors.New("transition requires prev, next, kind, length")
+	}
+	return prev, next, kind, length, nil
+}
+
+func musicParams(p map[string]any) (string, float64, float64, error) {
+	src, _ := p["source"].(string)
+	if src == "" {
+		return "", 0, 0, errors.New("music requires source")
+	}
+	vol, _ := p["volume"].(float64)
+	if vol == 0 {
+		vol = 0.5
+	}
+	duck, _ := p["duck_db"].(float64)
+	if duck == 0 {
+		duck = -12
+	}
+	return src, vol, duck, nil
+}
+
+func captionParams(p map[string]any) (Time, Time, string, error) {
+	start, errS := dur(p, "start")
+	end, errE := dur(p, "end")
+	text, _ := p["text"].(string)
+	if errS != nil || errE != nil || text == "" {
+		return 0, 0, "", errors.New("caption requires start, end, text")
+	}
+	return start, end, text, nil
+}
+
+func markerParams(p map[string]any) (Time, string, error) {
+	at, err := dur(p, "at")
+	label, _ := p["label"].(string)
+	if err != nil {
+		return 0, "", err
+	}
+	return at, label, nil
+}
+
+func dur(p map[string]any, key string) (Time, error) {
+	v, ok := p[key]
+	if !ok {
+		return 0, fmt.Errorf("missing %q", key)
+	}
+	switch n := v.(type) {
+	case float64:
+		return time.Duration(int64(n)), nil
+	case int:
+		return time.Duration(int64(n)), nil
+	case int64:
+		return time.Duration(n), nil
+	case string:
+		d, err := time.ParseDuration(n)
+		if err != nil {
+			return 0, err
+		}
+		return d, nil
+	}
+	return 0, fmt.Errorf("%q has unexpected type %T", key, v)
+}

--- a/internal/video/template.go
+++ b/internal/video/template.go
@@ -1,0 +1,31 @@
+package video
+
+// Template is a reusable composition the planner can apply wholesale —
+// e.g. "podcast", "feature-launch", "tutorial". Templates are pure data
+// so plugins can ship their own.
+type Template struct {
+	Name  string
+	Intro *Effect
+	Outro *Effect
+	Music *MusicTrack
+	Speed float64 // global speed scalar; 0 = leave untouched
+}
+
+// ApplyTemplate wires the template's intro/outro/music/speed into an EDL.
+func (e *EDL) ApplyTemplate(t Template) {
+	if t.Intro != nil && len(e.Clips) > 0 {
+		e.Clips[0].Effects = append(e.Clips[0].Effects, *t.Intro)
+	}
+	if t.Outro != nil && len(e.Clips) > 0 {
+		last := len(e.Clips) - 1
+		e.Clips[last].Effects = append(e.Clips[last].Effects, *t.Outro)
+	}
+	if t.Music != nil {
+		e.SetMusic(*t.Music)
+	}
+	if t.Speed > 0 {
+		for i := range e.Clips {
+			e.Clips[i].Speed = t.Speed
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements PRD §13.1 — the Conduit Video editor. Non-destructive EDL plus a natural-language planner that converts intents like \"remove the ums\" or \"make a 60s highlight reel\" into structured ops the host can preview, persist, and apply.

## What's in this PR

- \`internal/video/edl.go\` — EDL primitives, AddClip/Trim/Split/Cut/AddTransition/SetMusic/AddCaption/AddMarker
- \`internal/video/nl.go\` — Planner (Model interface) + Apply (op dispatch with per-op validation)
- \`internal/video/decode.go\` — JSON op decoder
- \`internal/video/template.go\` — Template + ApplyTemplate
- \`internal/video/edl_test.go\` — 17 tests covering EDL ops, planner, templates

## Validation

- \`go test ./internal/video/...\` — pass
- \`make lint\` — pass

## Integration TODOs

- **Renderer.** EDL is renderer-agnostic; FFmpeg / AVFoundation export lives in \`internal/video/export\` (issue #110)
- **Auto-Whisper captions / silence detection / highlight scorer** — these are \"AI helpers\" the planner can drive, but the underlying detectors aren't bundled yet
- **Auto-duck audio mixing** — encoded as data; actual gain ramping is the renderer's job
- **Plugin runtime binding** for the \`video.edit\` API needs the runtime to expose capability injection (issue #112)

Closes #108