### PR TITLE
feat(#63): nested agent delegation — subagent spawning and orchestration

### DIFF
--- a/internal/delegation/delegation.go
+++ b/internal/delegation/delegation.go
@@ -1,0 +1,181 @@
+// Package delegation provides nested agent orchestration for conduit.
+// Agents can spawn subagents for parallel or sequential task execution,
+// enabling complex multi-step workflows to be broken into focused subtasks.
+package delegation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// SubagentSpec describes a task to be delegated to a subagent.
+type SubagentSpec struct {
+	// Name is a human-readable identifier for this subtask.
+	Name string
+	// Prompt is the task instruction sent to the subagent.
+	Prompt string
+	// Model overrides the parent's model for this subagent. Empty means inherit.
+	Model string
+	// MaxTokens caps token usage for this subagent. Zero means no limit.
+	MaxTokens int
+	// Tools restricts the subagent to a named subset of available tools.
+	Tools []string
+	// Timeout caps execution time. Zero means no timeout.
+	Timeout time.Duration
+}
+
+// SubagentResult holds the outcome of a single delegated subagent run.
+type SubagentResult struct {
+	// Name matches SubagentSpec.Name.
+	Name string
+	// Output is the subagent's final text response.
+	Output string
+	// Error is non-nil if the subagent failed or timed out.
+	Error error
+	// TokensUsed is the number of tokens consumed, if available.
+	TokensUsed int
+	// Duration is wall-clock time the subagent ran.
+	Duration time.Duration
+}
+
+// Runner executes a single SubagentSpec and returns its result.
+// Implementations may call a real model API, a stub, or a sandboxed process.
+type Runner interface {
+	Run(ctx context.Context, spec SubagentSpec) SubagentResult
+}
+
+// Orchestrator manages concurrent and sequential subagent execution.
+type Orchestrator struct {
+	Runner         Runner
+	MaxConcurrency int // 0 means unbounded
+}
+
+// NewOrchestrator returns an Orchestrator with the given runner.
+// maxConcurrency controls how many subagents run in parallel; 0 = unbounded.
+func NewOrchestrator(runner Runner, maxConcurrency int) *Orchestrator {
+	return &Orchestrator{Runner: runner, MaxConcurrency: maxConcurrency}
+}
+
+// Run executes all specs concurrently (up to MaxConcurrency at a time) and
+// returns results in the same order as the input specs.
+func (o *Orchestrator) Run(ctx context.Context, specs []SubagentSpec) ([]SubagentResult, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+
+	results := make([]SubagentResult, len(specs))
+	sem := make(chan struct{}, o.concurrencyLimit(len(specs)))
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+
+	for i, spec := range specs {
+		wg.Add(1)
+		go func(idx int, s SubagentSpec) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			runCtx := ctx
+			if s.Timeout > 0 {
+				var cancel context.CancelFunc
+				runCtx, cancel = context.WithTimeout(ctx, s.Timeout)
+				defer cancel()
+			}
+
+			res := o.Runner.Run(runCtx, s)
+			results[idx] = res
+
+			if res.Error != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("subagent %q: %w", s.Name, res.Error)
+				}
+				mu.Unlock()
+			}
+		}(i, spec)
+	}
+
+	wg.Wait()
+	return results, firstErr
+}
+
+// RunSequential executes specs one at a time in order, stopping on the first
+// error.
+func (o *Orchestrator) RunSequential(ctx context.Context, specs []SubagentSpec) ([]SubagentResult, error) {
+	results := make([]SubagentResult, 0, len(specs))
+	for _, spec := range specs {
+		if ctx.Err() != nil {
+			return results, ctx.Err()
+		}
+		runCtx := ctx
+		if spec.Timeout > 0 {
+			var cancel context.CancelFunc
+			runCtx, cancel = context.WithTimeout(ctx, spec.Timeout)
+			defer cancel()
+		}
+		res := o.Runner.Run(runCtx, spec)
+		results = append(results, res)
+		if res.Error != nil {
+			return results, fmt.Errorf("subagent %q: %w", spec.Name, res.Error)
+		}
+	}
+	return results, nil
+}
+
+// Aggregate combines multiple SubagentResult outputs into a single string,
+// prefixing each with a header that identifies the subagent by name.
+func (o *Orchestrator) Aggregate(results []SubagentResult) string {
+	var sb strings.Builder
+	for i, r := range results {
+		if i > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString("## ")
+		sb.WriteString(r.Name)
+		sb.WriteString("\n")
+		if r.Error != nil {
+			sb.WriteString("**Error:** ")
+			sb.WriteString(r.Error.Error())
+		} else {
+			sb.WriteString(r.Output)
+		}
+		if r.Duration > 0 {
+			sb.WriteString(fmt.Sprintf("\n\n_(%s, %d tokens)_", r.Duration.Round(time.Millisecond), r.TokensUsed))
+		}
+	}
+	return sb.String()
+}
+
+// SpawnSubagentParams is the JSON-serialisable parameter block for the
+// spawn_subagent virtual tool.
+type SpawnSubagentParams struct {
+	Name    string `json:"name"`
+	Prompt  string `json:"prompt"`
+	Model   string `json:"model,omitempty"`
+	Timeout string `json:"timeout,omitempty"` // e.g. "30s", "2m"
+}
+
+// ParseTimeout converts the string timeout field to a time.Duration.
+// Empty or invalid strings default to 5 minutes.
+func ParseTimeout(s string) time.Duration {
+	if s == "" {
+		return 5 * time.Minute
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 5 * time.Minute
+	}
+	return d
+}
+
+// concurrencyLimit returns the effective concurrency cap.
+func (o *Orchestrator) concurrencyLimit(n int) int {
+	if o.MaxConcurrency <= 0 || o.MaxConcurrency > n {
+		return n
+	}
+	return o.MaxConcurrency
+}

--- a/internal/delegation/delegation_test.go
+++ b/internal/delegation/delegation_test.go
@@ -1,0 +1,183 @@
+package delegation_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/delegation"
+)
+
+// mockRunner records calls and returns canned responses.
+type mockRunner struct {
+	mu      interface{ Lock(); Unlock() }
+	calls   []delegation.SubagentSpec
+	outputs map[string]string
+	errs    map[string]error
+	delay   time.Duration
+}
+
+func newMockRunner() *mockRunner {
+	return &mockRunner{
+		outputs: map[string]string{},
+		errs:    map[string]error{},
+	}
+}
+
+func (m *mockRunner) Run(ctx context.Context, spec delegation.SubagentSpec) delegation.SubagentResult {
+	if m.delay > 0 {
+		select {
+		case <-time.After(m.delay):
+		case <-ctx.Done():
+			return delegation.SubagentResult{Name: spec.Name, Error: ctx.Err()}
+		}
+	}
+	start := time.Now()
+	out := m.outputs[spec.Name]
+	if out == "" {
+		out = "output:" + spec.Name
+	}
+	err := m.errs[spec.Name]
+	return delegation.SubagentResult{
+		Name:     spec.Name,
+		Output:   out,
+		Error:    err,
+		Duration: time.Since(start),
+	}
+}
+
+func specs(names ...string) []delegation.SubagentSpec {
+	out := make([]delegation.SubagentSpec, len(names))
+	for i, n := range names {
+		out[i] = delegation.SubagentSpec{Name: n, Prompt: "do " + n}
+	}
+	return out
+}
+
+func TestRunParallel(t *testing.T) {
+	runner := newMockRunner()
+	o := delegation.NewOrchestrator(runner, 0)
+	results, err := o.Run(context.Background(), specs("a", "b", "c"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("want 3 results, got %d", len(results))
+	}
+	for i, r := range results {
+		want := specs("a", "b", "c")[i].Name
+		if r.Name != want {
+			t.Errorf("result[%d].Name = %q, want %q", i, r.Name, want)
+		}
+	}
+}
+
+func TestRunConcurrencyLimit(t *testing.T) {
+	runner := newMockRunner()
+	runner.delay = 10 * time.Millisecond
+	o := delegation.NewOrchestrator(runner, 2)
+	results, err := o.Run(context.Background(), specs("x", "y", "z"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("want 3, got %d", len(results))
+	}
+}
+
+func TestRunReturnsErrorOnFailure(t *testing.T) {
+	runner := newMockRunner()
+	runner.errs["bad"] = errors.New("boom")
+	o := delegation.NewOrchestrator(runner, 0)
+	_, err := o.Run(context.Background(), specs("good", "bad"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad") {
+		t.Errorf("error should mention subagent name, got: %v", err)
+	}
+}
+
+func TestRunSequential(t *testing.T) {
+	runner := newMockRunner()
+	o := delegation.NewOrchestrator(runner, 0)
+	results, err := o.RunSequential(context.Background(), specs("p", "q"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("want 2, got %d", len(results))
+	}
+	if results[0].Name != "p" || results[1].Name != "q" {
+		t.Errorf("wrong order: %v", results)
+	}
+}
+
+func TestRunSequentialStopsOnError(t *testing.T) {
+	runner := newMockRunner()
+	runner.errs["first"] = fmt.Errorf("fail")
+	o := delegation.NewOrchestrator(runner, 0)
+	results, err := o.RunSequential(context.Background(), specs("first", "second"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if len(results) != 1 {
+		t.Errorf("want 1 result before stop, got %d", len(results))
+	}
+}
+
+func TestAggregate(t *testing.T) {
+	o := delegation.NewOrchestrator(newMockRunner(), 0)
+	results := []delegation.SubagentResult{
+		{Name: "alpha", Output: "result-alpha"},
+		{Name: "beta", Output: "result-beta"},
+	}
+	got := o.Aggregate(results)
+	if !strings.Contains(got, "## alpha") || !strings.Contains(got, "result-alpha") {
+		t.Errorf("aggregate missing alpha section: %s", got)
+	}
+	if !strings.Contains(got, "## beta") {
+		t.Errorf("aggregate missing beta section: %s", got)
+	}
+}
+
+func TestAggregateWithError(t *testing.T) {
+	o := delegation.NewOrchestrator(newMockRunner(), 0)
+	results := []delegation.SubagentResult{
+		{Name: "ok", Output: "fine"},
+		{Name: "fail", Error: errors.New("kaboom")},
+	}
+	got := o.Aggregate(results)
+	if !strings.Contains(got, "kaboom") {
+		t.Errorf("aggregate should include error text: %s", got)
+	}
+}
+
+func TestParseTimeout(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", 5 * time.Minute},
+		{"invalid", 5 * time.Minute},
+		{"30s", 30 * time.Second},
+		{"2m", 2 * time.Minute},
+	}
+	for _, c := range cases {
+		got := delegation.ParseTimeout(c.in)
+		if got != c.want {
+			t.Errorf("ParseTimeout(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRunEmpty(t *testing.T) {
+	o := delegation.NewOrchestrator(newMockRunner(), 0)
+	results, err := o.Run(context.Background(), nil)
+	if err != nil || len(results) != 0 {
+		t.Errorf("empty input should return nil, nil; got %v, %v", results, err)
+	}
+}


### PR DESCRIPTION
Closes #63

Adds internal/delegation package with SubagentSpec, SubagentResult, Runner interface, and Orchestrator with parallel/sequential execution and result aggregation.