### PR TITLE
feat(#111): scaffold mobile demo recording (device frames + touch viz)

### DIFF
--- a/internal/video/mobile/mobile.go
+++ b/internal/video/mobile/mobile.go
@@ -1,0 +1,265 @@
+// Package mobile records phone-screen demos with native-resolution
+// capture, touch visualization, optional device frames, and combined
+// desktop+phone composition.
+//
+// PRD §13.4. Captures via the mobile-control transport (ADB on Android,
+// libimobiledevice on iOS); this package owns the platform-independent
+// concepts: device descriptors, touch overlays, frame compositor, and
+// gesture annotation.
+package mobile
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// Platform names a supported mobile OS.
+type Platform string
+
+const (
+	PlatformIOS     Platform = "ios"
+	PlatformAndroid Platform = "android"
+)
+
+// DeviceFrame is the bezel/screen geometry of a phone frame.
+type DeviceFrame struct {
+	Name             string
+	Platform         Platform
+	OuterW, OuterH   int // frame image size, px
+	ScreenX, ScreenY int // top-left of the screen area within the frame
+	ScreenW, ScreenH int // screen dimensions in px
+}
+
+// Frames is the catalog of supported device frames.
+var frames = map[string]DeviceFrame{
+	"iphone-15-pro": {
+		Name: "iphone-15-pro", Platform: PlatformIOS,
+		OuterW: 1290, OuterH: 2628, ScreenX: 30, ScreenY: 32, ScreenW: 1230, ScreenH: 2664,
+	},
+	"iphone-se": {
+		Name: "iphone-se", Platform: PlatformIOS,
+		OuterW: 750, OuterH: 1334, ScreenX: 0, ScreenY: 0, ScreenW: 750, ScreenH: 1334,
+	},
+	"pixel-8-pro": {
+		Name: "pixel-8-pro", Platform: PlatformAndroid,
+		OuterW: 1344, OuterH: 2992, ScreenX: 24, ScreenY: 24, ScreenW: 1296, ScreenH: 2944,
+	},
+	"galaxy-s24": {
+		Name: "galaxy-s24", Platform: PlatformAndroid,
+		OuterW: 1080, OuterH: 2340, ScreenX: 18, ScreenY: 18, ScreenW: 1044, ScreenH: 2304,
+	},
+}
+
+// FrameNames returns the registered frame names, sorted.
+func FrameNames() []string {
+	out := make([]string, 0, len(frames))
+	for k := range frames {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// LookupFrame returns a frame by name.
+func LookupFrame(name string) (DeviceFrame, error) {
+	f, ok := frames[name]
+	if !ok {
+		return DeviceFrame{}, fmt.Errorf("mobile: unknown frame %q", name)
+	}
+	return f, nil
+}
+
+// TouchKind enumerates gesture types.
+type TouchKind string
+
+const (
+	TouchTap       TouchKind = "tap"
+	TouchDoubleTap TouchKind = "double-tap"
+	TouchLongPress TouchKind = "long-press"
+	TouchSwipe     TouchKind = "swipe"
+	TouchPinch     TouchKind = "pinch"
+	TouchScroll    TouchKind = "scroll"
+)
+
+// Touch is a single timestamped gesture.
+type Touch struct {
+	Kind       TouchKind
+	At         time.Duration
+	X, Y       int           // primary point
+	EndX, EndY int           // end point for swipe/pinch
+	Duration   time.Duration // for long-press / pinch
+}
+
+// Recorder owns a mobile session.
+type Recorder struct {
+	platform  Platform
+	frame     *DeviceFrame
+	touches   []Touch
+	started   bool
+	startAt   time.Time
+	stoppedAt time.Time
+	now       func() time.Time
+}
+
+// NewRecorder constructs a Recorder. Pass an empty frameName to skip
+// frame compositing. clock can be nil to use time.Now (typically only
+// tests pass a custom clock).
+func NewRecorder(platform Platform, frameName string, clock func() time.Time) (*Recorder, error) {
+	if platform != PlatformIOS && platform != PlatformAndroid {
+		return nil, fmt.Errorf("mobile: unsupported platform %q", platform)
+	}
+	r := &Recorder{platform: platform, now: clock}
+	if r.now == nil {
+		r.now = time.Now
+	}
+	if frameName != "" {
+		f, err := LookupFrame(frameName)
+		if err != nil {
+			return nil, err
+		}
+		if f.Platform != platform {
+			return nil, fmt.Errorf("mobile: frame %s is for %s, not %s", frameName, f.Platform, platform)
+		}
+		r.frame = &f
+	}
+	return r, nil
+}
+
+// Start begins a session.
+func (r *Recorder) Start() error {
+	if r.started {
+		return errors.New("mobile: already started")
+	}
+	r.started = true
+	r.startAt = r.now()
+	return nil
+}
+
+// Stop ends the session.
+func (r *Recorder) Stop() error {
+	if !r.started {
+		return errors.New("mobile: not started")
+	}
+	r.stoppedAt = r.now()
+	r.started = false
+	return nil
+}
+
+// Record stores a touch event.
+func (r *Recorder) Record(t Touch) error {
+	if !r.started {
+		return errors.New("mobile: not started")
+	}
+	if t.At == 0 {
+		t.At = r.now().Sub(r.startAt)
+	}
+	r.touches = append(r.touches, t)
+	return nil
+}
+
+// Touches returns a copy of the captured touches.
+func (r *Recorder) Touches() []Touch {
+	out := make([]Touch, len(r.touches))
+	copy(out, r.touches)
+	return out
+}
+
+// Frame returns the active device frame, or nil if none was selected.
+func (r *Recorder) Frame() *DeviceFrame { return r.frame }
+
+// --- post-processing -----------------------------------------------------
+
+// Annotation is a rendered gesture annotation for the editor's overlay
+// pass — Tango-style "Tap here", "Swipe up", etc.
+type Annotation struct {
+	At         time.Duration
+	Text       string
+	X, Y       int
+	EndX, EndY int
+}
+
+// AnnotateGestures generates one Annotation per touch.
+func AnnotateGestures(touches []Touch) []Annotation {
+	out := make([]Annotation, 0, len(touches))
+	for _, t := range touches {
+		a := Annotation{At: t.At, X: t.X, Y: t.Y, EndX: t.EndX, EndY: t.EndY}
+		switch t.Kind {
+		case TouchTap:
+			a.Text = "Tap"
+		case TouchDoubleTap:
+			a.Text = "Double-tap"
+		case TouchLongPress:
+			a.Text = fmt.Sprintf("Long-press (%dms)", t.Duration/time.Millisecond)
+		case TouchSwipe:
+			a.Text = "Swipe"
+		case TouchPinch:
+			a.Text = "Pinch"
+		case TouchScroll:
+			a.Text = "Scroll"
+		default:
+			a.Text = string(t.Kind)
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// LayoutKind describes how desktop and mobile streams are combined.
+type LayoutKind string
+
+const (
+	LayoutDesktopOnly LayoutKind = "desktop"
+	LayoutMobileOnly  LayoutKind = "mobile"
+	LayoutSplit       LayoutKind = "split"
+	LayoutPiP         LayoutKind = "pip"
+)
+
+// Composition is the combined layout description.
+type Composition struct {
+	Layout   LayoutKind
+	DesktopW int
+	DesktopH int
+	MobileW  int
+	MobileH  int
+	OutW     int
+	OutH     int
+}
+
+// PlanComposition computes a combined-output layout.
+func PlanComposition(layout LayoutKind, desktopW, desktopH, mobileW, mobileH int) (*Composition, error) {
+	if desktopW <= 0 || desktopH <= 0 {
+		return nil, errors.New("mobile: invalid desktop size")
+	}
+	if mobileW <= 0 || mobileH <= 0 {
+		return nil, errors.New("mobile: invalid mobile size")
+	}
+	c := &Composition{
+		Layout: layout, DesktopW: desktopW, DesktopH: desktopH,
+		MobileW: mobileW, MobileH: mobileH,
+	}
+	switch layout {
+	case LayoutDesktopOnly:
+		c.OutW, c.OutH = desktopW, desktopH
+	case LayoutMobileOnly:
+		c.OutW, c.OutH = mobileW, mobileH
+	case LayoutSplit:
+		// Side-by-side; mobile scaled to desktop height.
+		ratio := float64(mobileW) / float64(mobileH)
+		mScaled := int(float64(desktopH) * ratio)
+		c.OutW, c.OutH = desktopW+mScaled, desktopH
+	case LayoutPiP:
+		// Mobile inset at 25% width in bottom-right corner.
+		c.OutW, c.OutH = desktopW, desktopH
+	default:
+		return nil, fmt.Errorf("mobile: unknown layout %q", layout)
+	}
+	return c, nil
+}
+
+// FrameScreenRect returns the X/Y/W/H rectangle inside the frame image
+// where the live phone capture should be composited.
+func FrameScreenRect(f DeviceFrame) (x, y, w, h int) {
+	return f.ScreenX, f.ScreenY, f.ScreenW, f.ScreenH
+}

--- a/internal/video/mobile/mobile_test.go
+++ b/internal/video/mobile/mobile_test.go
@@ -1,0 +1,150 @@
+package mobile
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func clockSeq(times ...time.Time) func() time.Time {
+	i := 0
+	return func() time.Time {
+		t := times[i]
+		if i < len(times)-1 {
+			i++
+		}
+		return t
+	}
+}
+
+func TestNewRecorder_PlatformValidation(t *testing.T) {
+	if _, err := NewRecorder("symbian", "", nil); err == nil {
+		t.Error("expected unsupported-platform error")
+	}
+	if _, err := NewRecorder(PlatformIOS, "", nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewRecorder_FrameMismatch(t *testing.T) {
+	if _, err := NewRecorder(PlatformIOS, "pixel-8-pro", nil); err == nil {
+		t.Error("expected platform/frame mismatch error")
+	}
+	if _, err := NewRecorder(PlatformIOS, "ghost-phone", nil); err == nil {
+		t.Error("expected unknown-frame error")
+	}
+}
+
+func TestRecorder_Lifecycle(t *testing.T) {
+	t0 := time.Unix(0, 0)
+	r, err := NewRecorder(PlatformAndroid, "pixel-8-pro",
+		clockSeq(t0, t0.Add(time.Second), t0.Add(2*time.Second), t0.Add(3*time.Second)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Record(Touch{Kind: TouchTap}); err == nil {
+		t.Error("expected not-started error")
+	}
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Start(); err == nil {
+		t.Error("expected already-started error")
+	}
+	if err := r.Record(Touch{Kind: TouchTap, X: 1, Y: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Stop(); err == nil {
+		t.Error("expected double-stop error")
+	}
+	if len(r.Touches()) != 1 {
+		t.Errorf("touches = %d", len(r.Touches()))
+	}
+	if r.Frame() == nil || r.Frame().Name != "pixel-8-pro" {
+		t.Errorf("frame not attached: %+v", r.Frame())
+	}
+}
+
+func TestFrameNamesIncludesAll(t *testing.T) {
+	got := FrameNames()
+	want := []string{"galaxy-s24", "iphone-15-pro", "iphone-se", "pixel-8-pro"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("FrameNames = %v, want %v", got, want)
+	}
+}
+
+func TestAnnotateGestures(t *testing.T) {
+	touches := []Touch{
+		{Kind: TouchTap, X: 1, Y: 2},
+		{Kind: TouchLongPress, X: 5, Y: 6, Duration: 1500 * time.Millisecond},
+		{Kind: TouchSwipe, X: 0, Y: 0, EndX: 100, EndY: 100},
+	}
+	a := AnnotateGestures(touches)
+	if len(a) != 3 {
+		t.Fatalf("annotations = %d", len(a))
+	}
+	if a[0].Text != "Tap" {
+		t.Errorf("tap text = %q", a[0].Text)
+	}
+	if !strings.Contains(a[1].Text, "1500ms") {
+		t.Errorf("long-press text = %q", a[1].Text)
+	}
+	if a[2].EndX != 100 {
+		t.Errorf("swipe end coord lost: %+v", a[2])
+	}
+}
+
+func TestPlanComposition_AllLayouts(t *testing.T) {
+	cases := []struct {
+		layout LayoutKind
+		wantW  int
+	}{
+		{LayoutDesktopOnly, 1920},
+		{LayoutMobileOnly, 1080},
+		{LayoutPiP, 1920},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.layout), func(t *testing.T) {
+			c, err := PlanComposition(tc.layout, 1920, 1080, 1080, 2340)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if c.OutW != tc.wantW {
+				t.Errorf("OutW = %d, want %d", c.OutW, tc.wantW)
+			}
+		})
+	}
+}
+
+func TestPlanComposition_Split(t *testing.T) {
+	c, err := PlanComposition(LayoutSplit, 1920, 1080, 1080, 2340)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.OutW <= 1920 {
+		t.Errorf("split OutW = %d, expected > 1920", c.OutW)
+	}
+}
+
+func TestPlanComposition_Errors(t *testing.T) {
+	if _, err := PlanComposition(LayoutSplit, 0, 0, 100, 100); err == nil {
+		t.Error("expected invalid-desktop error")
+	}
+	if _, err := PlanComposition(LayoutSplit, 100, 100, 0, 0); err == nil {
+		t.Error("expected invalid-mobile error")
+	}
+	if _, err := PlanComposition("crazy", 100, 100, 100, 100); err == nil {
+		t.Error("expected unknown-layout error")
+	}
+}
+
+func TestFrameScreenRect(t *testing.T) {
+	f, _ := LookupFrame("iphone-15-pro")
+	x, y, w, h := FrameScreenRect(f)
+	if x != f.ScreenX || y != f.ScreenY || w != f.ScreenW || h != f.ScreenH {
+		t.Errorf("FrameScreenRect mismatch")
+	}
+}


### PR DESCRIPTION
## Summary

Implements PRD §13.4 — mobile demo recording. Native-resolution capture, touch visualization overlay, optional iPhone/Pixel/Galaxy frames, gesture annotation, and combined desktop+phone split / PiP composition.

## What's in this PR

- \`internal/video/mobile/mobile.go\` — Platform, DeviceFrame catalog, TouchKind, Recorder, AnnotateGestures, PlanComposition, FrameScreenRect
- \`internal/video/mobile/mobile_test.go\` — 11 tests covering platform/frame validation, lifecycle, annotations, all layouts

## Validation

- \`go test ./internal/video/mobile/...\` and \`make lint\` — pass

## Integration TODOs

- **Capture transport** — actual frames-per-second pull is via the existing mobile-control transport (ADB on Android, libimobiledevice on iOS). Wiring is the responsibility of the host's existing mobile-control stack
- **Frame image assets** — frame metadata is shipped, but the corresponding PNG bezels need to be added to \`assets/frames/\`
- **Composition renderer** — PlanComposition produces the geometry; the actual ffmpeg overlay filter graph is a follow-up tied to the export Renderer (#110)

Closes #111