### PR TITLE
feat: wire the GUI — conduit serve + WebSocket agent + chat surface + sidebars

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jabreeflor/conduit/internal/provider/codex"
 	"github.com/jabreeflor/conduit/internal/router"
 	"github.com/jabreeflor/conduit/internal/sandbox"
+	"github.com/jabreeflor/conduit/internal/server"
 	"github.com/jabreeflor/conduit/internal/sessions"
 	"github.com/jabreeflor/conduit/internal/skills"
 	"github.com/jabreeflor/conduit/internal/tools"
@@ -92,6 +93,12 @@ func main() {
 		case "code":
 			if err := runCodeCLI(context.Background(), os.Args[2:], os.Stdin, os.Stdout, os.Stderr); err != nil {
 				fmt.Fprintf(os.Stderr, "conduit code: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		case "serve":
+			if err := runServeCLI(context.Background(), os.Args[2:], os.Stdout, os.Stderr); err != nil {
+				fmt.Fprintf(os.Stderr, "conduit serve: %v\n", err)
 				os.Exit(1)
 			}
 			return
@@ -320,6 +327,49 @@ func runCodeCLI(ctx context.Context, args []string, stdin, stdout, stderr *os.Fi
 	fmt.Fprintf(stdout, "conduit code: session %s (provider=%s model=%s allow-write=%t allow-shell=%t cache=%t)\n",
 		session.ID, chosen, chosenModel, perms.AllowWrite, perms.AllowShell, *enableCache)
 	return repl.Run(ctx)
+}
+
+// runServeCLI starts the HTTP+WebSocket server that backs the Conduit
+// GUI. The server reuses selectCodingStreamer for provider/auth logic
+// so `conduit serve` and `conduit code` share the same fallback rules
+// (Anthropic key → codex login → echo). Read-only is the default —
+// allow-write/allow-shell must be opted into explicitly because the
+// server is long-running.
+func runServeCLI(ctx context.Context, args []string, stdout, stderr *os.File) error {
+	fs := flag.NewFlagSet("conduit serve", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	addr := fs.String("addr", "127.0.0.1:9876", "listen address")
+	provider := fs.String("provider", "auto", "model provider: auto | anthropic | codex | echo")
+	model := fs.String("model", "", "model id (defaults per provider)")
+	allowWrite := fs.Bool("allow-write", false, "allow filesystem write tools")
+	allowShell := fs.Bool("allow-shell", false, "allow shell tools")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	perms := contracts.CodingPermissions{AllowWrite: *allowWrite, AllowShell: *allowShell}
+	liveTools := coding.LiveCodingTools(websearch.Config{}, nil)
+	codingTools := coding.RegisterCodingTools(liveTools, perms)
+
+	// Probe the provider once for /api/info; the per-connection factory
+	// re-runs the selection so each WebSocket gets its own streamer
+	// (independent conversation history). Tools are fed in unwrapped
+	// from the cmd layer; the server wraps them with tool-event hooks.
+	_, providerName, modelName := selectCodingStreamer(*provider, *model, codingTools, stderr)
+
+	srv := server.New(server.Config{
+		Factory: func(wrapped []tools.Tool) (coding.Streamer, string, string) {
+			return selectCodingStreamer(*provider, *model, wrapped, stderr)
+		},
+		BaseTools: codingTools,
+		Provider:  providerName,
+		Model:     modelName,
+		Version:   version,
+	})
+
+	fmt.Fprintf(stdout, "conduit serve: listening on %s (provider=%s model=%s allow-write=%t allow-shell=%t)\n",
+		*addr, providerName, modelName, perms.AllowWrite, perms.AllowShell)
+	return srv.Serve(ctx, *addr)
 }
 
 // selectCodingStreamer picks a Streamer based on the provider flag:

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
+	github.com/coder/websocket v1.8.14 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfa
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
 github.com/clipperhouse/uax29/v2 v2.5.0 h1:x7T0T4eTHDONxFJsL94uKNKPHrclyFI0lm7+w94cO8U=
 github.com/clipperhouse/uax29/v2 v2.5.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=

--- a/internal/server/agent.go
+++ b/internal/server/agent.go
@@ -1,0 +1,162 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/jabreeflor/conduit/internal/coding"
+	"github.com/jabreeflor/conduit/internal/tools"
+)
+
+// agentEvent is the wire shape the GUI consumes. Only fields relevant to
+// a given event type are populated; omitempty keeps the JSON minimal.
+type agentEvent struct {
+	Type     string `json:"type"`
+	ID       string `json:"id,omitempty"`
+	Provider string `json:"provider,omitempty"`
+	Model    string `json:"model,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Text     string `json:"text,omitempty"`
+	Input    string `json:"input,omitempty"`
+	Output   string `json:"output,omitempty"`
+	IsError  bool   `json:"isError,omitempty"`
+	Message  string `json:"message,omitempty"`
+}
+
+// promptMsg is the only client→server frame the agent endpoint
+// currently understands.
+type promptMsg struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// handleAgent implements the WebSocket protocol documented in the
+// package README. One streamer + one wrapped tool slice are bound per
+// connection so concurrent sessions don't share conversation history
+// or tool-event channels.
+func (s *Server) handleAgent(w http.ResponseWriter, r *http.Request) {
+	if s.factory == nil {
+		http.Error(w, "agent: no streamer factory configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		// Tests and curl-based smoke checks may come from arbitrary
+		// origins; the server is intended to be loopback-only and
+		// gated by --addr, so origin enforcement adds friction without
+		// security benefit. Lock down at the listener instead.
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		return
+	}
+	defer c.Close(websocket.StatusInternalError, "closing")
+
+	ctx := r.Context()
+	emitter := newEventEmitter(ctx, c)
+
+	// Wrap the base tool slice so every Run is sandwiched between a
+	// tool_use and a tool_result event on the wire.
+	wrappedTools := wrapTools(s.baseTools, emitter)
+
+	streamer, providerName, modelName := s.factory(wrappedTools)
+	sessionID := fmt.Sprintf("code-%d", time.Now().UTC().Unix())
+
+	if err := emitter.send(agentEvent{
+		Type:     "session",
+		ID:       sessionID,
+		Provider: providerName,
+		Model:    modelName,
+	}); err != nil {
+		return
+	}
+
+	for {
+		_, data, err := c.Read(ctx)
+		if err != nil {
+			return
+		}
+		var msg promptMsg
+		if err := json.Unmarshal(data, &msg); err != nil || msg.Type != "prompt" {
+			_ = emitter.send(agentEvent{Type: "error", Message: "expected {type:\"prompt\", text:string}"})
+			continue
+		}
+		runTurn(ctx, streamer, msg.Text, emitter)
+	}
+}
+
+// runTurn drives one user→assistant exchange. text_delta callbacks are
+// translated 1:1; the streamer's terminal return becomes either an
+// end_turn or error frame. We never close the connection on an error —
+// the GUI is expected to recover by sending the next prompt.
+func runTurn(ctx context.Context, streamer coding.Streamer, prompt string, em *eventEmitter) {
+	_, _, err := streamer.Stream(ctx, prompt, func(delta string) {
+		_ = em.send(agentEvent{Type: "text_delta", Text: delta})
+	})
+	if err != nil {
+		_ = em.send(agentEvent{Type: "error", Message: err.Error()})
+		return
+	}
+	_ = em.send(agentEvent{Type: "end_turn"})
+}
+
+// eventEmitter serializes writes to the WebSocket. coder/websocket does
+// not serialize Write internally, and our tool-result and text_delta
+// callbacks may fire from goroutines spawned by the pipeline wrapper,
+// so we guard with a mutex.
+type eventEmitter struct {
+	ctx context.Context
+	c   *websocket.Conn
+	mu  sync.Mutex
+}
+
+func newEventEmitter(ctx context.Context, c *websocket.Conn) *eventEmitter {
+	return &eventEmitter{ctx: ctx, c: c}
+}
+
+func (e *eventEmitter) send(ev agentEvent) error {
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		return err
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.c.Write(e.ctx, websocket.MessageText, payload)
+}
+
+// wrapTools returns a copy of the input slice with each tool's Run
+// instrumented to emit tool_use before invocation and tool_result after.
+// The tool's own Result/error path is preserved exactly so the streamer
+// continues to see authentic provider behaviour.
+func wrapTools(base []tools.Tool, em *eventEmitter) []tools.Tool {
+	out := make([]tools.Tool, len(base))
+	for i, t := range base {
+		t := t // capture
+		original := t.Run
+		t.Run = func(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+			callID := fmt.Sprintf("call_%d", time.Now().UnixNano())
+			input := string(raw)
+			if input == "" {
+				input = "{}"
+			}
+			_ = em.send(agentEvent{Type: "tool_use", ID: callID, Name: t.Name, Input: input})
+			res, err := original(ctx, raw)
+			out := res.Text
+			isError := res.IsError
+			if err != nil {
+				out = err.Error()
+				isError = true
+			}
+			_ = em.send(agentEvent{Type: "tool_result", ID: callID, Name: t.Name, Output: out, IsError: isError})
+			return res, err
+		}
+		out[i] = t
+	}
+	return out
+}

--- a/internal/server/agent_test.go
+++ b/internal/server/agent_test.go
@@ -1,0 +1,193 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+
+	"github.com/jabreeflor/conduit/internal/coding"
+	"github.com/jabreeflor/conduit/internal/tools"
+)
+
+// scriptedStreamer is a coding.Streamer that replays a pre-recorded
+// list of actions per call to Stream. Each scriptStep either emits a
+// text delta or invokes a named tool with the provided input — the
+// latter exercises the tool_use/tool_result wrapping path.
+type scriptedStreamer struct {
+	steps  []scriptStep
+	finish string
+	tools  map[string]tools.Tool
+}
+
+type scriptStep struct {
+	delta    string
+	toolName string
+	toolIn   string
+}
+
+func (s *scriptedStreamer) Stream(ctx context.Context, prompt string, onDelta func(string)) (string, string, error) {
+	var collected strings.Builder
+	for _, step := range s.steps {
+		if step.delta != "" {
+			onDelta(step.delta)
+			collected.WriteString(step.delta)
+			continue
+		}
+		if step.toolName != "" {
+			if t, ok := s.tools[step.toolName]; ok {
+				_, _ = t.Run(ctx, json.RawMessage(step.toolIn))
+			}
+		}
+	}
+	finish := s.finish
+	if finish == "" {
+		finish = "end_turn"
+	}
+	return collected.String(), finish, nil
+}
+
+// TestAgentWebSocket end-to-ends the handshake → session → prompt →
+// streamed events → end_turn flow against a real httptest server. The
+// scripted streamer also fires a tool against the wrapped slice so we
+// confirm tool_use and tool_result land on the wire in order.
+func TestAgentWebSocket(t *testing.T) {
+	echoTool := tools.Tool{
+		Name:        "echo",
+		Description: "echo input back",
+		Schema:      map[string]any{"type": "object"},
+		Run: func(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+			return tools.Result{Text: "echoed:" + string(raw)}, nil
+		},
+	}
+
+	factory := func(wrapped []tools.Tool) (coding.Streamer, string, string) {
+		toolMap := make(map[string]tools.Tool, len(wrapped))
+		for _, t := range wrapped {
+			toolMap[t.Name] = t
+		}
+		return &scriptedStreamer{
+			steps: []scriptStep{
+				{delta: "hello "},
+				{delta: "world"},
+				{toolName: "echo", toolIn: `{"x":1}`},
+				{delta: "done"},
+			},
+			tools: toolMap,
+		}, "test-provider", "test-model"
+	}
+
+	srv := New(Config{
+		Factory:   factory,
+		BaseTools: []tools.Tool{echoTool},
+		Provider:  "test-provider",
+		Model:     "test-model",
+		Version:   "test",
+	})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/agent"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	c, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "done")
+
+	// session frame is unsolicited.
+	var ev agentEvent
+	if err := wsjson.Read(ctx, c, &ev); err != nil {
+		t.Fatalf("read session: %v", err)
+	}
+	if ev.Type != "session" || ev.Provider != "test-provider" || ev.Model != "test-model" {
+		t.Fatalf("session: %+v", ev)
+	}
+
+	// Send the prompt; expect the scripted stream of events back.
+	if err := wsjson.Write(ctx, c, promptMsg{Type: "prompt", Text: "hi"}); err != nil {
+		t.Fatalf("write prompt: %v", err)
+	}
+
+	expected := []agentEvent{
+		{Type: "text_delta", Text: "hello "},
+		{Type: "text_delta", Text: "world"},
+		{Type: "tool_use", Name: "echo", Input: `{"x":1}`},
+		{Type: "tool_result", Name: "echo", Output: `echoed:{"x":1}`},
+		{Type: "text_delta", Text: "done"},
+		{Type: "end_turn"},
+	}
+	for i, want := range expected {
+		var got agentEvent
+		if err := wsjson.Read(ctx, c, &got); err != nil {
+			t.Fatalf("read event %d: %v", i, err)
+		}
+		if got.Type != want.Type {
+			t.Fatalf("event %d type: got %q want %q (full=%+v)", i, got.Type, want.Type, got)
+		}
+		if want.Text != "" && got.Text != want.Text {
+			t.Errorf("event %d text: got %q want %q", i, got.Text, want.Text)
+		}
+		if want.Name != "" && got.Name != want.Name {
+			t.Errorf("event %d name: got %q want %q", i, got.Name, want.Name)
+		}
+		if want.Input != "" && got.Input != want.Input {
+			t.Errorf("event %d input: got %q want %q", i, got.Input, want.Input)
+		}
+		if want.Output != "" && got.Output != want.Output {
+			t.Errorf("event %d output: got %q want %q", i, got.Output, want.Output)
+		}
+	}
+}
+
+// TestAgentInvalidPrompt confirms the handler emits an error frame and
+// stays open when the client sends junk, instead of dropping the
+// connection.
+func TestAgentInvalidPrompt(t *testing.T) {
+	factory := func([]tools.Tool) (coding.Streamer, string, string) {
+		return &scriptedStreamer{steps: []scriptStep{{delta: "ok"}}}, "p", "m"
+	}
+	srv := New(Config{Factory: factory})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/agent"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "done")
+
+	var ev agentEvent
+	_ = wsjson.Read(ctx, c, &ev) // discard session frame
+
+	if err := c.Write(ctx, websocket.MessageText, []byte(`not json`)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := wsjson.Read(ctx, c, &ev); err != nil {
+		t.Fatalf("read err: %v", err)
+	}
+	if ev.Type != "error" {
+		t.Errorf("expected error frame, got %+v", ev)
+	}
+
+	// Recovery: a valid prompt should still work after the error.
+	if err := wsjson.Write(ctx, c, promptMsg{Type: "prompt", Text: "hi"}); err != nil {
+		t.Fatalf("write recover: %v", err)
+	}
+	if err := wsjson.Read(ctx, c, &ev); err != nil {
+		t.Fatalf("read delta: %v", err)
+	}
+	if ev.Type != "text_delta" || ev.Text != "ok" {
+		t.Errorf("recover frame: %+v", ev)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,7 +84,23 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/info", s.handleInfo)
 	mux.HandleFunc("/api/sessions", s.handleSessions)
 	mux.HandleFunc("/api/memory", s.handleMemory)
-	return mux
+	return withCORS(mux)
+}
+
+// withCORS lets the local Tauri/vite dev frontend (different origin) call
+// the REST endpoints. The server only ever binds to localhost so this is
+// not a real-world cross-site exposure.
+func withCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // Serve binds to addr and runs the HTTP server until ctx is cancelled.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,124 @@
+// Package server exposes Conduit's coding agent over HTTP+WebSocket.
+//
+// The server is the backend for the Conduit GUI: a single binary that
+// hosts a JSON-over-WebSocket agent endpoint plus a small REST surface
+// for read-only views (info, sessions, memory). Wire protocol is
+// documented in agent.go and views.go; the contract is locked because
+// the frontend is built against the exact event shapes here.
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/coding"
+	"github.com/jabreeflor/conduit/internal/tools"
+)
+
+// StreamerFactory produces a coding.Streamer wired to the given tool
+// slice. It returns the streamer and the human-readable provider/model
+// names so /api/info and the per-connection "session" frame can carry
+// them. The factory is called once per WebSocket connection so each
+// connection gets its own streamer (and thus its own conversation
+// history).
+type StreamerFactory func(codingTools []tools.Tool) (coding.Streamer, string, string)
+
+// Server wires the coding agent factory and read-only data sources into
+// HTTP routes. The zero value is not usable; construct via New.
+type Server struct {
+	factory     StreamerFactory
+	baseTools   []tools.Tool
+	provider    string
+	model       string
+	version     string
+	homeDir     string
+	sessionsDir string
+}
+
+// Config bundles the values the server needs to render /api/info and
+// emit accurate "session" frames. Provider and Model describe the
+// streamer the factory will build; SessionsDir/HomeDir let the REST
+// handlers locate journals and memory files (override for tests).
+type Config struct {
+	Factory     StreamerFactory
+	BaseTools   []tools.Tool
+	Provider    string
+	Model       string
+	Version     string
+	HomeDir     string
+	SessionsDir string
+}
+
+// New returns a Server ready to serve the documented routes.
+func New(cfg Config) *Server {
+	home := cfg.HomeDir
+	if home == "" {
+		home, _ = os.UserHomeDir()
+	}
+	sessions := cfg.SessionsDir
+	if sessions == "" && home != "" {
+		sessions = filepath.Join(home, ".conduit", "coding-sessions")
+	}
+	return &Server{
+		factory:     cfg.Factory,
+		baseTools:   cfg.BaseTools,
+		provider:    cfg.Provider,
+		model:       cfg.Model,
+		version:     cfg.Version,
+		homeDir:     home,
+		sessionsDir: sessions,
+	}
+}
+
+// Handler returns the HTTP mux with all routes wired up. Exposed
+// separately so tests can mount it on httptest without binding a port.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/agent", s.handleAgent)
+	mux.HandleFunc("/api/info", s.handleInfo)
+	mux.HandleFunc("/api/sessions", s.handleSessions)
+	mux.HandleFunc("/api/memory", s.handleMemory)
+	return mux
+}
+
+// Serve binds to addr and runs the HTTP server until ctx is cancelled.
+// Cancellation triggers a 5 s graceful shutdown; if the listener fails
+// to bind, the error is returned immediately.
+func (s *Server) Serve(ctx context.Context, addr string) error {
+	hs := &http.Server{
+		Addr:              addr,
+		Handler:           s.Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("server: listen %s: %w", addr, err)
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- hs.Serve(ln) }()
+	select {
+	case <-ctx.Done():
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = hs.Shutdown(shutCtx)
+		return nil
+	case err := <-errCh:
+		if err == http.ErrServerClosed {
+			return nil
+		}
+		return err
+	}
+}
+
+// writeJSON is the shared response helper for the REST views.
+func writeJSON(w http.ResponseWriter, code int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestHandleInfo(t *testing.T) {
+	s := New(Config{Provider: "codex", Model: "gpt-5.5", Version: "test"})
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/info", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", rr.Code)
+	}
+	var got infoResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Provider != "codex" || got.Model != "gpt-5.5" || got.Version != "test" {
+		t.Errorf("unexpected info: %+v", got)
+	}
+}
+
+func TestHandleMemory(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".conduit"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".conduit", "SOUL.md"), []byte("soul-bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := New(Config{HomeDir: home})
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/memory", nil))
+	var got memoryResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Soul != "soul-bytes" {
+		t.Errorf("soul: got %q want %q", got.Soul, "soul-bytes")
+	}
+	if got.User != "" {
+		t.Errorf("user: want empty for missing USER.md, got %q", got.User)
+	}
+}
+
+func TestHandleSessions(t *testing.T) {
+	dir := t.TempDir()
+	// Two journal files with predictable mtimes so order is verifiable.
+	older := filepath.Join(dir, "code-1-aaa.jsonl")
+	newer := filepath.Join(dir, "code-2-bbb.jsonl")
+	if err := os.WriteFile(older, []byte(`{"role":"user","content":"first prompt"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newer, []byte(`{"prompt":"second prompt"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	_ = os.Chtimes(older, now.Add(-2*time.Hour), now.Add(-2*time.Hour))
+	_ = os.Chtimes(newer, now, now)
+
+	s := New(Config{SessionsDir: dir})
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/sessions", nil))
+	var got []sessionInfo
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("count: got %d want 2", len(got))
+	}
+	if got[0].ID != "code-2-bbb" {
+		t.Errorf("order: got first=%q want code-2-bbb", got[0].ID)
+	}
+	if got[0].Summary != "second prompt" {
+		t.Errorf("summary: got %q want %q", got[0].Summary, "second prompt")
+	}
+	if got[1].Summary != "first prompt" {
+		t.Errorf("summary[1]: got %q", got[1].Summary)
+	}
+}
+
+func TestHandleSessionsMissingDir(t *testing.T) {
+	s := New(Config{SessionsDir: filepath.Join(t.TempDir(), "does-not-exist")})
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/sessions", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", rr.Code)
+	}
+	if got := rr.Body.String(); got != "[]\n" {
+		t.Errorf("body: got %q want %q", got, "[]\n")
+	}
+}

--- a/internal/server/views.go
+++ b/internal/server/views.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ── /api/info ────────────────────────────────────────────────────────
+
+type infoResponse struct {
+	Provider  string `json:"provider"`
+	Model     string `json:"model"`
+	Version   string `json:"version"`
+	SessionID string `json:"sessionId"`
+}
+
+func (s *Server) handleInfo(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, infoResponse{
+		Provider:  s.provider,
+		Model:     s.model,
+		Version:   s.version,
+		SessionID: "", // filled per-connection in the agent ws "session" frame
+	})
+}
+
+// ── /api/sessions ────────────────────────────────────────────────────
+
+type sessionInfo struct {
+	ID        string `json:"id"`
+	CreatedAt string `json:"createdAt"`
+	Summary   string `json:"summary"`
+}
+
+// handleSessions tails up to 20 most-recent coding-session journals.
+// Each .jsonl under sessionsDir is treated as one session; ordering is
+// by file modtime descending to match the GUI expectation that the
+// most recent run sits at the top. A missing directory returns an
+// empty list rather than a 500 — the GUI handles empty.
+func (s *Server) handleSessions(w http.ResponseWriter, _ *http.Request) {
+	out := make([]sessionInfo, 0)
+	if s.sessionsDir == "" {
+		writeJSON(w, http.StatusOK, out)
+		return
+	}
+	entries, err := os.ReadDir(s.sessionsDir)
+	if err != nil {
+		writeJSON(w, http.StatusOK, out)
+		return
+	}
+	type entry struct {
+		name string
+		mod  time.Time
+	}
+	var ents []entry
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		fi, err := e.Info()
+		if err != nil {
+			continue
+		}
+		ents = append(ents, entry{name: e.Name(), mod: fi.ModTime()})
+	}
+	sort.Slice(ents, func(i, j int) bool { return ents[i].mod.After(ents[j].mod) })
+	if len(ents) > 20 {
+		ents = ents[:20]
+	}
+	for _, e := range ents {
+		id := strings.TrimSuffix(e.name, ".jsonl")
+		out = append(out, sessionInfo{
+			ID:        id,
+			CreatedAt: e.mod.UTC().Format(time.RFC3339),
+			Summary:   summarizeJournal(filepath.Join(s.sessionsDir, e.name)),
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// summarizeJournal pulls the first prompt/content field from a JSONL
+// session journal so the sidebar has something to display. Peeks at up
+// to 8 lines and bails; older or unrelated files return empty.
+func summarizeJournal(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	for i := 0; i < 8; i++ {
+		var raw map[string]any
+		if err := dec.Decode(&raw); err != nil {
+			return ""
+		}
+		for _, k := range []string{"prompt", "content"} {
+			if v, ok := raw[k].(string); ok && v != "" {
+				v = strings.TrimSpace(v)
+				if len(v) > 80 {
+					v = v[:79] + "…"
+				}
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+// ── /api/memory ──────────────────────────────────────────────────────
+
+type memoryResponse struct {
+	Soul string `json:"soul"`
+	User string `json:"user"`
+}
+
+// handleMemory reads SOUL.md and USER.md from ~/.conduit/. Missing
+// files return empty strings — the GUI's editor seeds them on first
+// save.
+func (s *Server) handleMemory(w http.ResponseWriter, _ *http.Request) {
+	out := memoryResponse{}
+	if s.homeDir != "" {
+		out.Soul = readFileOrEmpty(filepath.Join(s.homeDir, ".conduit", "SOUL.md"))
+		out.User = readFileOrEmpty(filepath.Join(s.homeDir, ".conduit", "USER.md"))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func readFileOrEmpty(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/spike/gui/package-lock.json
+++ b/spike/gui/package-lock.json
@@ -1,0 +1,1947 @@
+{
+  "name": "conduit-gui-spike",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "conduit-gui-spike",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@tauri-apps/cli": "^2.0.0",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.1",
+        "typescript": "^5.5.3",
+        "vite": "^5.4.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tauri-apps/cli": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.1.tgz",
+      "integrity": "sha512-rpEbaJ/HzNb6fwsquwoAbq29/Vt4gADhS423A8fdkwL4edJ0wZmoB8ar7O6JPDL834MUKOCm/rrJ7c9oAaEaYQ==",
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "bin": {
+        "tauri": "tauri.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      },
+      "optionalDependencies": {
+        "@tauri-apps/cli-darwin-arm64": "2.11.1",
+        "@tauri-apps/cli-darwin-x64": "2.11.1",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.1",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.1",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.1",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.1",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.1",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.1",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.1",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.1",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.1"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-arm64": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.1.tgz",
+      "integrity": "sha512-6eEKMBXsQPCuM1EmvrjT2+aBuxWQuFdKdW8pzNuNQtpq45nEEpBlD5gr8pUeAyOU1DQKlkFaEc/MPBxb/Pfjtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-x64": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.1.tgz",
+      "integrity": "sha512-LQUO7exfRWjWALNhetph5guWpMeHphRpokOLk0OIbTTExaNwJNFu3I4vb+CCM/4G/QGoZe/5XikZOJdNEFP1ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.1.tgz",
+      "integrity": "sha512-5i/awiBCRRhOUG8yjn0fMHXIWD5Ez8eEk5LtvOxyQrKuJkRaZDvnbIjZbE183blAwkoA4xN3aO/prJiqscl02Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.1.tgz",
+      "integrity": "sha512-9LrwDw3S9Fygtw/Q6WDhOP+3svJRGAsejeE+GKrc0eO1ThMVhwi2LL6hw4dlKw93IfS7VY1G19sWGxJ/NcU4nA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-musl": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.1.tgz",
+      "integrity": "sha512-mNA5dbbqPqDUdTIwdUYYuhO2GvIe9UnB2r0VU2njxBOS3Opbx4gKNC5yP0Iu4rYmEmqdlwry9VzGZQ3wq9dyFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.1.tgz",
+      "integrity": "sha512-fZj3Gwq+6fUs305T5WQiD5iSGJw+j/4w/HGmk4sHDAcy+rp9zU5eaxB7nOyz5/I/nkNAuKPqfp6uIbiUBXkBCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-gnu": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.1.tgz",
+      "integrity": "sha512-XFxGxOvHM7jjeD6ozCKdGfhzJ7lERYDGZl1/Kb4fsvchaJsfLJ981TlyTG8Qy/gFq+f5GitH3bfrX9JAkjPEyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-musl": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.1.tgz",
+      "integrity": "sha512-d5C2/Zm+68v7R9wTuTCjRQEVrWjcdMkJBZ1+rXse+QdMMlTB9+u9PDNDLw9PQflWxYLaYZ7tjxxL9Nb9II6PbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.1.tgz",
+      "integrity": "sha512-YdeVWFAR1pTXzUU6NLstPq4G6OLxuDrXCXEBdmBH+5EZIDXUx0D2kJlz3+YjpazkKvAzYpgziTsyRagls0OfRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.1.tgz",
+      "integrity": "sha512-VBGkuH0eB9K9LLSMv361Gzr5Ou72sCS4+ztpmkWEQ+wd/amhcYOsf3X6qn1RJZDzIhiOYHJEOysZUC3baD01rA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-x64-msvc": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.1.tgz",
+      "integrity": "sha512-b3ORhIAKgp9ZYY+zBt7b7r0kLU2kjvyGF0+MS2SBym3emsweGPybEqocJcmtMuxyBhkOKHP4CiuEJEDuAlTx6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.352",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
+      "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/spike/gui/package-lock.json
+++ b/spike/gui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "conduit-gui-spike",
       "version": "0.0.0",
       "dependencies": {
+        "lucide-react": "^1.14.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1651,6 +1652,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz",
+      "integrity": "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/ms": {

--- a/spike/gui/package.json
+++ b/spike/gui/package.json
@@ -10,6 +10,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "lucide-react": "^1.14.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/spike/gui/src/App.tsx
+++ b/spike/gui/src/App.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from "react";
 import { Spotlight } from "./Spotlight";
+import { ChatPanel } from "./components/ChatPanel";
+import { SessionList } from "./components/SessionList";
+import { MemoryView } from "./components/MemoryView";
 
 // SidebarTab mirrors the iota in internal/gui/layout.go.
 type SidebarTab = "sessions" | "workflows" | "memory" | "skills" | "evals";
@@ -46,8 +49,8 @@ export function App() {
   return (
     <div className="app">
       <Sidebar activeTab={activeTab} onSelect={selectTab} />
-      <Main view={mainView} />
-      <AgentPanel />
+      <Main view={mainView} activeTab={activeTab} />
+      <ChatPanel />
       {spotlightOpen && (
         <Spotlight onClose={() => setSpotlightOpen(false)} />
       )}
@@ -76,6 +79,11 @@ function Sidebar({
           </button>
         ))}
       </nav>
+      {activeTab === "sessions" && (
+        <div className="sidebar-section">
+          <SessionList />
+        </div>
+      )}
       <div className="sidebar-footer">
         <kbd>⌥Space</kbd> Spotlight · <kbd>⌘K</kbd> Palette
       </div>
@@ -83,11 +91,11 @@ function Sidebar({
   );
 }
 
-function Main({ view }: { view: MainView }) {
+function Main({ view, activeTab }: { view: MainView; activeTab: SidebarTab }) {
   return (
     <main className="main" aria-label="Main content">
       <div className="main-header">{viewTitle(view)}</div>
-      <div className="main-body">{viewBody(view)}</div>
+      <div className="main-body">{viewBody(view, activeTab)}</div>
     </main>
   );
 }
@@ -109,14 +117,9 @@ function viewTitle(v: MainView): string {
   }
 }
 
-function viewBody(v: MainView) {
+function viewBody(v: MainView, activeTab: SidebarTab) {
   if (v === "memory") {
-    return (
-      <div className="placeholder">
-        <p>SOUL.md / USER.md editor — wired in #SUP-9 follow-up.</p>
-        <p>View-model: <code>internal/gui/memory_editor.go</code></p>
-      </div>
-    );
+    return <MemoryView />;
   }
   if (v === "evals") {
     return (
@@ -133,31 +136,17 @@ function viewBody(v: MainView) {
       </div>
     );
   }
+  if (activeTab === "sessions") {
+    return (
+      <div className="placeholder">
+        <p>Pick a session in the sidebar to view its screenshot stream.</p>
+        <p>View-model: <code>internal/gui/screenshot_stream.go</code></p>
+      </div>
+    );
+  }
   return (
     <div className="placeholder">
       <p>Screenshot stream — already wired in <code>internal/gui/screenshot_stream.go</code>.</p>
     </div>
-  );
-}
-
-function AgentPanel() {
-  return (
-    <section className="agent-panel" aria-label="Agent">
-      <div className="agent-header">Chat</div>
-      <div className="agent-stream">
-        <div className="message agent">
-          Conduit GUI scaffold — three columns up, Spotlight on ⌥Space.
-        </div>
-      </div>
-      <textarea
-        className="agent-input"
-        placeholder="Message Conduit…"
-        rows={3}
-      />
-      <div className="agent-status">
-        <span>model: claude-opus-4-7</span>
-        <span>$0.00</span>
-      </div>
-    </section>
   );
 }

--- a/spike/gui/src/App.tsx
+++ b/spike/gui/src/App.tsx
@@ -1,26 +1,35 @@
 import { useEffect, useState } from "react";
+import {
+  Brain,
+  Gauge,
+  History,
+  MessagesSquare,
+  Sparkles,
+  Workflow,
+  type LucideIcon,
+} from "lucide-react";
 import { Spotlight } from "./Spotlight";
 import { ChatPanel } from "./components/ChatPanel";
 import { SessionList } from "./components/SessionList";
 import { MemoryView } from "./components/MemoryView";
+import logoUrl from "../../../assets/logo.svg";
 
-// SidebarTab mirrors the iota in internal/gui/layout.go.
-type SidebarTab = "sessions" | "workflows" | "memory" | "skills" | "evals";
+type SidebarTab = "chat" | "sessions" | "workflows" | "memory" | "skills" | "evals";
 
-// MainView mirrors internal/gui/layout.go MainView.
-type MainView = "screenshot" | "canvas" | "workflow" | "memory" | "diff" | "evals";
+type MainView = "chat" | "sessions" | "workflow" | "memory" | "evals";
 
-const TABS: { id: SidebarTab; label: string; view: MainView }[] = [
-  { id: "sessions", label: "Sessions", view: "screenshot" },
-  { id: "workflows", label: "Workflows", view: "workflow" },
-  { id: "memory", label: "Memory", view: "memory" },
-  { id: "skills", label: "Skills", view: "screenshot" },
-  { id: "evals", label: "Evals", view: "evals" },
+const TABS: { id: SidebarTab; label: string; view: MainView; icon: LucideIcon }[] = [
+  { id: "chat", label: "Chat", view: "chat", icon: MessagesSquare },
+  { id: "sessions", label: "Sessions", view: "sessions", icon: History },
+  { id: "workflows", label: "Workflows", view: "workflow", icon: Workflow },
+  { id: "memory", label: "Memory", view: "memory", icon: Brain },
+  { id: "skills", label: "Skills", view: "chat", icon: Sparkles },
+  { id: "evals", label: "Evals", view: "evals", icon: Gauge },
 ];
 
 export function App() {
-  const [activeTab, setActiveTab] = useState<SidebarTab>("sessions");
-  const [mainView, setMainView] = useState<MainView>("screenshot");
+  const [activeTab, setActiveTab] = useState<SidebarTab>("chat");
+  const [mainView, setMainView] = useState<MainView>("chat");
   const [spotlightOpen, setSpotlightOpen] = useState(false);
 
   // Global hotkey: ⌥Space (the production binding) AND ⌘K (dev convenience
@@ -50,7 +59,6 @@ export function App() {
     <div className="app">
       <Sidebar activeTab={activeTab} onSelect={selectTab} />
       <Main view={mainView} activeTab={activeTab} />
-      <ChatPanel />
       {spotlightOpen && (
         <Spotlight onClose={() => setSpotlightOpen(false)} />
       )}
@@ -67,17 +75,24 @@ function Sidebar({
 }) {
   return (
     <aside className="sidebar" aria-label="Navigation">
-      <div className="sidebar-header">Conduit</div>
+      <div className="sidebar-header">
+        <img src={logoUrl} alt="" className="sidebar-logo" />
+        <span>Conduit</span>
+      </div>
       <nav>
-        {TABS.map((t) => (
-          <button
-            key={t.id}
-            className={`sidebar-tab ${activeTab === t.id ? "active" : ""}`}
-            onClick={() => onSelect(t.id)}
-          >
-            {t.label}
-          </button>
-        ))}
+        {TABS.map((t) => {
+          const Icon = t.icon;
+          return (
+            <button
+              key={t.id}
+              className={`sidebar-tab ${activeTab === t.id ? "active" : ""}`}
+              onClick={() => onSelect(t.id)}
+            >
+              <Icon size={16} className="sidebar-tab-icon" aria-hidden />
+              <span>{t.label}</span>
+            </button>
+          );
+        })}
       </nav>
       {activeTab === "sessions" && (
         <div className="sidebar-section">
@@ -92,9 +107,23 @@ function Sidebar({
 }
 
 function Main({ view, activeTab }: { view: MainView; activeTab: SidebarTab }) {
+  // Chat is the primary surface — render it edge-to-edge in main without a
+  // header, since ChatPanel has its own header with provider/model badge.
+  if (view === "chat") {
+    return (
+      <main className="main main-chat" aria-label="Chat">
+        <ChatPanel />
+      </main>
+    );
+  }
   return (
     <main className="main" aria-label="Main content">
-      <div className="main-header">{viewTitle(view)}</div>
+      <div className="main-header">
+        {view === "memory" && (
+          <Brain size={16} className="main-header-icon" aria-hidden />
+        )}
+        <span>{viewTitle(view)}</span>
+      </div>
       <div className="main-body">{viewBody(view, activeTab)}</div>
     </main>
   );
@@ -102,22 +131,20 @@ function Main({ view, activeTab }: { view: MainView; activeTab: SidebarTab }) {
 
 function viewTitle(v: MainView): string {
   switch (v) {
-    case "screenshot":
-      return "Computer use — live screenshots";
-    case "canvas":
-      return "Canvas";
+    case "chat":
+      return "Chat";
+    case "sessions":
+      return "Sessions";
     case "workflow":
       return "Workflow DAG";
     case "memory":
       return "Memory — SOUL.md / USER.md";
-    case "diff":
-      return "Diff review";
     case "evals":
       return "Evals — scorecards";
   }
 }
 
-function viewBody(v: MainView, activeTab: SidebarTab) {
+function viewBody(v: MainView, _activeTab: SidebarTab) {
   if (v === "memory") {
     return <MemoryView />;
   }
@@ -136,17 +163,13 @@ function viewBody(v: MainView, activeTab: SidebarTab) {
       </div>
     );
   }
-  if (activeTab === "sessions") {
+  if (v === "sessions") {
     return (
       <div className="placeholder">
-        <p>Pick a session in the sidebar to view its screenshot stream.</p>
-        <p>View-model: <code>internal/gui/screenshot_stream.go</code></p>
+        <p>Pick a session in the sidebar to view its turns.</p>
+        <p>View-model: <code>internal/gui/session_tree.go</code></p>
       </div>
     );
   }
-  return (
-    <div className="placeholder">
-      <p>Screenshot stream — already wired in <code>internal/gui/screenshot_stream.go</code>.</p>
-    </div>
-  );
+  return null;
 }

--- a/spike/gui/src/api.ts
+++ b/spike/gui/src/api.ts
@@ -1,0 +1,123 @@
+// Backend client. Speaks the protocol described in the GUI brief: a single
+// websocket at /api/agent for streaming, plus a few REST endpoints for
+// snapshots. Uses native fetch + WebSocket — no third-party clients.
+
+const BASE: string =
+  (import.meta.env.VITE_CONDUIT_API as string | undefined) ??
+  "http://localhost:9876";
+
+function wsBase(): string {
+  return BASE.replace(/^http/, "ws");
+}
+
+// ── Protocol types (must match internal/gui/api/protocol.go on the server). ──
+
+export type ServerMessage =
+  | { type: "session"; id: string; provider: string; model: string }
+  | { type: "text_delta"; text: string }
+  | { type: "tool_use"; id: string; name: string; input: string }
+  | { type: "tool_result"; id: string; name: string; output: string; isError: boolean }
+  | { type: "end_turn" }
+  | { type: "error"; message: string };
+
+export type ClientMessage = { type: "prompt"; text: string };
+
+export type Info = {
+  provider: string;
+  model: string;
+  version: string;
+  sessionId: string;
+};
+
+export type SessionMeta = {
+  id: string;
+  createdAt: string;
+  summary: string;
+};
+
+export type Memory = {
+  soul: string;
+  user: string;
+};
+
+// ── REST helpers ─────────────────────────────────────────────────────────
+
+async function getJSON<T>(path: string): Promise<T> {
+  const r = await fetch(`${BASE}${path}`);
+  if (!r.ok) throw new Error(`${path}: HTTP ${r.status}`);
+  return (await r.json()) as T;
+}
+
+export const getInfo = (): Promise<Info> => getJSON<Info>("/api/info");
+export const getSessions = (): Promise<SessionMeta[]> =>
+  getJSON<SessionMeta[]>("/api/sessions");
+export const getMemory = (): Promise<Memory> => getJSON<Memory>("/api/memory");
+
+// ── WebSocket helper with reconnection ───────────────────────────────────
+
+export type ConnectionState = "connecting" | "connected" | "disconnected";
+
+export type AgentClient = {
+  send: (msg: ClientMessage) => void;
+  close: () => void;
+};
+
+export type AgentClientHandlers = {
+  onMessage: (msg: ServerMessage) => void;
+  onState: (state: ConnectionState) => void;
+};
+
+export function connectAgent(handlers: AgentClientHandlers): AgentClient {
+  let ws: WebSocket | null = null;
+  let closed = false;
+  let retry = 0;
+  let retryTimer: number | null = null;
+
+  function open() {
+    handlers.onState("connecting");
+    ws = new WebSocket(`${wsBase()}/api/agent`);
+
+    ws.addEventListener("open", () => {
+      retry = 0;
+      handlers.onState("connected");
+    });
+
+    ws.addEventListener("message", (e: MessageEvent<string>) => {
+      try {
+        const data = JSON.parse(e.data) as ServerMessage;
+        handlers.onMessage(data);
+      } catch {
+        // Drop frames the server promised but didn't deliver. Better to keep
+        // the stream alive than tear down on a single bad frame.
+      }
+    });
+
+    ws.addEventListener("close", () => {
+      if (closed) return;
+      handlers.onState("disconnected");
+      // Capped exponential backoff: 0.5s, 1s, 2s, 4s, … 8s.
+      const delay = Math.min(8000, 500 * 2 ** retry);
+      retry++;
+      retryTimer = window.setTimeout(open, delay);
+    });
+
+    ws.addEventListener("error", () => {
+      // The close handler runs after this, so reconnect logic lives there.
+    });
+  }
+
+  open();
+
+  return {
+    send(msg) {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(msg));
+      }
+    },
+    close() {
+      closed = true;
+      if (retryTimer !== null) window.clearTimeout(retryTimer);
+      if (ws) ws.close();
+    },
+  };
+}

--- a/spike/gui/src/components/ChatPanel.tsx
+++ b/spike/gui/src/components/ChatPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { ChevronDown, ChevronRight, SendHorizontal } from "lucide-react";
 import {
   connectAgent,
   getInfo,
@@ -37,6 +38,30 @@ type Turn = {
   blocks: Block[];
   done: boolean;
 };
+
+type ProviderTone = "claude" | "openai" | "litellm" | "openrouter" | "local";
+
+// Map raw provider strings (as emitted by the core session frame) onto the
+// per-provider model-badge tokens published in design/dist/web/tokens.css.
+function providerTone(provider: string | undefined): ProviderTone {
+  switch ((provider ?? "").toLowerCase()) {
+    case "anthropic":
+    case "claude":
+      return "claude";
+    case "openai":
+    case "codex":
+      return "openai";
+    case "litellm":
+      return "litellm";
+    case "openrouter":
+      return "openrouter";
+    case "auto":
+    case "":
+      return "local";
+    default:
+      return "local";
+  }
+}
 
 export function ChatPanel() {
   const [info, setInfo] = useState<Info | null>(null);
@@ -88,11 +113,24 @@ export function ChatPanel() {
     }
   }
 
-  const header = info ? `${info.provider} / ${info.model}` : "Chat";
+  const tone = providerTone(info?.provider);
+  const sendDisabled = state !== "connected" || draft.trim().length === 0;
 
   return (
     <section className="agent-panel" aria-label="Agent">
-      <div className="agent-header">{header}</div>
+      <div className="agent-header">
+        <span className="agent-header-title">Chat</span>
+        {info ? (
+          <span
+            className={`model-badge model-badge--${tone}`}
+            title={`${info.provider} / ${info.model}`}
+          >
+            {info.provider}/{info.model}
+          </span>
+        ) : (
+          <span className="model-badge model-badge--local">offline</span>
+        )}
+      </div>
       <div className="agent-stream" ref={streamRef}>
         {turns.length === 0 && (
           <div className="placeholder" style={{ margin: 0 }}>
@@ -103,21 +141,35 @@ export function ChatPanel() {
           <TurnCard key={t.id} turn={t} />
         ))}
       </div>
-      <textarea
-        className="agent-input"
-        placeholder={
-          state === "connected"
-            ? "Message Conduit…"
-            : `Reconnecting… (${state})`
-        }
-        rows={3}
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        onKeyDown={onKey}
-        disabled={state !== "connected"}
-      />
+      <div className="agent-input-wrap">
+        <textarea
+          className="agent-input"
+          placeholder={
+            state === "connected"
+              ? "Message Conduit…"
+              : `Reconnecting… (${state})`
+          }
+          rows={3}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onKey}
+          disabled={state !== "connected"}
+        />
+        <button
+          type="button"
+          className="agent-send"
+          aria-label="Send message"
+          onClick={send}
+          disabled={sendDisabled}
+        >
+          <SendHorizontal size={20} aria-hidden />
+        </button>
+      </div>
       <div className="agent-status">
-        <span>{stateLabel(state)}</span>
+        <span className="agent-status-left">
+          <span className={`state-dot state-dot--${state}`} aria-hidden />
+          <span>{stateLabel(state)}</span>
+        </span>
         <span>{info?.version ? `v${info.version}` : ""}</span>
       </div>
     </section>
@@ -127,11 +179,11 @@ export function ChatPanel() {
 function stateLabel(s: ConnectionState): string {
   switch (s) {
     case "connecting":
-      return "● connecting";
+      return "connecting";
     case "connected":
-      return "● connected";
+      return "connected";
     case "disconnected":
-      return "● disconnected";
+      return "disconnected";
   }
 }
 
@@ -241,23 +293,34 @@ function TurnCard({ turn }: { turn: Turn }) {
 
 function ToolCall({ block }: { block: ToolBlock }) {
   const [open, setOpen] = useState(false);
-  const summary =
+  const pillClass =
     block.output === null
-      ? "running…"
+      ? "tool-pill--running"
       : block.isError
-        ? "error"
-        : "ok";
+        ? "tool-pill--error"
+        : "tool-pill--ok";
+  const pillLabel =
+    block.output === null ? "running" : block.isError ? "error" : "ok";
   return (
     <div className={`tool-call ${block.isError ? "error" : ""}`}>
       <button
         type="button"
         className="tool-head"
         onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
       >
-        <span className="tool-arrow">{open ? "▼" : "▶"}</span>
+        <span className="tool-arrow">
+          {open ? (
+            <ChevronDown size={14} aria-hidden />
+          ) : (
+            <ChevronRight size={14} aria-hidden />
+          )}
+        </span>
         <span className="tool-name">{block.name}</span>
         <span className="tool-input">{block.input}</span>
-        <span className="tool-summary">→ {summary}</span>
+        <span className="tool-summary">
+          <span className={`tool-pill ${pillClass}`}>{pillLabel}</span>
+        </span>
       </button>
       {open && block.output !== null && (
         <pre className="tool-output">{block.output}</pre>

--- a/spike/gui/src/components/ChatPanel.tsx
+++ b/spike/gui/src/components/ChatPanel.tsx
@@ -1,0 +1,267 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  connectAgent,
+  getInfo,
+  type ConnectionState,
+  type Info,
+  type ServerMessage,
+} from "../api";
+
+// A single rendered chat block. Tool blocks are derived from tool_use frames
+// and updated in place when the matching tool_result arrives.
+type ToolBlock = {
+  kind: "tool";
+  id: string;
+  name: string;
+  input: string;
+  output: string | null;
+  isError: boolean;
+};
+
+type AssistantBlock = {
+  kind: "assistant";
+  text: string;
+};
+
+type UserBlock = {
+  kind: "user";
+  text: string;
+};
+
+type Block = UserBlock | AssistantBlock | ToolBlock;
+
+// A turn groups a user prompt with the resulting assistant + tool blocks so
+// the UI can render them as a single card.
+type Turn = {
+  id: number;
+  blocks: Block[];
+  done: boolean;
+};
+
+export function ChatPanel() {
+  const [info, setInfo] = useState<Info | null>(null);
+  const [state, setState] = useState<ConnectionState>("connecting");
+  const [turns, setTurns] = useState<Turn[]>([]);
+  const [draft, setDraft] = useState("");
+  const clientRef = useRef<ReturnType<typeof connectAgent> | null>(null);
+  const streamRef = useRef<HTMLDivElement | null>(null);
+  const turnIdRef = useRef(0);
+
+  useEffect(() => {
+    getInfo().then(setInfo).catch(() => {
+      // Info is non-essential for the chat surface; the websocket session
+      // frame carries the same provider/model.
+    });
+  }, []);
+
+  useEffect(() => {
+    const client = connectAgent({
+      onState: setState,
+      onMessage: (msg) => applyMessage(msg, setTurns, setInfo),
+    });
+    clientRef.current = client;
+    return () => client.close();
+  }, []);
+
+  // Pin the stream to the bottom whenever it grows.
+  useEffect(() => {
+    const el = streamRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [turns]);
+
+  function send() {
+    const text = draft.trim();
+    if (!text || state !== "connected") return;
+    const id = ++turnIdRef.current;
+    setTurns((prev) => [
+      ...prev,
+      { id, blocks: [{ kind: "user", text }], done: false },
+    ]);
+    clientRef.current?.send({ type: "prompt", text });
+    setDraft("");
+  }
+
+  function onKey(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  }
+
+  const header = info ? `${info.provider} / ${info.model}` : "Chat";
+
+  return (
+    <section className="agent-panel" aria-label="Agent">
+      <div className="agent-header">{header}</div>
+      <div className="agent-stream" ref={streamRef}>
+        {turns.length === 0 && (
+          <div className="placeholder" style={{ margin: 0 }}>
+            <p>No messages yet — say hello.</p>
+          </div>
+        )}
+        {turns.map((t) => (
+          <TurnCard key={t.id} turn={t} />
+        ))}
+      </div>
+      <textarea
+        className="agent-input"
+        placeholder={
+          state === "connected"
+            ? "Message Conduit…"
+            : `Reconnecting… (${state})`
+        }
+        rows={3}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={onKey}
+        disabled={state !== "connected"}
+      />
+      <div className="agent-status">
+        <span>{stateLabel(state)}</span>
+        <span>{info?.version ? `v${info.version}` : ""}</span>
+      </div>
+    </section>
+  );
+}
+
+function stateLabel(s: ConnectionState): string {
+  switch (s) {
+    case "connecting":
+      return "● connecting";
+    case "connected":
+      return "● connected";
+    case "disconnected":
+      return "● disconnected";
+  }
+}
+
+// applyMessage reduces a single websocket frame into the turn list. The last
+// in-progress turn (the one with done === false) is the active target. The
+// session frame is sent once on connect and updates the header info; it does
+// not start a new turn.
+function applyMessage(
+  msg: ServerMessage,
+  setTurns: React.Dispatch<React.SetStateAction<Turn[]>>,
+  setInfo: React.Dispatch<React.SetStateAction<Info | null>>,
+): void {
+  if (msg.type === "session") {
+    setInfo((prev) => ({
+      provider: msg.provider,
+      model: msg.model,
+      version: prev?.version ?? "",
+      sessionId: msg.id,
+    }));
+    return;
+  }
+
+  setTurns((prev) => {
+    const turns = [...prev];
+    let active = turns[turns.length - 1];
+    // Errors that arrive without a turn (e.g. before the user has prompted)
+    // get shown as a synthetic assistant block so they're still visible.
+    if (!active || active.done) {
+      active = { id: -1, blocks: [], done: false };
+      turns.push(active);
+    }
+    const blocks = [...active.blocks];
+
+    switch (msg.type) {
+      case "text_delta": {
+        const last = blocks[blocks.length - 1];
+        if (last && last.kind === "assistant") {
+          blocks[blocks.length - 1] = { ...last, text: last.text + msg.text };
+        } else {
+          blocks.push({ kind: "assistant", text: msg.text });
+        }
+        break;
+      }
+      case "tool_use":
+        blocks.push({
+          kind: "tool",
+          id: msg.id,
+          name: msg.name,
+          input: msg.input,
+          output: null,
+          isError: false,
+        });
+        break;
+      case "tool_result": {
+        const idx = blocks.findIndex(
+          (b) => b.kind === "tool" && b.id === msg.id,
+        );
+        if (idx >= 0) {
+          const t = blocks[idx] as ToolBlock;
+          blocks[idx] = {
+            ...t,
+            output: msg.output,
+            isError: msg.isError,
+          };
+        }
+        break;
+      }
+      case "end_turn":
+        turns[turns.length - 1] = { ...active, blocks, done: true };
+        return turns;
+      case "error":
+        blocks.push({
+          kind: "assistant",
+          text: `[error] ${msg.message}`,
+        });
+        break;
+    }
+
+    turns[turns.length - 1] = { ...active, blocks };
+    return turns;
+  });
+}
+
+function TurnCard({ turn }: { turn: Turn }) {
+  return (
+    <div className="turn">
+      {turn.blocks.map((b, i) => {
+        if (b.kind === "user") {
+          return (
+            <div key={i} className="message user">
+              {b.text}
+            </div>
+          );
+        }
+        if (b.kind === "assistant") {
+          return (
+            <div key={i} className="message agent">
+              {b.text}
+            </div>
+          );
+        }
+        return <ToolCall key={i} block={b} />;
+      })}
+    </div>
+  );
+}
+
+function ToolCall({ block }: { block: ToolBlock }) {
+  const [open, setOpen] = useState(false);
+  const summary =
+    block.output === null
+      ? "running…"
+      : block.isError
+        ? "error"
+        : "ok";
+  return (
+    <div className={`tool-call ${block.isError ? "error" : ""}`}>
+      <button
+        type="button"
+        className="tool-head"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="tool-arrow">{open ? "▼" : "▶"}</span>
+        <span className="tool-name">{block.name}</span>
+        <span className="tool-input">{block.input}</span>
+        <span className="tool-summary">→ {summary}</span>
+      </button>
+      {open && block.output !== null && (
+        <pre className="tool-output">{block.output}</pre>
+      )}
+    </div>
+  );
+}

--- a/spike/gui/src/components/MemoryView.tsx
+++ b/spike/gui/src/components/MemoryView.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { getMemory, type Memory } from "../api";
+
+export function MemoryView() {
+  const [mem, setMem] = useState<Memory | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getMemory()
+      .then(setMem)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+  }, []);
+
+  if (error) {
+    return <div className="placeholder">Failed to load memory: {error}</div>;
+  }
+  if (mem === null) {
+    return <div className="placeholder">Loading memory…</div>;
+  }
+  if (!mem.soul && !mem.user) {
+    return <div className="placeholder">No memory written yet.</div>;
+  }
+
+  return (
+    <div className="memory-grid">
+      <MemoryCard title="SOUL.md" body={mem.soul} />
+      <MemoryCard title="USER.md" body={mem.user} />
+    </div>
+  );
+}
+
+function MemoryCard({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="memory-card">
+      <div className="memory-card-title">{title}</div>
+      <pre className="memory-card-body">{body || "(empty)"}</pre>
+    </div>
+  );
+}

--- a/spike/gui/src/components/SessionList.tsx
+++ b/spike/gui/src/components/SessionList.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import { getSessions, type SessionMeta } from "../api";
+
+export function SessionList() {
+  const [sessions, setSessions] = useState<SessionMeta[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getSessions()
+      .then(setSessions)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+  }, []);
+
+  if (error) {
+    return (
+      <div className="session-list-empty">
+        Failed to load sessions: {error}
+      </div>
+    );
+  }
+
+  if (sessions === null) {
+    return <div className="session-list-empty">Loading sessions…</div>;
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <div className="session-list-empty">
+        No sessions yet — start chatting on the right →
+      </div>
+    );
+  }
+
+  return (
+    <ul className="session-list">
+      {sessions.map((s) => (
+        <li key={s.id} className="session-row">
+          <div className="session-id">{s.id}</div>
+          <div className="session-summary">{s.summary}</div>
+          <div className="session-time">{formatTime(s.createdAt)}</div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+}

--- a/spike/gui/src/styles.css
+++ b/spike/gui/src/styles.css
@@ -1,42 +1,7 @@
-/* Conduit GUI scaffold. Color values track design/dist/web/tokens.css —
-   when the design system is published as an npm package this file will be
-   replaced by an @import. Until then, the literals below are mirrored by
-   hand and verified against design/tokens.yaml. */
-
-:root {
-  color-scheme: dark;
-
-  --color-surface-canvas: #0a0c14;
-  --color-surface-primary: #10131e;
-  --color-surface-elevated: #1a1d2c;
-  --color-surface-sunken: #000000;
-
-  --color-border-subtle: #1a1d2c;
-  --color-border-default: #2a2e40;
-  --color-border-strong: #3e4358;
-  --color-border-focus: #f59e1f;
-
-  --color-text-body: #e2e5ee;
-  --color-text-muted: #8c93ab;
-  --color-text-subtle: #5d637a;
-  --color-text-link: #36b3cf;
-
-  --color-action-primary: #f59e1f;
-
-  --space-1: 4px;
-  --space-2: 8px;
-  --space-3: 12px;
-  --space-4: 16px;
-  --space-5: 24px;
-
-  --radius-sm: 4px;
-  --radius-md: 6px;
-  --radius-lg: 10px;
-
-  --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI",
-    Roboto, sans-serif;
-  --font-mono: "SF Mono", Menlo, Monaco, Consolas, monospace;
-}
+/* Conduit GUI — single source of color/spacing/type truth lives in the
+   design package. We import the generated token sheet directly so dark/
+   light/HC mode all flow through automatically. */
+@import "../../../design/dist/web/tokens.css";
 
 * {
   box-sizing: border-box;
@@ -50,18 +15,39 @@ body,
   padding: 0;
   background: var(--color-surface-canvas);
   color: var(--color-text-body);
-  font-family: var(--font-sans);
-  font-size: 13px;
-  line-height: 1.5;
+  font-family: var(--ref-type-family-sans);
+  font-size: var(--ref-type-size-small);
+  line-height: var(--ref-type-line-height-normal);
   -webkit-font-smoothing: antialiased;
 }
 
-/* ── three-column shell ──────────────────────────────────────────────── */
+:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+  border-radius: var(--ref-radius-sm);
+}
+
+/* ── two-column shell — sidebar + main (chat lives in main) ─────────── */
 .app {
   display: grid;
-  grid-template-columns: 18% 1fr 28%;
+  grid-template-columns: 240px 1fr;
   height: 100vh;
   gap: 0;
+}
+
+/* Chat-as-main: ChatPanel paints the whole main column edge-to-edge,
+   no main-header (ChatPanel has its own header with provider badge). */
+.main-chat {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+.main-chat .agent-panel {
+  border-left: none;
+  flex: 1;
+  min-height: 0;
 }
 
 .sidebar {
@@ -69,32 +55,52 @@ body,
   background: var(--color-surface-primary);
   display: flex;
   flex-direction: column;
-  padding: var(--space-4) 0;
+  padding: var(--ref-space-md) 0;
 }
 
 .sidebar-header {
-  padding: 0 var(--space-4) var(--space-4);
-  font-weight: 600;
-  font-size: 14px;
-  letter-spacing: 0.2px;
+  display: flex;
+  align-items: center;
+  padding: 0 var(--ref-space-md) var(--ref-space-md);
+  font-family: var(--ref-type-family-display);
+  font-weight: var(--ref-type-weight-semibold);
+  font-size: var(--ref-type-size-small);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-body);
+}
+
+.sidebar-logo {
+  width: 22px;
+  height: 22px;
+  margin-right: var(--ref-space-sm);
+  border-radius: var(--ref-radius-sm);
+  display: block;
+  flex-shrink: 0;
 }
 
 .sidebar nav {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
-  padding: 0 var(--space-2);
+  gap: var(--ref-space-xs);
+  padding: 0 var(--ref-space-sm);
 }
 
 .sidebar-tab {
+  display: flex;
+  align-items: center;
+  gap: var(--ref-space-sm);
   background: transparent;
-  border: none;
+  border: 1px solid transparent;
   color: var(--color-text-muted);
   text-align: left;
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-sm);
+  padding: var(--ref-space-sm) var(--ref-space-sm);
+  border-radius: var(--ref-radius-sm);
   font: inherit;
+  font-weight: var(--ref-type-weight-medium);
   cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease,
+    color 120ms ease;
 }
 
 .sidebar-tab:hover {
@@ -105,14 +111,24 @@ body,
 .sidebar-tab.active {
   background: var(--color-surface-elevated);
   color: var(--color-text-body);
+  border-color: var(--color-border-default);
+}
+
+.sidebar-tab-icon {
+  flex-shrink: 0;
+  color: currentColor;
+}
+
+.sidebar-tab.active .sidebar-tab-icon {
+  color: var(--color-brand-primary);
 }
 
 .sidebar-footer {
   margin-top: auto;
-  padding: var(--space-3) var(--space-4);
+  padding: var(--ref-space-sm) var(--ref-space-md);
   border-top: 1px solid var(--color-border-subtle);
   color: var(--color-text-subtle);
-  font-size: 11px;
+  font-size: var(--ref-type-size-caption);
 }
 
 /* ── main ────────────────────────────────────────────────────────────── */
@@ -124,32 +140,40 @@ body,
 }
 
 .main-header {
-  padding: var(--space-3) var(--space-5);
+  display: flex;
+  align-items: center;
+  gap: var(--ref-space-sm);
+  padding: var(--ref-space-sm) var(--ref-space-lg);
   border-bottom: 1px solid var(--color-border-subtle);
-  font-weight: 500;
-  font-size: 13px;
+  font-weight: var(--ref-type-weight-medium);
+  font-size: var(--ref-type-size-small);
   color: var(--color-text-muted);
+}
+
+.main-header-icon {
+  color: var(--color-brand-primary);
+  flex-shrink: 0;
 }
 
 .main-body {
   flex: 1;
-  padding: var(--space-5);
+  padding: var(--ref-space-lg);
   overflow: auto;
 }
 
 .placeholder {
   border: 1px dashed var(--color-border-default);
-  border-radius: var(--radius-md);
-  padding: var(--space-5);
+  border-radius: var(--ref-radius-md);
+  padding: var(--ref-space-lg);
   color: var(--color-text-muted);
 }
 
 .placeholder code {
   background: var(--color-surface-elevated);
   padding: 2px 6px;
-  border-radius: var(--radius-sm);
-  font-family: var(--font-mono);
-  font-size: 12px;
+  border-radius: var(--ref-radius-sm);
+  font-family: var(--ref-type-family-mono);
+  font-size: var(--ref-type-size-small);
 }
 
 /* ── agent panel ─────────────────────────────────────────────────────── */
@@ -161,49 +185,177 @@ body,
 }
 
 .agent-header {
-  padding: var(--space-3) var(--space-4);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ref-space-sm);
+  padding: var(--ref-space-sm) var(--ref-space-md);
   border-bottom: 1px solid var(--color-border-subtle);
-  font-weight: 500;
+  font-weight: var(--ref-type-weight-medium);
   color: var(--color-text-muted);
+}
+
+.agent-header-title {
+  font-size: var(--ref-type-size-small);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-subtle);
+}
+
+.model-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: var(--ref-radius-full);
+  border: 1px solid var(--color-model-badge-local-border);
+  background: var(--color-model-badge-local-bg);
+  color: var(--color-model-badge-local-fg);
+  font-family: var(--ref-type-family-mono);
+  font-size: 10px;
+  font-weight: var(--ref-type-weight-medium);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.model-badge--claude {
+  background: var(--color-model-badge-claude-bg);
+  border-color: var(--color-model-badge-claude-border);
+  color: var(--color-model-badge-claude-fg);
+}
+
+.model-badge--openai {
+  background: var(--color-model-badge-openai-bg);
+  border-color: var(--color-model-badge-openai-border);
+  color: var(--color-model-badge-openai-fg);
+}
+
+.model-badge--litellm {
+  background: var(--color-model-badge-litellm-bg);
+  border-color: var(--color-model-badge-litellm-border);
+  color: var(--color-model-badge-litellm-fg);
+}
+
+.model-badge--openrouter {
+  background: var(--color-model-badge-openrouter-bg);
+  border-color: var(--color-model-badge-openrouter-border);
+  color: var(--color-model-badge-openrouter-fg);
+}
+
+.model-badge--local {
+  background: var(--color-model-badge-local-bg);
+  border-color: var(--color-model-badge-local-border);
+  color: var(--color-model-badge-local-fg);
 }
 
 .agent-stream {
   flex: 1;
-  padding: var(--space-4);
+  padding: var(--ref-space-md);
   overflow: auto;
 }
 
 .message {
   background: var(--color-surface-elevated);
-  padding: var(--space-3);
-  border-radius: var(--radius-md);
-  margin-bottom: var(--space-3);
+  padding: var(--ref-space-sm);
+  border-radius: var(--ref-radius-md);
+  margin-bottom: var(--ref-space-sm);
+}
+
+.agent-input-wrap {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--ref-space-sm);
+  margin: var(--ref-space-sm);
 }
 
 .agent-input {
-  margin: var(--space-3);
-  padding: var(--space-3);
+  flex: 1;
+  padding: var(--ref-space-sm);
   background: var(--color-surface-sunken);
   color: var(--color-text-body);
   border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-md);
+  border-radius: var(--ref-radius-md);
   font: inherit;
+  font-family: var(--ref-type-family-sans);
   resize: none;
+  transition: border-color 120ms ease, background-color 120ms ease;
 }
 
 .agent-input:focus {
-  outline: 1px solid var(--color-border-focus);
+  outline: none;
   border-color: var(--color-border-focus);
+}
+
+.agent-send {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--ref-radius-md);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-surface-elevated);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease,
+    color 120ms ease;
+}
+
+.agent-send:hover:not(:disabled) {
+  background: var(--color-brand-primary);
+  border-color: var(--color-brand-primary);
+  color: var(--color-brand-on-primary);
+}
+
+.agent-send:active:not(:disabled) {
+  background: var(--color-brand-primary-active);
+  border-color: var(--color-brand-primary-active);
+}
+
+.agent-send:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .agent-status {
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  padding: var(--space-2) var(--space-4);
+  gap: var(--ref-space-sm);
+  padding: var(--ref-space-sm) var(--ref-space-md);
   border-top: 1px solid var(--color-border-subtle);
   color: var(--color-text-subtle);
-  font-size: 11px;
-  font-family: var(--font-mono);
+  font-size: var(--ref-type-size-caption);
+  font-family: var(--ref-type-family-mono);
+}
+
+.agent-status-left {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ref-space-xs);
+}
+
+.state-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--ref-radius-full);
+  background: var(--color-agent-idle);
+  flex-shrink: 0;
+}
+
+.state-dot--connected {
+  background: var(--color-agent-active);
+  box-shadow: 0 0 0 3px rgba(245, 158, 31, 0.18);
+}
+
+.state-dot--connecting {
+  background: var(--color-agent-thinking);
+  box-shadow: 0 0 0 3px rgba(54, 179, 207, 0.18);
+}
+
+.state-dot--disconnected {
+  background: var(--color-agent-error);
+  box-shadow: 0 0 0 3px rgba(243, 130, 130, 0.18);
 }
 
 /* ── spotlight overlay ───────────────────────────────────────────────── */
@@ -215,28 +367,28 @@ body,
   align-items: flex-start;
   justify-content: center;
   padding-top: 12vh;
-  z-index: 100;
+  z-index: var(--ref-z-spotlight);
 }
 
 .spotlight {
   width: min(620px, 90%);
   background: var(--color-surface-elevated);
   border: 1px solid var(--color-border-strong);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+  border-radius: var(--ref-radius-lg);
+  box-shadow: var(--ref-shadow-lg);
   overflow: hidden;
 }
 
 .spotlight-input {
   width: 100%;
-  padding: var(--space-4) var(--space-5);
+  padding: var(--ref-space-md) var(--ref-space-lg);
   background: transparent;
   color: var(--color-text-body);
   border: none;
   border-bottom: 1px solid var(--color-border-subtle);
-  font-size: 16px;
   font: inherit;
-  font-size: 16px;
+  font-family: var(--ref-type-family-sans);
+  font-size: var(--ref-type-size-body-large);
 }
 
 .spotlight-input:focus {
@@ -246,7 +398,7 @@ body,
 .spotlight-results {
   list-style: none;
   margin: 0;
-  padding: var(--space-2);
+  padding: var(--ref-space-sm);
   max-height: 360px;
   overflow: auto;
 }
@@ -254,9 +406,9 @@ body,
 .spotlight-row {
   display: grid;
   grid-template-columns: 80px 1fr auto;
-  gap: var(--space-3);
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-sm);
+  gap: var(--ref-space-sm);
+  padding: var(--ref-space-sm) var(--ref-space-sm);
+  border-radius: var(--ref-radius-sm);
   align-items: center;
 }
 
@@ -268,7 +420,7 @@ body,
   display: block;
   text-align: center;
   color: var(--color-text-subtle);
-  padding: var(--space-4);
+  padding: var(--ref-space-md);
 }
 
 .kind {
@@ -276,11 +428,11 @@ body,
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--color-text-subtle);
-  font-family: var(--font-mono);
+  font-family: var(--ref-type-family-mono);
 }
 
 .kind-command {
-  color: var(--color-action-primary);
+  color: var(--color-brand-primary);
 }
 
 .kind-workflow {
@@ -305,63 +457,69 @@ body,
 
 .subtitle {
   color: var(--color-text-subtle);
-  font-size: 11px;
-  font-family: var(--font-mono);
+  font-size: var(--ref-type-size-caption);
+  font-family: var(--ref-type-family-mono);
 }
 
 kbd {
   background: var(--color-surface-elevated);
   border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-sm);
+  border-radius: var(--ref-radius-sm);
   padding: 1px 4px;
-  font-family: var(--font-mono);
-  font-size: 11px;
+  font-family: var(--ref-type-family-mono);
+  font-size: var(--ref-type-size-caption);
 }
 
 /* ── chat turns ──────────────────────────────────────────────────────── */
 .turn {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
-  margin-bottom: var(--space-4);
+  gap: var(--ref-space-sm);
+  margin-bottom: var(--ref-space-md);
 }
 
 .message.user {
   background: var(--color-surface-sunken);
   border: 1px solid var(--color-border-default);
+  color: var(--color-text-body);
 }
 
 .message.agent {
+  background: var(--color-surface-elevated);
   white-space: pre-wrap;
   word-break: break-word;
+  color: var(--color-text-body);
 }
 
 /* ── tool calls ──────────────────────────────────────────────────────── */
 .tool-call {
   border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-sm);
+  border-radius: var(--ref-radius-sm);
   background: var(--color-surface-sunken);
-  font-family: var(--font-mono);
-  font-size: 11px;
+  font-family: var(--ref-type-family-mono);
+  font-size: var(--ref-type-size-caption);
   overflow: hidden;
 }
 
 .tool-call.error {
-  border-color: #6b2424;
+  border-color: var(--color-status-error);
 }
 
 .tool-head {
   display: grid;
-  grid-template-columns: 14px auto 1fr auto;
-  gap: var(--space-2);
+  grid-template-columns: 16px auto 1fr auto;
+  gap: var(--ref-space-sm);
+  align-items: center;
   width: 100%;
   background: transparent;
   border: none;
   color: var(--color-text-muted);
   text-align: left;
-  padding: var(--space-2) var(--space-3);
+  padding: var(--ref-space-sm) var(--ref-space-sm);
   cursor: pointer;
   font: inherit;
+  font-family: var(--ref-type-family-mono);
+  transition: background-color 120ms ease;
 }
 
 .tool-head:hover {
@@ -369,11 +527,15 @@ kbd {
 }
 
 .tool-arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--color-text-subtle);
 }
 
 .tool-name {
-  color: var(--color-action-primary);
+  color: var(--color-brand-primary);
+  font-weight: var(--ref-type-weight-medium);
 }
 
 .tool-input {
@@ -384,12 +546,46 @@ kbd {
 }
 
 .tool-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ref-space-xs);
   color: var(--color-text-subtle);
+}
+
+.tool-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 8px;
+  border-radius: var(--ref-radius-full);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-surface-elevated);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.tool-pill--ok {
+  border-color: var(--color-status-success);
+  color: var(--color-status-success);
+  background: transparent;
+}
+
+.tool-pill--error {
+  border-color: var(--color-status-error);
+  color: var(--color-status-error);
+  background: transparent;
+}
+
+.tool-pill--running {
+  color: var(--color-status-info);
+  border-color: var(--color-status-info);
+  background: transparent;
 }
 
 .tool-output {
   margin: 0;
-  padding: var(--space-3);
+  padding: var(--ref-space-sm);
   border-top: 1px solid var(--color-border-subtle);
   background: var(--color-surface-canvas);
   color: var(--color-text-body);
@@ -401,8 +597,8 @@ kbd {
 
 /* ── session list (sidebar) ──────────────────────────────────────────── */
 .sidebar-section {
-  margin-top: var(--space-3);
-  padding: 0 var(--space-2);
+  margin-top: var(--ref-space-sm);
+  padding: 0 var(--ref-space-sm);
   overflow: auto;
 }
 
@@ -412,24 +608,30 @@ kbd {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
+  gap: var(--ref-space-xs);
 }
 
 .session-row {
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-sm);
+  padding: var(--ref-space-sm) var(--ref-space-sm);
+  border-radius: var(--ref-radius-sm);
   background: var(--color-surface-elevated);
+  border: 1px solid transparent;
+  transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+.session-row:hover {
+  border-color: var(--color-border-default);
 }
 
 .session-id {
-  font-family: var(--font-mono);
-  font-size: 11px;
+  font-family: var(--ref-type-family-mono);
+  font-size: var(--ref-type-size-caption);
   color: var(--color-text-link);
 }
 
 .session-summary {
   color: var(--color-text-body);
-  font-size: 12px;
+  font-size: var(--ref-type-size-small);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -438,20 +640,20 @@ kbd {
 .session-time {
   font-size: 10px;
   color: var(--color-text-subtle);
-  font-family: var(--font-mono);
+  font-family: var(--ref-type-family-mono);
 }
 
 .session-list-empty {
-  padding: var(--space-3);
+  padding: var(--ref-space-sm);
   color: var(--color-text-subtle);
-  font-size: 12px;
+  font-size: var(--ref-type-size-small);
 }
 
 /* ── memory view ─────────────────────────────────────────────────────── */
 .memory-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: var(--space-4);
+  gap: var(--ref-space-md);
   height: 100%;
 }
 
@@ -465,26 +667,26 @@ kbd {
   display: flex;
   flex-direction: column;
   border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
+  border-radius: var(--ref-radius-md);
   background: var(--color-surface-primary);
   overflow: hidden;
 }
 
 .memory-card-title {
-  padding: var(--space-2) var(--space-4);
+  padding: var(--ref-space-sm) var(--ref-space-md);
   border-bottom: 1px solid var(--color-border-subtle);
   color: var(--color-text-muted);
-  font-family: var(--font-mono);
-  font-size: 11px;
+  font-family: var(--ref-type-family-mono);
+  font-size: var(--ref-type-size-caption);
 }
 
 .memory-card-body {
   flex: 1;
   margin: 0;
-  padding: var(--space-4);
+  padding: var(--ref-space-md);
   overflow: auto;
-  font-family: var(--font-mono);
-  font-size: 12px;
+  font-family: var(--ref-type-family-mono);
+  font-size: var(--ref-type-size-small);
   white-space: pre-wrap;
   word-break: break-word;
   color: var(--color-text-body);

--- a/spike/gui/src/styles.css
+++ b/spike/gui/src/styles.css
@@ -317,3 +317,175 @@ kbd {
   font-family: var(--font-mono);
   font-size: 11px;
 }
+
+/* ── chat turns ──────────────────────────────────────────────────────── */
+.turn {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.message.user {
+  background: var(--color-surface-sunken);
+  border: 1px solid var(--color-border-default);
+}
+
+.message.agent {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── tool calls ──────────────────────────────────────────────────────── */
+.tool-call {
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-sunken);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  overflow: hidden;
+}
+
+.tool-call.error {
+  border-color: #6b2424;
+}
+
+.tool-head {
+  display: grid;
+  grid-template-columns: 14px auto 1fr auto;
+  gap: var(--space-2);
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  font: inherit;
+}
+
+.tool-head:hover {
+  background: var(--color-surface-elevated);
+}
+
+.tool-arrow {
+  color: var(--color-text-subtle);
+}
+
+.tool-name {
+  color: var(--color-action-primary);
+}
+
+.tool-input {
+  color: var(--color-text-subtle);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tool-summary {
+  color: var(--color-text-subtle);
+}
+
+.tool-output {
+  margin: 0;
+  padding: var(--space-3);
+  border-top: 1px solid var(--color-border-subtle);
+  background: var(--color-surface-canvas);
+  color: var(--color-text-body);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 320px;
+  overflow: auto;
+}
+
+/* ── session list (sidebar) ──────────────────────────────────────────── */
+.sidebar-section {
+  margin-top: var(--space-3);
+  padding: 0 var(--space-2);
+  overflow: auto;
+}
+
+.session-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.session-row {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-elevated);
+}
+
+.session-id {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-link);
+}
+
+.session-summary {
+  color: var(--color-text-body);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-time {
+  font-size: 10px;
+  color: var(--color-text-subtle);
+  font-family: var(--font-mono);
+}
+
+.session-list-empty {
+  padding: var(--space-3);
+  color: var(--color-text-subtle);
+  font-size: 12px;
+}
+
+/* ── memory view ─────────────────────────────────────────────────────── */
+.memory-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+  height: 100%;
+}
+
+@media (max-width: 1100px) {
+  .memory-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.memory-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-primary);
+  overflow: hidden;
+}
+
+.memory-card-title {
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.memory-card-body {
+  flex: 1;
+  margin: 0;
+  padding: var(--space-4);
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--color-text-body);
+}

--- a/spike/gui/src/vite-env.d.ts
+++ b/spike/gui/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_CONDUIT_API?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary

Closes the loop on PR [#277](https://github.com/jabreeflor/conduit/pull/277)'s static Tauri scaffold. The frontend now talks to a real backend; chatting in the right column streams text and tool calls live from the same agent loop the CLI uses (Anthropic or Codex), and the Sessions / Memory sidebars show real data.

## How to use

\`\`\`sh
go build -o conduit ./cmd/conduit
./conduit serve --provider codex --allow-write &
cd spike/gui && npm install && npm run tauri dev
\`\`\`

Window opens. Chat with the agent in the right column. Real session ids in the left sidebar. SOUL.md / USER.md content in the middle column.

## Backend — \`internal/server/\`

| File | Lines | Role |
|---|---|---|
| \`server.go\` | 124 | HTTP+WebSocket server, route setup, lifecycle |
| \`agent.go\` | 162 | \`/api/agent\` WebSocket. Per-connection: spins up a \`coding.Streamer\` (provider routing reused from \`cmd/conduit\`), wraps each registered tool so \`Run()\` emits a \`tool_use\` → \`tool.Run\` → \`tool_result\` triple over the socket, runs the prompt, emits \`text_delta\` / \`end_turn\` / \`error\`. WebSocket writes mutex-serialized because tool callbacks fire from goroutines |
| \`views.go\` | 138 | REST: \`/api/info\`, \`/api/sessions\` (reads \`~/.conduit/coding-sessions/*.jsonl\`), \`/api/memory\` (reads \`~/.conduit/SOUL.md\` + \`~/.conduit/USER.md\`) |
| Tests | ~290 | Handler tests + fake-streamer end-to-end WS roundtrip incl. tool_use/tool_result |

\`github.com/coder/websocket\` added (modern fork of nhooyr/websocket).

## CLI — \`cmd/conduit/main.go\`

New \`conduit serve\` subcommand. Flags: \`--addr\` (default \`127.0.0.1:9876\`), \`--provider\`, \`--model\`, \`--allow-write\`, \`--allow-shell\`. Reuses the same \`selectCodingStreamer\` factory as \`conduit code\` so provider behavior is consistent across surfaces.

## Frontend — \`spike/gui/src/\`

| File | Lines | Role |
|---|---|---|
| \`api.ts\` | 123 | Typed protocol, REST helpers, WebSocket client with capped exponential-backoff reconnect |
| \`components/ChatPanel.tsx\` | 267 | Replaces static \`AgentPanel\`. Streaming text renders live; tool calls inline as collapsible monospace blocks; textarea (Enter sends, Shift+Enter newline); status footer shows connection state |
| \`components/SessionList.tsx\` | 51 | Sessions sidebar tab; fetches \`/api/sessions\` |
| \`components/MemoryView.tsx\` | 39 | Memory main view; fetches \`/api/memory\`, renders SOUL.md + USER.md side-by-side |
| \`App.tsx\` (modified) | 152 | Wires the three components in. Spotlight + ⌥Space hotkey untouched |
| \`styles.css\` (appended) | +140 | Tool-call / session list / memory grid styles, matches existing tokens |

No new heavy deps. Native fetch + native WebSocket. Strict TS, zero \`any\` in new code.

## Wire protocol (shared spec)

WebSocket \`/api/agent\`:

\`\`\`typescript
// Server → Client
type ServerMessage =
  | { type: \"session\"; id: string; provider: string; model: string }
  | { type: \"text_delta\"; text: string }
  | { type: \"tool_use\"; id: string; name: string; input: string }
  | { type: \"tool_result\"; id: string; name: string; output: string; isError: boolean }
  | { type: \"end_turn\" }
  | { type: \"error\"; message: string };

// Client → Server
type ClientMessage = { type: \"prompt\"; text: string };
\`\`\`

REST: \`GET /api/info\`, \`GET /api/sessions\`, \`GET /api/memory\`.

## Verified

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` all green (incl. 4 new server tests covering REST handlers + the full WebSocket protocol with tool_use/tool_result/end_turn/error)
- [x] \`make lint\` clean (gofmt + vet)
- [x] \`cd spike/gui && npm run build\` clean (152 kB JS, no \`any\` types)
- [x] Live smoke against \`/api/info\`, \`/api/sessions\`, \`/api/memory\`: all return expected JSON
- [x] Live smoke text-only via WebSocket through Codex backend: streamed text_delta events → end_turn cleanly
- [x] Live smoke tool-call roundtrip via WebSocket: \`tool_use(read_file)\` → conduit dispatched → \`tool_result\` with file contents → final text_delta → end_turn
- [ ] Manual visual check in Tauri window (requires a desktop session, not in CI)

## Out of scope

- Auth/permission UI in the GUI (server inherits creds from env / \`~/.codex/auth.json\` the same way the CLI does)
- Evals tab still placeholder (no real eval data store yet)
- Workflow / canvas / diff / screenshot views still placeholder
- Frontend unit tests (manual verification via \`npm run build\` only; full Vitest setup for a follow-up)
- Per-session history (each WebSocket connection starts a fresh streamer; reconnecting loses prior turns)
- Auth refresh during long-running serve (server holds a cached token; the underlying codex.Auth refreshes on next request, so this works for normal use but a multi-day server run hitting expiry mid-call would surface as a 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)