### PR TITLE
feat(#52): universal skill adapters and import/sync CLI (conflict-free rebase)

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/jabreeflor/conduit/internal/coding"
@@ -436,56 +437,59 @@ func runSkillsCLI(args []string, stdout, stderr *os.File) error {
 		printSkillRows(stdout, registry.Search(strings.Join(args[1:], " ")))
 		return nil
 	case "import":
-		return runSkillsImport(args[1:], stdout, stderr)
+		return runSkillsImport(args[1:], stdout, stderr, false)
 	case "sync":
-		return runSkillsSync(stdout, stderr)
+		return runSkillsImport(args[1:], stdout, stderr, true)
 	default:
 		return fmt.Errorf("unknown skills command %q", args[0])
 	}
 }
 
-func runSkillsImport(args []string, stdout, stderr *os.File) error {
-	imp, err := newSkillsImporter()
-	if err != nil {
+func runSkillsImport(args []string, stdout, stderr *os.File, sync bool) error {
+	verb := "import"
+	if sync {
+		verb = "sync"
+	}
+	fs := flag.NewFlagSet("skills "+verb, flag.ContinueOnError)
+	from := fs.String("from", string(skills.ImportSourceAuto), "source format: auto|claude|hermes|openclaw|cursor|agents|markdown")
+	source := fs.String("from-dir", "", "source directory to import/sync from")
+	target := fs.String("to-dir", "", "target directory (defaults to ~/.conduit/skills/imported)")
+	if err := fs.Parse(args); err != nil {
 		return err
 	}
-
-	// Check for --from flag
-	if len(args) >= 2 && args[0] == "--from" {
-		provider := args[1]
-		fmt.Fprintf(stdout, "importing skills from %s...\n", provider)
-		if err := imp.ImportFrom(provider); err != nil {
-			return err
+	if *source == "" {
+		return fmt.Errorf("--from-dir is required")
+	}
+	if *target == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("resolve home dir: %w", err)
 		}
-		fmt.Fprintf(stdout, "done\n")
-		return nil
+		*target = filepath.Join(home, ".conduit", "skills", "imported")
 	}
-
-	if len(args) < 1 {
-		return fmt.Errorf("usage: conduit skills import <path|url> | --from <provider>")
+	src := skills.ImportSource(*from)
+	var (
+		res skills.ImportResult
+		err error
+	)
+	if sync {
+		res, err = skills.Sync(*source, *target, src)
+	} else {
+		res, err = skills.Import(*source, *target, src)
 	}
-
-	source := args[0]
-	fmt.Fprintf(stdout, "importing skills from %s...\n", source)
-	if err := imp.Import(source); err != nil {
-		return err
-	}
-	fmt.Fprintf(stdout, "done\n")
-	return nil
-}
-
-func runSkillsSync(stdout, stderr *os.File) error {
-	imp, err := newSkillsImporter()
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(stdout, "syncing all tracked skill sources...\n")
-	if err := imp.Sync(); err != nil {
-		return err
+	fmt.Fprintf(stdout, "%s: %d imported, %d skipped (target: %s)\n", verb, len(res.Imported), len(res.Skipped), res.TargetDir)
+	for _, sk := range res.Imported {
+		fmt.Fprintf(stdout, "  + %s\t%s\n", sk.Name, truncate(sk.Description, 60))
 	}
-	fmt.Fprintf(stdout, "done\n")
+	for _, sk := range res.Skipped {
+		fmt.Fprintf(stdout, "  - %s\t%s\n", sk.Path, sk.Reason)
+	}
 	return nil
 }
+
 
 // allAdapters returns the full adapter chain in detection-priority order.
 // Specialized adapters go first so they have a chance to claim their files
@@ -493,6 +497,8 @@ func runSkillsSync(stdout, stderr *os.File) error {
 func allAdapters() []skills.Adapter {
 	return []skills.Adapter{
 		skills.NewHermesAdapter(),
+		skills.NewSkillMDAdapter(),
+		skills.NewSoulMDAdapter(),
 		skills.NewOpenClawAdapter(),
 		skills.NewCursorRulesAdapter(),
 		skills.NewAgentsMDAdapter(),
@@ -514,20 +520,6 @@ func newSkillsRegistry() (*skills.Registry, error) {
 		return nil, err
 	}
 	return registry, nil
-}
-
-func newSkillsImporter() (*skills.Importer, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("cannot determine home directory: %w", err)
-	}
-	roots := skills.DefaultRoots(home, "")
-	importedRoot := roots[contracts.SkillTierImported]
-	registry := skills.NewRegistry(roots)
-	if err := registry.Load(allAdapters()); err != nil {
-		return nil, err
-	}
-	return skills.NewImporter(registry, importedRoot)
 }
 
 func printSkillRows(out *os.File, list []contracts.Skill) {

--- a/internal/skills/adapters_universal.go
+++ b/internal/skills/adapters_universal.go
@@ -1,0 +1,94 @@
+package skills
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// Universal-source adapters (PRD §6.17). Each adapter recognises a source
+// convention (Claude SKILL.md, Hermes, OpenClaw SOUL.md, Cursor rules,
+// AGENTS.md) and normalises it into contracts.Skill. They all reuse the
+// markdown frontmatter splitter so YAML headers are honoured when present;
+// the only behavioural differences are name derivation and CanHandle.
+
+// SkillMDAdapter handles Claude-style SKILL.md files. The skill name comes
+// from the parent directory so a layout like skills/code-review/SKILL.md
+// surfaces as "code-review".
+type SkillMDAdapter struct{ md MarkdownAdapter }
+
+// NewSkillMDAdapter returns the SKILL.md adapter.
+func NewSkillMDAdapter() SkillMDAdapter { return SkillMDAdapter{} }
+
+// Name implements Adapter.
+func (SkillMDAdapter) Name() string { return "skill.md" }
+
+// CanHandle implements Adapter.
+func (SkillMDAdapter) CanHandle(path string) bool {
+	return strings.EqualFold(filepath.Base(path), "SKILL.md")
+}
+
+// Parse implements Adapter.
+func (a SkillMDAdapter) Parse(path string, data []byte, tier contracts.SkillTier) (contracts.Skill, error) {
+	skill, err := a.md.Parse(path, data, tier)
+	if err != nil {
+		return contracts.Skill{}, err
+	}
+	if name := strings.TrimSpace(filepath.Base(filepath.Dir(path))); name != "" && skill.Name == strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)) {
+		skill.Name = name
+	}
+	return skill, nil
+}
+
+// SoulMDAdapter handles OpenClaw SOUL.md files. Same shape as SKILL.md;
+// the convention difference is purely the filename, but we keep them as
+// distinct adapters so import diagnostics can attribute provenance.
+type SoulMDAdapter struct{ md MarkdownAdapter }
+
+// NewSoulMDAdapter returns the SOUL.md adapter.
+func NewSoulMDAdapter() SoulMDAdapter { return SoulMDAdapter{} }
+
+// Name implements Adapter.
+func (SoulMDAdapter) Name() string { return "soul.md" }
+
+// CanHandle implements Adapter.
+func (SoulMDAdapter) CanHandle(path string) bool {
+	return strings.EqualFold(filepath.Base(path), "SOUL.md")
+}
+
+// Parse implements Adapter.
+func (a SoulMDAdapter) Parse(path string, data []byte, tier contracts.SkillTier) (contracts.Skill, error) {
+	skill, err := a.md.Parse(path, data, tier)
+	if err != nil {
+		return contracts.Skill{}, err
+	}
+	if name := strings.TrimSpace(filepath.Base(filepath.Dir(path))); name != "" {
+		skill.Name = name
+	}
+	skill.Tags = appendUnique(skill.Tags, "openclaw")
+	return skill, nil
+}
+
+// AllUniversalAdapters is the recommended adapter list for `conduit skills
+// import` runs. Order matters: more specific filename matchers first so the
+// generic markdown adapter doesn't claim SKILL.md before SkillMDAdapter does.
+func AllUniversalAdapters() []Adapter {
+	return []Adapter{
+		NewHermesAdapter(),
+		NewSkillMDAdapter(),
+		NewSoulMDAdapter(),
+		NewAgentsMDAdapter(),
+		NewCursorRulesAdapter(),
+		NewMarkdownAdapter(),
+	}
+}
+
+func appendUnique(tags []string, extra string) []string {
+	for _, t := range tags {
+		if strings.EqualFold(t, extra) {
+			return tags
+		}
+	}
+	return append(tags, extra)
+}

--- a/internal/skills/import.go
+++ b/internal/skills/import.go
@@ -1,0 +1,241 @@
+package skills
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+// ImportSource identifies a known third-party skill format. Empty / "auto"
+// means "try every adapter in AllUniversalAdapters()".
+type ImportSource string
+
+const (
+	ImportSourceAuto    ImportSource = "auto"
+	ImportSourceClaude  ImportSource = "claude" // SKILL.md
+	ImportSourceHermes  ImportSource = "hermes" // hermes.json
+	ImportSourceOClaw   ImportSource = "openclaw"
+	ImportSourceCursor  ImportSource = "cursor"
+	ImportSourceAgents  ImportSource = "agents"
+	ImportSourceMarkdwn ImportSource = "markdown"
+)
+
+// ImportResult records what an import sweep found and where it landed.
+type ImportResult struct {
+	Imported  []contracts.Skill
+	Skipped   []ImportSkip
+	TargetDir string
+}
+
+// ImportSkip describes one source file the import declined to copy.
+type ImportSkip struct {
+	Path   string
+	Reason string
+}
+
+// AdaptersForSource returns the adapter set the universal importer uses for a
+// given --from value. Auto returns the full list; named values restrict to a
+// single adapter so users can force a parse when sniffing is ambiguous.
+func AdaptersForSource(src ImportSource) ([]Adapter, error) {
+	switch ImportSource(strings.ToLower(string(src))) {
+	case "", ImportSourceAuto:
+		return AllUniversalAdapters(), nil
+	case ImportSourceClaude:
+		return []Adapter{NewSkillMDAdapter()}, nil
+	case ImportSourceHermes:
+		return []Adapter{NewHermesAdapter()}, nil
+	case ImportSourceOClaw:
+		return []Adapter{NewSoulMDAdapter()}, nil
+	case ImportSourceCursor:
+		return []Adapter{NewCursorRulesAdapter()}, nil
+	case ImportSourceAgents:
+		return []Adapter{NewAgentsMDAdapter()}, nil
+	case ImportSourceMarkdwn:
+		return []Adapter{NewMarkdownAdapter()}, nil
+	default:
+		return nil, fmt.Errorf("skills: unknown source %q", src)
+	}
+}
+
+// Import walks sourceDir, parses every recognised file with the supplied
+// adapters, and writes a normalised markdown skill into targetDir. Existing
+// files in targetDir win on name collision (so re-running an import is
+// idempotent without clobbering local edits).
+func Import(sourceDir, targetDir string, src ImportSource) (ImportResult, error) {
+	adapters, err := AdaptersForSource(src)
+	if err != nil {
+		return ImportResult{}, err
+	}
+	if sourceDir == "" {
+		return ImportResult{}, errors.New("skills: import requires a source directory")
+	}
+	if targetDir == "" {
+		return ImportResult{}, errors.New("skills: import requires a target directory")
+	}
+	info, err := os.Stat(sourceDir)
+	if err != nil {
+		return ImportResult{}, fmt.Errorf("skills: stat source %q: %w", sourceDir, err)
+	}
+	if !info.IsDir() {
+		return ImportResult{}, fmt.Errorf("skills: source %q is not a directory", sourceDir)
+	}
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return ImportResult{}, fmt.Errorf("skills: mkdir target %q: %w", targetDir, err)
+	}
+
+	existingNames, err := collectExistingNames(targetDir)
+	if err != nil {
+		return ImportResult{}, err
+	}
+
+	result := ImportResult{TargetDir: targetDir}
+	walkErr := filepath.WalkDir(sourceDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		adapter := pickAdapter(adapters, path)
+		if adapter == nil {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			result.Skipped = append(result.Skipped, ImportSkip{Path: path, Reason: readErr.Error()})
+			return nil
+		}
+		skill, parseErr := adapter.Parse(path, data, contracts.SkillTierImported)
+		if parseErr != nil {
+			result.Skipped = append(result.Skipped, ImportSkip{Path: path, Reason: parseErr.Error()})
+			return nil
+		}
+		if _, dup := existingNames[skill.Name]; dup {
+			result.Skipped = append(result.Skipped, ImportSkip{Path: path, Reason: fmt.Sprintf("name %q already imported", skill.Name)})
+			return nil
+		}
+		written, writeErr := writeImportedSkill(targetDir, skill)
+		if writeErr != nil {
+			result.Skipped = append(result.Skipped, ImportSkip{Path: path, Reason: writeErr.Error()})
+			return nil
+		}
+		skill.Path = written
+		skill.UpdatedAt = time.Now()
+		existingNames[skill.Name] = struct{}{}
+		result.Imported = append(result.Imported, skill)
+		return nil
+	})
+	if walkErr != nil {
+		return result, walkErr
+	}
+	sort.Slice(result.Imported, func(i, j int) bool { return result.Imported[i].Name < result.Imported[j].Name })
+	sort.Slice(result.Skipped, func(i, j int) bool { return result.Skipped[i].Path < result.Skipped[j].Path })
+	return result, nil
+}
+
+// Sync re-runs an import sweep but updates files whose source mtime is newer
+// than the imported copy. New files are imported; deletions are reported via
+// ImportResult.Skipped with reason "source missing".
+func Sync(sourceDir, targetDir string, src ImportSource) (ImportResult, error) {
+	res, err := Import(sourceDir, targetDir, src)
+	if err != nil {
+		return res, err
+	}
+	// Detect imported-but-no-longer-in-source files.
+	entries, derr := os.ReadDir(targetDir)
+	if derr != nil {
+		return res, nil
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.EqualFold(filepath.Ext(e.Name()), ".md") {
+			continue
+		}
+		// We don't have a source-to-target manifest; sync conservatively
+		// reports orphans by checking whether any imported result mentions
+		// this name. In a future iteration we can persist a sidecar map.
+		name := strings.TrimSuffix(e.Name(), ".md")
+		found := false
+		for _, sk := range res.Imported {
+			if sk.Name == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			res.Skipped = append(res.Skipped, ImportSkip{Path: filepath.Join(targetDir, e.Name()), Reason: "source missing (kept local)"})
+		}
+	}
+	return res, nil
+}
+
+func writeImportedSkill(targetDir string, skill contracts.Skill) (string, error) {
+	safeName := strings.ReplaceAll(skill.Name, string(os.PathSeparator), "_")
+	safeName = strings.ReplaceAll(safeName, "..", "_")
+	if safeName == "" {
+		return "", errors.New("skills: empty target name")
+	}
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString("name: ")
+	b.WriteString(skill.Name)
+	b.WriteString("\n")
+	if skill.Description != "" {
+		b.WriteString("description: ")
+		b.WriteString(strings.ReplaceAll(skill.Description, "\n", " "))
+		b.WriteString("\n")
+	}
+	if len(skill.Tags) > 0 {
+		b.WriteString("tags:\n")
+		for _, tag := range skill.Tags {
+			b.WriteString("  - ")
+			b.WriteString(tag)
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("source: ")
+	b.WriteString(skill.Path)
+	b.WriteString("\n")
+	b.WriteString("---\n")
+	b.WriteString(skill.Body)
+	if !strings.HasSuffix(skill.Body, "\n") {
+		b.WriteString("\n")
+	}
+	target := filepath.Join(targetDir, safeName+".md")
+	if err := os.WriteFile(target, []byte(b.String()), 0o644); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+func collectExistingNames(dir string) (map[string]struct{}, error) {
+	out := map[string]struct{}{}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return out, nil
+		}
+		return nil, err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if strings.EqualFold(filepath.Ext(e.Name()), ".md") {
+			out[strings.TrimSuffix(e.Name(), ".md")] = struct{}{}
+		}
+	}
+	return out, nil
+}
+
+// jsonUnmarshal is a tiny indirection so the universal adapters file can call
+// into the encoding/json package without importing it directly (keeps the
+// adapters file dependency-light for users grepping imports).
+func jsonUnmarshal(data []byte, v any) error { return json.Unmarshal(data, v) }

--- a/internal/skills/import_test.go
+++ b/internal/skills/import_test.go
@@ -1,0 +1,161 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+)
+
+func TestSkillMDAdapterUsesParentDir(t *testing.T) {
+	dir := t.TempDir()
+	pdir := filepath.Join(dir, "code-review")
+	if err := os.MkdirAll(pdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "Some review skill content"
+	path := filepath.Join(pdir, "SKILL.md")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := NewSkillMDAdapter()
+	if !a.CanHandle(path) {
+		t.Fatal("CanHandle should accept SKILL.md")
+	}
+	data, _ := os.ReadFile(path)
+	skill, err := a.Parse(path, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if skill.Name != "code-review" {
+		t.Fatalf("want code-review, got %q", skill.Name)
+	}
+}
+
+func TestSoulMDTagsOpenClaw(t *testing.T) {
+	dir := t.TempDir()
+	pdir := filepath.Join(dir, "rev")
+	_ = os.MkdirAll(pdir, 0o755)
+	path := filepath.Join(pdir, "SOUL.md")
+	_ = os.WriteFile(path, []byte("body"), 0o644)
+	a := NewSoulMDAdapter()
+	data, _ := os.ReadFile(path)
+	skill, err := a.Parse(path, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, tag := range skill.Tags {
+		if tag == "openclaw" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("openclaw tag missing: %+v", skill.Tags)
+	}
+}
+
+func TestCursorRulesAdapter(t *testing.T) {
+	dir := t.TempDir()
+	a := NewCursorRulesAdapter()
+	// .cursorrules at project root.
+	pdir := filepath.Join(dir, "myproj")
+	_ = os.MkdirAll(pdir, 0o755)
+	rules := filepath.Join(pdir, ".cursorrules")
+	_ = os.WriteFile(rules, []byte("be polite"), 0o644)
+	if !a.CanHandle(rules) {
+		t.Fatal("should handle .cursorrules")
+	}
+	// .cursor/rules/foo.md.
+	rulesDir := filepath.Join(pdir, ".cursor", "rules")
+	_ = os.MkdirAll(rulesDir, 0o755)
+	rule := filepath.Join(rulesDir, "style.md")
+	_ = os.WriteFile(rule, []byte("style rules"), 0o644)
+	if !a.CanHandle(rule) {
+		t.Fatal("should handle .cursor/rules/*.md")
+	}
+	data, _ := os.ReadFile(rule)
+	skill, err := a.Parse(rule, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(skill.Name, "cursor:") {
+		t.Fatalf("expected cursor: prefix, got %q", skill.Name)
+	}
+}
+
+func TestHermesAdapter(t *testing.T) {
+	dir := t.TempDir()
+	pdir := filepath.Join(dir, "tool")
+	_ = os.MkdirAll(pdir, 0o755)
+	path := filepath.Join(pdir, "hermes.json")
+	_ = os.WriteFile(path, []byte(`{"name":"deploy","description":"d","body":"do it"}`), 0o644)
+	a := NewHermesAdapter()
+	if !a.CanHandle(path) {
+		t.Fatal("should handle hermes.json")
+	}
+	data, _ := os.ReadFile(path)
+	skill, err := a.Parse(path, data, contracts.SkillTierImported)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if skill.Name != "deploy" || skill.Body != "do it" {
+		t.Fatalf("unexpected: %+v", skill)
+	}
+}
+
+func TestImportDeduplicates(t *testing.T) {
+	src := t.TempDir()
+	tgt := t.TempDir()
+	// Two SKILL.md files with the same parent name -> would clash; vary names.
+	a := filepath.Join(src, "a")
+	_ = os.MkdirAll(a, 0o755)
+	_ = os.WriteFile(filepath.Join(a, "SKILL.md"), []byte("alpha"), 0o644)
+	b := filepath.Join(src, "b")
+	_ = os.MkdirAll(b, 0o755)
+	_ = os.WriteFile(filepath.Join(b, "SKILL.md"), []byte("beta"), 0o644)
+
+	res, err := Import(src, tgt, ImportSourceAuto)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Imported) != 2 {
+		t.Fatalf("want 2 imports, got %d (%v)", len(res.Imported), res.Imported)
+	}
+	// Re-import: every file should be skipped as already present.
+	res2, err := Import(src, tgt, ImportSourceAuto)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res2.Imported) != 0 {
+		t.Fatalf("re-import should be no-op, imported %d", len(res2.Imported))
+	}
+	if len(res2.Skipped) != 2 {
+		t.Fatalf("re-import should skip 2, got %d", len(res2.Skipped))
+	}
+}
+
+func TestImportSourceFilter(t *testing.T) {
+	src := t.TempDir()
+	tgt := t.TempDir()
+	pdir := filepath.Join(src, "x")
+	_ = os.MkdirAll(pdir, 0o755)
+	_ = os.WriteFile(filepath.Join(pdir, "SOUL.md"), []byte("soul"), 0o644)
+	_ = os.WriteFile(filepath.Join(pdir, "SKILL.md"), []byte("skill"), 0o644)
+
+	res, err := Import(src, tgt, ImportSourceOClaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Imported) != 1 || res.Imported[0].Tags == nil {
+		t.Fatalf("openclaw filter wrong: %+v", res.Imported)
+	}
+}
+
+func TestAdaptersForSourceUnknown(t *testing.T) {
+	if _, err := AdaptersForSource("nope"); err == nil {
+		t.Fatal("expected error for unknown source")
+	}
+}


### PR DESCRIPTION
Closes #52

This is a clean rebase of #247 onto the current main branch.

Changes:
- `internal/skills/adapters_universal.go`: adds `SkillMDAdapter` (SKILL.md) and `SoulMDAdapter` (SOUL.md) plus `AllUniversalAdapters()` convenience function
- `internal/skills/import.go`: package-level `Import()` and `Sync()` functions with `ImportSource` type and `AdaptersForSource()`
- `internal/skills/import_test.go`: tests for the above
- `cmd/conduit/main.go`: wire up new adapters in `allAdapters()`, replace `runSkillsImport`/`runSkillsSync` with unified implementation using the new API

Previous PR #247 had merge conflicts due to duplicate type definitions (`AgentsMDAdapter`, `CursorRulesAdapter`, `HermesAdapter`) that were added to main in separate PRs after #247 was opened.