### PR TITLE
feat(#143): VS Code and JetBrains extension scaffolds

### DIFF
--- a/ide/README.md
+++ b/ide/README.md
@@ -1,0 +1,40 @@
+# IDE integrations
+
+This directory holds the editor extensions that connect to a running Conduit
+instance (PRD §6.25.14, issue #143).
+
+| Editor                    | Path              | Status                |
+| ------------------------- | ----------------- | --------------------- |
+| VS Code (+ Cursor / Windsurf, both VS Code-API compatible) | [`vscode/`](./vscode/) | Scaffold + connect command |
+| JetBrains (IntelliJ etc.) | [`jetbrains/`](./jetbrains/) | Scaffold + connect action |
+
+## Scope
+
+The PR that adds these scaffolds intentionally ships the **minimum** an IDE
+needs:
+
+- a sidebar entry,
+- keyboard shortcuts,
+- a single "Connect to running Conduit" command that probes the local API
+  port (`http://127.0.0.1:8923/v1/healthz`) and reports back,
+- editor selection / file context sharing helpers (paths only — no file
+  contents are uploaded by the scaffold).
+
+Full feature parity (chat panel, diff review, inline suggestions) is **out of
+scope** here and tracked under separate per-feature issues. The goal is to
+unblock parallel work on the rich UI surfaces by establishing the build
+system, manifest, and connection plumbing for each editor.
+
+## Why VS Code covers Cursor / Windsurf too
+
+Both Cursor and Windsurf are VS Code forks and consume the same `.vsix`
+extension format and API. The `vscode/` extension installs unmodified in all
+three. We document install steps for each in the README and may publish to
+their separate marketplaces from a single CI build.
+
+## Cross-platform
+
+Both extensions rely only on platform-neutral APIs (`fetch` in VS Code,
+`HttpClient` in JetBrains) and ship as portable bundles. macOS, Windows, and
+Linux all work — the only platform-specific bit is the running Conduit
+binary itself, which today is macOS-only.

--- a/ide/jetbrains/.gitignore
+++ b/ide/jetbrains/.gitignore
@@ -1,0 +1,5 @@
+.gradle/
+build/
+out/
+*.iml
+.idea/

--- a/ide/jetbrains/README.md
+++ b/ide/jetbrains/README.md
@@ -1,0 +1,41 @@
+# Conduit for JetBrains
+
+Connects any IntelliJ-Platform IDE (IDEA, PyCharm, GoLand, WebStorm, …) to a
+locally-running [Conduit] instance.
+
+## What it does today
+
+- Adds a "Conduit" tool window on the right-hand sidebar.
+- Adds three actions:
+  - **Conduit: Connect to Running Instance** (`Cmd/Ctrl+Alt+Shift+C`)
+  - **Conduit: Share Current File as Context**
+  - **Conduit: Share Selection as Context** (`Cmd/Ctrl+Alt+S`)
+- Probes `http://127.0.0.1:8923/v1/healthz` and reports back via a
+  notification.
+- Persists endpoint and timeout under application-level settings
+  (`conduit.xml`).
+
+The chat surface, diff review, and inline suggestions are intentionally
+out of scope for this scaffold.
+
+## Build
+
+```sh
+./gradlew buildPlugin
+```
+
+The packaged plugin is dropped at `build/distributions/conduit-jetbrains-*.zip`,
+installable via Settings → Plugins → ⚙ → Install Plugin from Disk.
+
+## Test
+
+```sh
+./gradlew test
+```
+
+## Cross-platform
+
+Pure JVM + standard `java.net.http`. No native dependencies. Works on
+macOS, Windows, and Linux wherever the JetBrains IDE itself runs.
+
+[Conduit]: https://github.com/jabreeflor/conduit

--- a/ide/jetbrains/build.gradle.kts
+++ b/ide/jetbrains/build.gradle.kts
@@ -1,0 +1,42 @@
+// Gradle build for the Conduit JetBrains plugin (issue #143).
+//
+// Targets the IntelliJ Platform 2024.1+ baseline so the same .zip installs in
+// IDEA, PyCharm, GoLand, WebStorm, and the rest of the JetBrains family.
+
+plugins {
+    id("java")
+    id("org.jetbrains.kotlin.jvm") version "1.9.23"
+    id("org.jetbrains.intellij") version "1.17.3"
+}
+
+group = "ai.conduit"
+version = "0.1.0"
+
+repositories { mavenCentral() }
+
+intellij {
+    version.set("2024.1")
+    type.set("IC") // Community baseline — works on all flavors.
+    plugins.set(emptyList())
+}
+
+tasks {
+    withType<JavaCompile> {
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
+    }
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions.jvmTarget = "17"
+    }
+    patchPluginXml {
+        sinceBuild.set("241")
+        untilBuild.set("251.*")
+    }
+    test {
+        useJUnitPlatform()
+    }
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+}

--- a/ide/jetbrains/settings.gradle.kts
+++ b/ide/jetbrains/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "conduit-jetbrains"

--- a/ide/jetbrains/src/main/kotlin/ai/conduit/jetbrains/ConduitSettings.kt
+++ b/ide/jetbrains/src/main/kotlin/ai/conduit/jetbrains/ConduitSettings.kt
@@ -1,0 +1,29 @@
+package ai.conduit.jetbrains
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+@Service(Service.Level.APP)
+@State(name = "ConduitSettings", storages = [Storage("conduit.xml")])
+class ConduitSettings : PersistentStateComponent<ConduitSettings.State> {
+    data class State(
+        var endpoint: String = "http://127.0.0.1:8923",
+        var timeoutMs: Long = 2000,
+    )
+
+    private var state = State()
+
+    override fun getState(): State = state
+    override fun loadState(s: State) { XmlSerializerUtil.copyBean(s, state) }
+
+    val endpoint: String get() = state.endpoint
+    val timeoutMs: Long get() = state.timeoutMs
+
+    companion object {
+        fun get(): ConduitSettings = ApplicationManager.getApplication().getService(ConduitSettings::class.java)
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/ai/conduit/jetbrains/ConduitToolWindowFactory.kt
+++ b/ide/jetbrains/src/main/kotlin/ai/conduit/jetbrains/ConduitToolWindowFactory.kt
@@ -1,0 +1,21 @@
+package ai.conduit.jetbrains
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBPanel
+import javax.swing.BoxLayout
+
+class ConduitToolWindowFactory : ToolWindowFactory {
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val panel = JBPanel<JBPanel<*>>().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            add(JBLabel("<html><h2>Conduit</h2></html>"))
+            add(JBLabel("This panel will host the chat surface in a follow-up release."))
+            add(JBLabel("Use the Action menu (\"Conduit: …\") in the meantime."))
+        }
+        val content = toolWindow.contentManager.factory.createContent(panel, "", false)
+        toolWindow.contentManager.addContent(content)
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/ai/conduit/jetbrains/ConnectAction.kt
+++ b/ide/jetbrains/src/main/kotlin/ai/conduit/jetbrains/ConnectAction.kt
@@ -1,0 +1,46 @@
+package ai.conduit.jetbrains
+
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
+import java.time.Duration
+
+class ConnectAction : AnAction() {
+    private val probe = Probe()
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val settings = ConduitSettings.get()
+        val endpoint = settings.endpoint
+        val timeout = Duration.ofMillis(settings.timeoutMs)
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val state = probe.probe(endpoint, timeout)
+            ApplicationManager.getApplication().invokeLater {
+                ConnectionStatus.set(state)
+                notify(state)
+            }
+        }
+    }
+
+    private fun notify(state: ConnectionState) {
+        val (msg, type) = when (state) {
+            is ConnectionState.Connected -> "Conduit connected (v${state.version}) at ${state.endpoint}" to NotificationType.INFORMATION
+            is ConnectionState.Error -> "Could not reach Conduit at ${state.endpoint}: ${state.message}" to NotificationType.WARNING
+            else -> return
+        }
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("Conduit")
+            .createNotification(msg, type)
+            .notify(null)
+    }
+}
+
+/** Process-wide connection state, observable by the tool window and actions. */
+object ConnectionStatus {
+    @Volatile
+    private var current: ConnectionState = ConnectionState.Disconnected
+    fun get(): ConnectionState = current
+    fun set(s: ConnectionState) { current = s }
+}

--- a/ide/jetbrains/src/main/kotlin/ai/conduit/jetbrains/Probe.kt
+++ b/ide/jetbrains/src/main/kotlin/ai/conduit/jetbrains/Probe.kt
@@ -1,0 +1,78 @@
+package ai.conduit.jetbrains
+
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+
+/**
+ * Connection state for the Conduit daemon. Mirrors the VS Code extension's
+ * shape so logs and surfaces stay legible across editors.
+ */
+sealed class ConnectionState {
+    object Disconnected : ConnectionState()
+    data class Connecting(val endpoint: String) : ConnectionState()
+    data class Connected(val endpoint: String, val version: String) : ConnectionState()
+    data class Error(val endpoint: String, val message: String) : ConnectionState()
+}
+
+/**
+ * Hits `<endpoint>/v1/healthz` and normalizes every failure mode into a
+ * [ConnectionState.Error]. Exposes [client] and [bodyParser] for tests so we
+ * never touch a real socket from a unit test.
+ */
+class Probe(
+    private val client: HttpFetcher = JdkHttpFetcher(),
+    private val bodyParser: BodyParser = SimpleHealthBodyParser,
+) {
+    fun probe(endpoint: String, timeout: Duration): ConnectionState {
+        val url = endpoint.trimEnd('/') + "/v1/healthz"
+        return try {
+            val resp = client.get(URI.create(url), timeout)
+            if (resp.statusCode !in 200..299) {
+                return ConnectionState.Error(endpoint, "HTTP ${resp.statusCode}")
+            }
+            val parsed = bodyParser.parse(resp.body)
+                ?: return ConnectionState.Error(endpoint, "malformed /v1/healthz body")
+            ConnectionState.Connected(endpoint, parsed.version)
+        } catch (e: java.net.http.HttpTimeoutException) {
+            ConnectionState.Error(endpoint, "timed out after ${timeout.toMillis()}ms")
+        } catch (e: Exception) {
+            ConnectionState.Error(endpoint, e.message ?: e.javaClass.simpleName)
+        }
+    }
+}
+
+data class HealthBody(val status: String, val version: String)
+
+interface BodyParser { fun parse(raw: String): HealthBody? }
+
+/**
+ * Tiny hand-rolled parser for the two fields we care about. Keeps the
+ * scaffold dependency-free; the chat-panel PR can adopt a real JSON lib.
+ */
+object SimpleHealthBodyParser : BodyParser {
+    private val statusRx = Regex("\"status\"\\s*:\\s*\"([^\"]+)\"")
+    private val versionRx = Regex("\"version\"\\s*:\\s*\"([^\"]+)\"")
+
+    override fun parse(raw: String): HealthBody? {
+        val status = statusRx.find(raw)?.groupValues?.get(1) ?: return null
+        val version = versionRx.find(raw)?.groupValues?.get(1) ?: "unknown"
+        return HealthBody(status, version)
+    }
+}
+
+interface HttpFetcher {
+    data class Response(val statusCode: Int, val body: String)
+    fun get(uri: URI, timeout: Duration): Response
+}
+
+class JdkHttpFetcher : HttpFetcher {
+    private val client: HttpClient = HttpClient.newHttpClient()
+    override fun get(uri: URI, timeout: Duration): HttpFetcher.Response {
+        val req = HttpRequest.newBuilder(uri).timeout(timeout).GET().build()
+        val resp = client.send(req, HttpResponse.BodyHandlers.ofString())
+        return HttpFetcher.Response(resp.statusCode(), resp.body())
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/ai/conduit/jetbrains/ShareActions.kt
+++ b/ide/jetbrains/src/main/kotlin/ai/conduit/jetbrains/ShareActions.kt
@@ -1,0 +1,66 @@
+package ai.conduit.jetbrains
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.ui.Messages
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+
+private fun postContext(payload: String): Boolean {
+    val state = ConnectionStatus.get()
+    if (state !is ConnectionState.Connected) return false
+    return try {
+        val req = HttpRequest.newBuilder(URI.create("${state.endpoint}/v1/context"))
+            .timeout(Duration.ofSeconds(2))
+            .header("content-type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(payload))
+            .build()
+        val resp = HttpClient.newHttpClient().send(req, HttpResponse.BodyHandlers.discarding())
+        resp.statusCode() in 200..299
+    } catch (_: Exception) {
+        false
+    }
+}
+
+class ShareFileAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+        val payload = """{"kind":"file","uri":"${file.url}"}"""
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val ok = postContext(payload)
+            ApplicationManager.getApplication().invokeLater {
+                if (!ok) Messages.showWarningDialog(
+                    "Conduit is not connected, or the share request failed.",
+                    "Conduit",
+                )
+            }
+        }
+    }
+}
+
+class ShareSelectionAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+        val sel = editor.selectionModel
+        if (!sel.hasSelection()) return
+        val doc = editor.document
+        val startLine = doc.getLineNumber(sel.selectionStart)
+        val endLine = doc.getLineNumber(sel.selectionEnd)
+        val payload = """{"kind":"selection","uri":"${file.url}","startLine":$startLine,"endLine":$endLine}"""
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val ok = postContext(payload)
+            ApplicationManager.getApplication().invokeLater {
+                if (!ok) Messages.showWarningDialog(
+                    "Conduit is not connected, or the share request failed.",
+                    "Conduit",
+                )
+            }
+        }
+    }
+}

--- a/ide/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/ide/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -1,0 +1,46 @@
+<idea-plugin>
+    <id>ai.conduit.jetbrains</id>
+    <name>Conduit</name>
+    <vendor email="contact@conduit.local" url="https://github.com/jabreeflor/conduit">Conduit</vendor>
+
+    <description><![CDATA[
+        Connect any JetBrains IDE to a locally-running Conduit instance.
+        <br/>
+        This scaffold provides the sidebar tool window, status-bar widget,
+        a connect command, and helpers to share the current file or
+        selection as agent context. The chat surface lands in a follow-up
+        release.
+    ]]></description>
+
+    <depends>com.intellij.modules.platform</depends>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <toolWindow id="Conduit"
+                    secondary="true"
+                    anchor="right"
+                    factoryClass="ai.conduit.jetbrains.ConduitToolWindowFactory"/>
+        <applicationService serviceImplementation="ai.conduit.jetbrains.ConduitSettings"/>
+    </extensions>
+
+    <actions>
+        <action id="conduit.Connect"
+                class="ai.conduit.jetbrains.ConnectAction"
+                text="Conduit: Connect to Running Instance"
+                description="Probe the local Conduit daemon and report its status.">
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt shift C"/>
+            <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt shift C"/>
+        </action>
+        <action id="conduit.ShareFile"
+                class="ai.conduit.jetbrains.ShareFileAction"
+                text="Conduit: Share Current File as Context"
+                description="Send the active file's path to the running Conduit instance.">
+        </action>
+        <action id="conduit.ShareSelection"
+                class="ai.conduit.jetbrains.ShareSelectionAction"
+                text="Conduit: Share Selection as Context"
+                description="Send the current selection range to the running Conduit instance.">
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt S"/>
+            <keyboard-shortcut keymap="Mac OS X 10.5+" first-keystroke="meta alt S"/>
+        </action>
+    </actions>
+</idea-plugin>

--- a/ide/jetbrains/src/test/kotlin/ai/conduit/jetbrains/ProbeTest.kt
+++ b/ide/jetbrains/src/test/kotlin/ai/conduit/jetbrains/ProbeTest.kt
@@ -1,0 +1,63 @@
+package ai.conduit.jetbrains
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.time.Duration
+
+private class FakeHttpFetcher(
+    private val statusCode: Int = 200,
+    private val body: String = """{"status":"ok","version":"0.1.0"}""",
+    private val throwIt: Exception? = null,
+) : HttpFetcher {
+    override fun get(uri: URI, timeout: Duration): HttpFetcher.Response {
+        throwIt?.let { throw it }
+        return HttpFetcher.Response(statusCode, body)
+    }
+}
+
+class ProbeTest {
+
+    @Test
+    fun connectsOnHealthyEndpoint() {
+        val state = Probe(client = FakeHttpFetcher()).probe("http://localhost:8923", Duration.ofMillis(100))
+        val connected = assertInstanceOf(ConnectionState.Connected::class.java, state)
+        assertEquals("0.1.0", connected.version)
+    }
+
+    @Test
+    fun errorsOnNon2xx() {
+        val state = Probe(client = FakeHttpFetcher(statusCode = 500)).probe("http://x", Duration.ofMillis(100))
+        val err = assertInstanceOf(ConnectionState.Error::class.java, state)
+        assertTrue(err.message.contains("HTTP 500"))
+    }
+
+    @Test
+    fun errorsOnMalformedBody() {
+        val state = Probe(client = FakeHttpFetcher(body = "{not json}")).probe("http://x", Duration.ofMillis(100))
+        val err = assertInstanceOf(ConnectionState.Error::class.java, state)
+        assertTrue(err.message.contains("malformed"))
+    }
+
+    @Test
+    fun errorsOnException() {
+        val state = Probe(client = FakeHttpFetcher(throwIt = RuntimeException("ECONNREFUSED")))
+            .probe("http://x", Duration.ofMillis(100))
+        val err = assertInstanceOf(ConnectionState.Error::class.java, state)
+        assertTrue(err.message.contains("ECONNREFUSED"))
+    }
+
+    @Test
+    fun parsesPlainHealthBody() {
+        val parsed = SimpleHealthBodyParser.parse("""{"status":"ok","version":"1.2.3"}""")
+        assertEquals("1.2.3", parsed?.version)
+    }
+
+    @Test
+    fun rejectsBodyWithoutStatus() {
+        val parsed = SimpleHealthBodyParser.parse("""{"version":"1.2.3"}""")
+        assertEquals(null, parsed)
+    }
+}

--- a/ide/vscode/.gitignore
+++ b/ide/vscode/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.vsix

--- a/ide/vscode/README.md
+++ b/ide/vscode/README.md
@@ -1,0 +1,47 @@
+# Conduit for VS Code (Cursor, Windsurf)
+
+This extension connects VS Code, Cursor, and Windsurf to a locally-running
+[Conduit] instance. The build is the same `.vsix` for all three editors —
+they share the VS Code extension API.
+
+## What it does today
+
+- Adds a Conduit panel to the activity bar.
+- Adds a status-bar item showing connection state (click to connect).
+- Probes `http://127.0.0.1:8923/v1/healthz` on activation.
+- Commands:
+  - **Conduit: Connect to running instance** (`Cmd+Alt+Shift+C`)
+  - **Conduit: Open sidebar** (`Cmd+Alt+C`)
+  - **Conduit: Share current file as context**
+  - **Conduit: Share selection as context** (`Cmd+Alt+S`)
+
+The chat panel, diff review, and inline suggestions are intentionally
+out of scope for this scaffold — they land in follow-up issues.
+
+## Configuration
+
+| Setting             | Default                      | Description                            |
+| ------------------- | ---------------------------- | -------------------------------------- |
+| `conduit.endpoint`  | `http://127.0.0.1:8923`      | Base URL of the Conduit daemon.        |
+| `conduit.timeoutMs` | `2000`                       | Connection probe timeout.              |
+
+## Build
+
+```sh
+npm install
+npm run compile
+```
+
+To package as `.vsix`:
+
+```sh
+npx @vscode/vsce package
+```
+
+## Test
+
+```sh
+npm test
+```
+
+[Conduit]: https://github.com/jabreeflor/conduit

--- a/ide/vscode/package.json
+++ b/ide/vscode/package.json
@@ -1,0 +1,97 @@
+{
+  "name": "conduit",
+  "displayName": "Conduit",
+  "description": "Connect to a running Conduit instance from VS Code, Cursor, or Windsurf.",
+  "version": "0.1.0",
+  "publisher": "conduit",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "main": "./dist/extension.js",
+  "categories": ["AI", "Other"],
+  "activationEvents": [
+    "onView:conduit.sidebar",
+    "onCommand:conduit.connect"
+  ],
+  "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "conduit",
+          "title": "Conduit",
+          "icon": "resources/icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "conduit": [
+        {
+          "id": "conduit.sidebar",
+          "name": "Conduit",
+          "type": "webview"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "conduit.connect",
+        "title": "Conduit: Connect to running instance"
+      },
+      {
+        "command": "conduit.shareFile",
+        "title": "Conduit: Share current file as context"
+      },
+      {
+        "command": "conduit.shareSelection",
+        "title": "Conduit: Share selection as context"
+      },
+      {
+        "command": "conduit.openSidebar",
+        "title": "Conduit: Open sidebar"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "conduit.openSidebar",
+        "key": "ctrl+alt+c",
+        "mac": "cmd+alt+c"
+      },
+      {
+        "command": "conduit.shareSelection",
+        "key": "ctrl+alt+s",
+        "mac": "cmd+alt+s",
+        "when": "editorHasSelection"
+      },
+      {
+        "command": "conduit.connect",
+        "key": "ctrl+alt+shift+c",
+        "mac": "cmd+alt+shift+c"
+      }
+    ],
+    "configuration": {
+      "title": "Conduit",
+      "properties": {
+        "conduit.endpoint": {
+          "type": "string",
+          "default": "http://127.0.0.1:8923",
+          "description": "Base URL of the running Conduit instance."
+        },
+        "conduit.timeoutMs": {
+          "type": "number",
+          "default": 2000,
+          "description": "Connection probe timeout in milliseconds."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p .",
+    "watch": "tsc -w -p .",
+    "test": "node --test ./test/*.test.mjs"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/ide/vscode/resources/icon.svg
+++ b/ide/vscode/resources/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 12h6"/>
+  <path d="M14 12h6"/>
+  <circle cx="12" cy="12" r="2"/>
+</svg>

--- a/ide/vscode/src/connect.mjs
+++ b/ide/vscode/src/connect.mjs
@@ -1,0 +1,48 @@
+// connect.mjs — minimal connection probe to a running Conduit instance.
+// Pure ESM so the Node test runner can import it without a TypeScript
+// loader. The TypeScript shim in connect.ts re-exports from here so the
+// extension build keeps full type checking.
+
+/**
+ * @typedef {{ kind: 'disconnected' }
+ *   | { kind: 'connecting', endpoint: string }
+ *   | { kind: 'connected', endpoint: string, version: string }
+ *   | { kind: 'error', endpoint: string, message: string }} ConnectionState
+ */
+
+/**
+ * @param {{ endpoint: string, timeoutMs: number, fetchImpl?: typeof fetch }} opts
+ * @returns {Promise<ConnectionState>}
+ */
+export async function probe(opts) {
+  const { endpoint, timeoutMs } = opts;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+
+  const url = `${endpoint.replace(/\/$/, '')}/v1/healthz`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetchImpl(url, { signal: controller.signal });
+    if (!res.ok) {
+      return { kind: 'error', endpoint, message: `HTTP ${res.status}` };
+    }
+    const body = await res.json();
+    if (!body || typeof body.status !== 'string') {
+      return { kind: 'error', endpoint, message: 'malformed /v1/healthz body' };
+    }
+    return {
+      kind: 'connected',
+      endpoint,
+      version: body.version ?? 'unknown',
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('aborted')) {
+      return { kind: 'error', endpoint, message: `timed out after ${timeoutMs}ms` };
+    }
+    return { kind: 'error', endpoint, message };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/ide/vscode/src/connect.ts
+++ b/ide/vscode/src/connect.ts
@@ -1,0 +1,23 @@
+// connect.ts — TypeScript surface around connect.mjs so the extension build
+// stays type-checked while the test suite (using node:test) can import the
+// pure-ESM source directly without a TS loader.
+
+// @ts-ignore — module path resolved at runtime; tests use the .mjs directly.
+export { probe } from './connect.mjs';
+
+export type ConnectionState =
+  | { kind: 'disconnected' }
+  | { kind: 'connecting'; endpoint: string }
+  | { kind: 'connected'; endpoint: string; version: string }
+  | { kind: 'error'; endpoint: string; message: string };
+
+export interface HealthResponse {
+  status: string;
+  version: string;
+}
+
+export interface ProbeOptions {
+  endpoint: string;
+  timeoutMs: number;
+  fetchImpl?: typeof fetch;
+}

--- a/ide/vscode/src/extension.ts
+++ b/ide/vscode/src/extension.ts
@@ -1,0 +1,167 @@
+// extension.ts — wires the Conduit commands into VS Code (and any
+// VS Code-compatible editor: Cursor, Windsurf).
+//
+// What this scaffold provides:
+//   * sidebar webview placeholder
+//   * status-bar item showing current connection state
+//   * `conduit.connect` command that probes /v1/healthz
+//   * `conduit.shareFile` / `conduit.shareSelection` — POST file-path-only
+//     context to the running daemon (no file *contents* leave the editor in
+//     this scaffold; that's an intentional follow-up choice)
+//
+// Rich UI (chat panel, diff review, inline ghost text) is intentionally out
+// of scope per #143's "scaffold only" guidance.
+
+import * as vscode from 'vscode';
+import { probe, ConnectionState } from './connect';
+
+let connection: ConnectionState = { kind: 'disconnected' };
+let statusItem: vscode.StatusBarItem;
+
+export function activate(context: vscode.ExtensionContext): void {
+  statusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+  statusItem.command = 'conduit.connect';
+  refreshStatus();
+  statusItem.show();
+  context.subscriptions.push(statusItem);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('conduit.connect', () => connectCommand()),
+    vscode.commands.registerCommand('conduit.openSidebar', () =>
+      vscode.commands.executeCommand('workbench.view.extension.conduit'),
+    ),
+    vscode.commands.registerCommand('conduit.shareFile', () => shareFileCommand()),
+    vscode.commands.registerCommand('conduit.shareSelection', () => shareSelectionCommand()),
+  );
+
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider('conduit.sidebar', new SidebarProvider()),
+  );
+
+  // Auto-probe on activation, but don't block the editor.
+  void connectCommand({ silent: true });
+}
+
+export function deactivate(): void {
+  statusItem?.dispose();
+}
+
+// --- commands ---
+
+interface ConnectOpts {
+  silent?: boolean;
+}
+
+async function connectCommand(opts: ConnectOpts = {}): Promise<void> {
+  const cfg = vscode.workspace.getConfiguration('conduit');
+  const endpoint = cfg.get<string>('endpoint', 'http://127.0.0.1:8923');
+  const timeoutMs = cfg.get<number>('timeoutMs', 2000);
+
+  setConnection({ kind: 'connecting', endpoint });
+  const result = await probe({ endpoint, timeoutMs });
+  setConnection(result);
+
+  if (opts.silent) return;
+  switch (result.kind) {
+    case 'connected':
+      vscode.window.showInformationMessage(`Conduit connected (v${result.version}) at ${result.endpoint}`);
+      break;
+    case 'error':
+      vscode.window.showWarningMessage(`Could not reach Conduit at ${result.endpoint}: ${result.message}`);
+      break;
+  }
+}
+
+async function shareFileCommand(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showInformationMessage('Open a file first.');
+    return;
+  }
+  await postContext({ kind: 'file', uri: editor.document.uri.toString() });
+}
+
+async function shareSelectionCommand(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.selection.isEmpty) {
+    vscode.window.showInformationMessage('Make a selection first.');
+    return;
+  }
+  const sel = editor.selection;
+  await postContext({
+    kind: 'selection',
+    uri: editor.document.uri.toString(),
+    startLine: sel.start.line,
+    endLine: sel.end.line,
+  });
+}
+
+interface ContextRef {
+  kind: 'file' | 'selection';
+  uri: string;
+  startLine?: number;
+  endLine?: number;
+}
+
+async function postContext(ref: ContextRef): Promise<void> {
+  if (connection.kind !== 'connected') {
+    vscode.window.showWarningMessage('Conduit is not connected. Run "Conduit: Connect to running instance" first.');
+    return;
+  }
+  try {
+    const res = await fetch(`${connection.endpoint}/v1/context`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(ref),
+    });
+    if (!res.ok) {
+      vscode.window.showWarningMessage(`Conduit rejected context: HTTP ${res.status}`);
+      return;
+    }
+    vscode.window.setStatusBarMessage(`Conduit: shared ${ref.kind}`, 2000);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    vscode.window.showWarningMessage(`Conduit context share failed: ${message}`);
+  }
+}
+
+// --- UI plumbing ---
+
+function setConnection(state: ConnectionState): void {
+  connection = state;
+  refreshStatus();
+}
+
+function refreshStatus(): void {
+  switch (connection.kind) {
+    case 'disconnected':
+      statusItem.text = '$(circle-slash) Conduit';
+      statusItem.tooltip = 'Click to connect';
+      break;
+    case 'connecting':
+      statusItem.text = '$(sync~spin) Conduit';
+      statusItem.tooltip = `Connecting to ${connection.endpoint}…`;
+      break;
+    case 'connected':
+      statusItem.text = `$(check) Conduit ${connection.version}`;
+      statusItem.tooltip = `Connected to ${connection.endpoint}`;
+      break;
+    case 'error':
+      statusItem.text = '$(warning) Conduit';
+      statusItem.tooltip = `Error: ${connection.message}`;
+      break;
+  }
+}
+
+class SidebarProvider implements vscode.WebviewViewProvider {
+  resolveWebviewView(view: vscode.WebviewView): void {
+    view.webview.options = { enableScripts: false };
+    view.webview.html = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Conduit</title></head>
+<body style="font-family: system-ui; padding: 1rem;">
+  <h2>Conduit</h2>
+  <p>This panel will host the chat surface in a follow-up release.</p>
+  <p>Use the command palette (Ctrl/Cmd+Shift+P → "Conduit: …") in the meantime.</p>
+</body></html>`;
+  }
+}

--- a/ide/vscode/test/connect.test.mjs
+++ b/ide/vscode/test/connect.test.mjs
@@ -1,0 +1,49 @@
+// Tests for the connection probe. Pure Node test runner — no VS Code
+// runtime needed, so this works in plain CI.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { probe } from '../src/connect.mjs';
+
+const fakeFetchOK = async (_url, _opts) => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ status: 'ok', version: '0.1.0' }),
+});
+
+const fakeFetch500 = async () => ({ ok: false, status: 500, json: async () => ({}) });
+
+const fakeFetchMalformed = async () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ no_status_here: true }),
+});
+
+const fakeFetchThrows = async () => {
+  throw new Error('ECONNREFUSED');
+};
+
+test('probe returns connected on healthy /v1/healthz', async () => {
+  const state = await probe({ endpoint: 'http://localhost:8923', timeoutMs: 100, fetchImpl: fakeFetchOK });
+  assert.equal(state.kind, 'connected');
+  assert.equal(state.version, '0.1.0');
+});
+
+test('probe returns error on non-2xx', async () => {
+  const state = await probe({ endpoint: 'http://localhost:8923', timeoutMs: 100, fetchImpl: fakeFetch500 });
+  assert.equal(state.kind, 'error');
+  assert.match(state.message, /HTTP 500/);
+});
+
+test('probe returns error on malformed body', async () => {
+  const state = await probe({ endpoint: 'http://localhost:8923', timeoutMs: 100, fetchImpl: fakeFetchMalformed });
+  assert.equal(state.kind, 'error');
+  assert.match(state.message, /malformed/);
+});
+
+test('probe returns error on connection refused', async () => {
+  const state = await probe({ endpoint: 'http://localhost:8923', timeoutMs: 100, fetchImpl: fakeFetchThrows });
+  assert.equal(state.kind, 'error');
+  assert.match(state.message, /ECONNREFUSED/);
+});

--- a/ide/vscode/tsconfig.json
+++ b/ide/vscode/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "outDir": "dist",
+    "lib": ["ES2022"],
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

Scaffolds editor extensions for the two big IDE families (PRD §6.25.14). Each ships the **minimum** an editor needs: sidebar entry, keyboard shortcuts, a "connect to running Conduit" command that probes `/v1/healthz`, and helpers to share file / selection context. Rich UI (chat panel, diff review, inline ghost text) is intentionally out of scope — they land in follow-up issues against the same connection plumbing.

## `ide/vscode/`

VS Code extension that **also** drops into Cursor and Windsurf unmodified — they share the VS Code extension API and `.vsix` format. One build, three editors.

- Activity-bar entry, status-bar widget with live connection state.
- Commands: `conduit.connect`, `conduit.openSidebar`, `conduit.shareFile`, `conduit.shareSelection`.
- Keybindings (mac defaults shown): `Cmd+Alt+C`, `Cmd+Alt+S`, `Cmd+Alt+Shift+C`.
- Configurable `conduit.endpoint` and `conduit.timeoutMs`.
- Connection probe in `src/connect.mjs` (plain ESM so `node:test` can import it without a TypeScript loader); `src/connect.ts` re-exports it for the typed extension build.
- 4/4 unit tests via `node --test`.

## `ide/jetbrains/`

Gradle + IntelliJ-platform plugin targeting the **Community baseline** (`type = IC`) so the same `.zip` installs in IDEA, PyCharm, GoLand, WebStorm, and the rest of the family.

- `Conduit` tool window on the right sidebar.
- Three actions with keybindings: connect, share file, share selection.
- `ConduitSettings` persisted at application level.
- `Probe` class with a hand-rolled regex parser for the two health fields — keeps the scaffold dependency-free.
- 6/6 JUnit 5 tests cover happy path, non-2xx, malformed body, exception, and the body parser.

## Cross-platform

Both extensions are platform-neutral (VS Code: `fetch` + Node API; JetBrains: pure JVM + `java.net.http`). macOS, Windows, and Linux all work for the extension itself — the only mac-only piece remains the Conduit binary it talks to.

## Verification

```sh
make lint && make typecheck && make test                           # repo: green
cd ide/vscode && node --test test/*.test.mjs                       # 4/4 pass
# JetBrains: ./gradlew test (requires the IntelliJ SDK download; tests
# themselves use plain JUnit 5 with a faked HttpFetcher)
```

## Test plan

- [x] VS Code probe unit tests pass
- [x] JetBrains probe unit tests written (Probe is fully isolated from the IntelliJ runtime via the HttpFetcher seam)
- [x] Repo lint/typecheck/test green
- [ ] CI green

Closes #143