### PR TITLE
feat: Projects shell — Codex-style sidebar + welcome composer + integration cards

### DIFF
--- a/internal/server/projects.go
+++ b/internal/server/projects.go
@@ -1,0 +1,312 @@
+package server
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ── /api/projects ────────────────────────────────────────────────────
+//
+// Groups coding-session journals by their RepositoryRoot so the GUI's
+// project sidebar can render each repo as a parent row with its chats
+// nested underneath. Sessions whose journals carry no RepositoryRoot
+// (e.g. ad-hoc invocations from /tmp) fall into the orphans bucket so
+// they don't disappear from the sidebar.
+//
+// The wire shape is locked — the frontend agent is building to the
+// exact field names below. Do not rename without coordinating.
+
+// ChatSummary is one entry under a project (or in the orphans list).
+type ChatSummary struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	CreatedAt string `json:"createdAt"`
+	TurnCount int    `json:"turnCount"`
+}
+
+// ProjectSummary groups chats by their RepositoryRoot.
+type ProjectSummary struct {
+	ID           string        `json:"id"`
+	Name         string        `json:"name"`
+	Path         string        `json:"path"`
+	AbsolutePath string        `json:"absolutePath"`
+	Branch       string        `json:"branch"`
+	SessionCount int           `json:"sessionCount"`
+	LastActivity string        `json:"lastActivity"`
+	Chats        []ChatSummary `json:"chats"`
+}
+
+type projectsResponse struct {
+	Projects []ProjectSummary `json:"projects"`
+	Orphans  []ChatSummary    `json:"orphans"`
+}
+
+// readSessionJournal opens a single .jsonl file and pulls out the
+// values needed to slot the session into the projects response. It
+// reads the file once with a line-oriented scanner: the first line
+// gives createdAt + the title (first non-empty user `Content`), every
+// line bumps the turn count, and the LAST line's `At` becomes
+// lastTurnAt. RepositoryRoot/GitBranch are taken from the FIRST
+// non-empty value seen so an early failed turn that didn't capture
+// them doesn't shadow a later one.
+func readSessionJournal(path string) (chat ChatSummary, repoRoot, branch string, lastTurnAt time.Time, err error) {
+	f, openErr := os.Open(path)
+	if openErr != nil {
+		err = openErr
+		return
+	}
+	defer f.Close()
+
+	id := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+	chat.ID = id
+
+	scanner := bufio.NewScanner(f)
+	// JSONL turns can be large (tool output, file diffs); allow up to 4 MiB per line.
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	turnCount := 0
+	titleSet := false
+	createdSet := false
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		turnCount++
+
+		var turn struct {
+			At             string `json:"At"`
+			Role           string `json:"Role"`
+			Content        string `json:"Content"`
+			RepositoryRoot string `json:"RepositoryRoot"`
+			GitBranch      string `json:"GitBranch"`
+		}
+		if jerr := json.Unmarshal(line, &turn); jerr != nil {
+			// Skip malformed lines but keep counting — partial journals
+			// shouldn't make the whole project disappear.
+			continue
+		}
+
+		if !createdSet && turn.At != "" {
+			chat.CreatedAt = normalizeTime(turn.At)
+			createdSet = true
+		}
+		if turn.At != "" {
+			if t, perr := time.Parse(time.RFC3339Nano, turn.At); perr == nil {
+				lastTurnAt = t
+			}
+		}
+		if !titleSet && turn.Role == "user" {
+			if title := truncateTitle(turn.Content); title != "" {
+				chat.Title = title
+				titleSet = true
+			}
+		}
+		if repoRoot == "" && turn.RepositoryRoot != "" {
+			repoRoot = turn.RepositoryRoot
+		}
+		if branch == "" && turn.GitBranch != "" {
+			branch = turn.GitBranch
+		}
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		err = scanErr
+		return
+	}
+	chat.TurnCount = turnCount
+	return
+}
+
+// truncateTitle trims whitespace and clamps to ~80 runes so the
+// sidebar's chat row isn't blown out by a 2 KB first message.
+func truncateTitle(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= 80 {
+		return s
+	}
+	return string(runes[:77]) + "..."
+}
+
+// normalizeTime re-emits a journal timestamp in RFC3339 (second
+// precision) so the GUI gets a stable shape regardless of whether the
+// source had nanos.
+func normalizeTime(s string) string {
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t.UTC().Format(time.RFC3339)
+	}
+	return s
+}
+
+// projectIDFromPath returns the first 16 hex chars of SHA-256(absolutePath).
+// Stable across restarts so the GUI can use it as a React key.
+func projectIDFromPath(absolutePath string) string {
+	sum := sha256.Sum256([]byte(absolutePath))
+	return fmt.Sprintf("%x", sum)[:16]
+}
+
+// homeRelative collapses an absolute path under home to a `~/...` form
+// for display. Anything outside home stays absolute.
+func homeRelative(absolutePath, home string) string {
+	if home == "" {
+		return absolutePath
+	}
+	if absolutePath == home {
+		return "~"
+	}
+	prefix := home + string(filepath.Separator)
+	if strings.HasPrefix(absolutePath, prefix) {
+		return "~" + string(filepath.Separator) + strings.TrimPrefix(absolutePath, prefix)
+	}
+	return absolutePath
+}
+
+// handleProjects walks sessionsDir, groups every .jsonl by its
+// RepositoryRoot, and emits the projects/orphans wire shape. Empty or
+// missing directory returns the empty-but-well-formed response with
+// 200 OK so the GUI can render an empty state without error handling.
+func (s *Server) handleProjects(w http.ResponseWriter, _ *http.Request) {
+	resp := projectsResponse{
+		Projects: []ProjectSummary{},
+		Orphans:  []ChatSummary{},
+	}
+	if s.sessionsDir == "" {
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+	entries, err := os.ReadDir(s.sessionsDir)
+	if err != nil {
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	// Bucket per RepositoryRoot. We track last-turn metadata so the
+	// project's branch + lastActivity reflect the most recent session,
+	// not whichever was read first off disk.
+	type bucket struct {
+		absolutePath string
+		chats        []ChatSummary
+		// Track the journal turn-time and a per-chat creation time so
+		// we can pick the most-recent session's branch.
+		lastTurnAt     time.Time
+		latestSession  time.Time
+		latestBranch   string
+		latestBranchAt time.Time
+	}
+	buckets := make(map[string]*bucket)
+	var orphans []ChatSummary
+	// Track a parallel slice of (orphan, createdAt) so we can sort.
+	type orphanEntry struct {
+		chat      ChatSummary
+		createdAt time.Time
+	}
+	var orphanEntries []orphanEntry
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		path := filepath.Join(s.sessionsDir, e.Name())
+		chat, repoRoot, branch, lastTurnAt, jerr := readSessionJournal(path)
+		if jerr != nil {
+			continue
+		}
+
+		// Use createdAt for ordering chats within a project. If the
+		// journal didn't carry an At field at all, fall back to the
+		// file's mtime so we still produce a stable order.
+		createdAt := time.Time{}
+		if chat.CreatedAt != "" {
+			if t, perr := time.Parse(time.RFC3339, chat.CreatedAt); perr == nil {
+				createdAt = t
+			}
+		}
+		if createdAt.IsZero() {
+			if fi, ferr := e.Info(); ferr == nil {
+				createdAt = fi.ModTime()
+			}
+		}
+
+		if repoRoot == "" {
+			orphanEntries = append(orphanEntries, orphanEntry{chat: chat, createdAt: createdAt})
+			continue
+		}
+
+		b, ok := buckets[repoRoot]
+		if !ok {
+			b = &bucket{absolutePath: repoRoot}
+			buckets[repoRoot] = b
+		}
+		b.chats = append(b.chats, chat)
+		if lastTurnAt.After(b.lastTurnAt) {
+			b.lastTurnAt = lastTurnAt
+		}
+		// Branch comes from the most-recent session (by createdAt).
+		// Empty branches never overwrite a real one.
+		if branch != "" && (b.latestBranch == "" || createdAt.After(b.latestBranchAt)) {
+			b.latestBranch = branch
+			b.latestBranchAt = createdAt
+		}
+		if createdAt.After(b.latestSession) {
+			b.latestSession = createdAt
+		}
+	}
+
+	// Build the projects slice. Within each project, sort chats by
+	// createdAt descending.
+	projects := make([]ProjectSummary, 0, len(buckets))
+	for _, b := range buckets {
+		// Re-derive a comparable createdAt per chat for sorting since
+		// ChatSummary stores its time as a string.
+		sort.SliceStable(b.chats, func(i, j int) bool {
+			ti, _ := time.Parse(time.RFC3339, b.chats[i].CreatedAt)
+			tj, _ := time.Parse(time.RFC3339, b.chats[j].CreatedAt)
+			return ti.After(tj)
+		})
+
+		lastActivity := b.lastTurnAt
+		if lastActivity.IsZero() {
+			lastActivity = b.latestSession
+		}
+
+		projects = append(projects, ProjectSummary{
+			ID:           projectIDFromPath(b.absolutePath),
+			Name:         filepath.Base(b.absolutePath),
+			Path:         homeRelative(b.absolutePath, s.homeDir),
+			AbsolutePath: b.absolutePath,
+			Branch:       b.latestBranch,
+			SessionCount: len(b.chats),
+			LastActivity: lastActivity.UTC().Format(time.RFC3339),
+			Chats:        b.chats,
+		})
+	}
+	sort.SliceStable(projects, func(i, j int) bool {
+		ti, _ := time.Parse(time.RFC3339, projects[i].LastActivity)
+		tj, _ := time.Parse(time.RFC3339, projects[j].LastActivity)
+		return ti.After(tj)
+	})
+
+	// Sort orphans by createdAt descending and strip the helper struct.
+	sort.SliceStable(orphanEntries, func(i, j int) bool {
+		return orphanEntries[i].createdAt.After(orphanEntries[j].createdAt)
+	})
+	orphans = make([]ChatSummary, 0, len(orphanEntries))
+	for _, oe := range orphanEntries {
+		orphans = append(orphans, oe.chat)
+	}
+
+	resp.Projects = projects
+	resp.Orphans = orphans
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/server/projects_test.go
+++ b/internal/server/projects_test.go
@@ -1,0 +1,232 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeJournal joins each turn (encoded as JSON) with newlines and
+// drops the result at sessionsDir/{id}.jsonl. Returns the resulting
+// path so callers can chmod or otherwise massage it.
+func writeJournal(t *testing.T, sessionsDir, id string, turns []map[string]any) string {
+	t.Helper()
+	var b strings.Builder
+	for _, turn := range turns {
+		raw, err := json.Marshal(turn)
+		if err != nil {
+			t.Fatalf("marshal turn: %v", err)
+		}
+		b.Write(raw)
+		b.WriteByte('\n')
+	}
+	path := filepath.Join(sessionsDir, id+".jsonl")
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func TestHandleProjects(t *testing.T) {
+	dir := t.TempDir()
+
+	// Two sessions sharing /repo/conduit (one older, one newer) — must group.
+	writeJournal(t, dir, "code-1-aaa", []map[string]any{
+		{
+			"Index": 0, "At": "2026-05-06T10:00:00Z",
+			"Role": "user", "Content": "first conduit chat — older session",
+			"RepositoryRoot": "/repo/conduit", "GitBranch": "main",
+		},
+		{
+			"Index": 1, "At": "2026-05-06T10:01:00Z",
+			"Role": "assistant", "Content": "ok",
+			"RepositoryRoot": "/repo/conduit", "GitBranch": "main",
+		},
+	})
+	writeJournal(t, dir, "code-2-bbb", []map[string]any{
+		{
+			"Index": 0, "At": "2026-05-06T12:00:00Z",
+			"Role":           "user",
+			"Content":        strings.Repeat("x", 200), // long → must truncate
+			"RepositoryRoot": "/repo/conduit", "GitBranch": "feat/projects-shell",
+		},
+		{
+			"Index": 1, "At": "2026-05-06T12:00:30Z",
+			"Role": "assistant", "Content": "yes",
+			"RepositoryRoot": "/repo/conduit", "GitBranch": "feat/projects-shell",
+		},
+		{
+			"Index": 2, "At": "2026-05-06T12:01:00Z",
+			"Role": "user", "Content": "follow-up",
+			"RepositoryRoot": "/repo/conduit", "GitBranch": "feat/projects-shell",
+		},
+	})
+
+	// One session in a different repo — must be its own project,
+	// and because its lastActivity (2026-05-06T13:00) > conduit's
+	// (12:01), it must sort first.
+	writeJournal(t, dir, "code-3-ccc", []map[string]any{
+		{
+			"Index": 0, "At": "2026-05-06T13:00:00Z",
+			"Role": "user", "Content": "other repo prompt",
+			"RepositoryRoot": "/repo/other", "GitBranch": "main",
+		},
+	})
+
+	// One session with no RepositoryRoot — must land in orphans.
+	writeJournal(t, dir, "code-4-ddd", []map[string]any{
+		{
+			"Index": 0, "At": "2026-05-06T11:00:00Z",
+			"Role": "user", "Content": "stray prompt",
+			// no RepositoryRoot
+		},
+	})
+
+	s := New(Config{SessionsDir: dir, HomeDir: "/home/test"})
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/projects", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", rr.Code)
+	}
+
+	var got projectsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, rr.Body.String())
+	}
+
+	// Two projects, in lastActivity-desc order: /repo/other (13:00),
+	// /repo/conduit (12:01).
+	if len(got.Projects) != 2 {
+		t.Fatalf("projects: got %d want 2 (%+v)", len(got.Projects), got.Projects)
+	}
+	if got.Projects[0].AbsolutePath != "/repo/other" {
+		t.Errorf("project[0] sort: got %q want /repo/other", got.Projects[0].AbsolutePath)
+	}
+	if got.Projects[1].AbsolutePath != "/repo/conduit" {
+		t.Errorf("project[1] sort: got %q want /repo/conduit", got.Projects[1].AbsolutePath)
+	}
+
+	// Conduit project: 2 chats, branch from most-recent session,
+	// chats sorted createdAt desc.
+	conduit := got.Projects[1]
+	if conduit.Name != "conduit" {
+		t.Errorf("name: got %q want conduit", conduit.Name)
+	}
+	if conduit.SessionCount != 2 {
+		t.Errorf("sessionCount: got %d want 2", conduit.SessionCount)
+	}
+	if conduit.Branch != "feat/projects-shell" {
+		t.Errorf("branch: got %q want feat/projects-shell", conduit.Branch)
+	}
+	if conduit.LastActivity != "2026-05-06T12:01:00Z" {
+		t.Errorf("lastActivity: got %q want 2026-05-06T12:01:00Z", conduit.LastActivity)
+	}
+	if len(conduit.Chats) != 2 {
+		t.Fatalf("chats: got %d want 2", len(conduit.Chats))
+	}
+	// Newest chat first.
+	if conduit.Chats[0].ID != "code-2-bbb" {
+		t.Errorf("chat[0]: got %q want code-2-bbb", conduit.Chats[0].ID)
+	}
+	if conduit.Chats[1].ID != "code-1-aaa" {
+		t.Errorf("chat[1]: got %q want code-1-aaa", conduit.Chats[1].ID)
+	}
+	// Title truncation: 200 x's clamps to 77 + "..." = 80 runes.
+	wantPrefix := strings.Repeat("x", 77) + "..."
+	if conduit.Chats[0].Title != wantPrefix {
+		t.Errorf("title truncation: got %q (len=%d) want %q", conduit.Chats[0].Title, len([]rune(conduit.Chats[0].Title)), wantPrefix)
+	}
+	// Older chat title pulled from first user content verbatim.
+	if conduit.Chats[1].Title != "first conduit chat — older session" {
+		t.Errorf("title: got %q want %q", conduit.Chats[1].Title, "first conduit chat — older session")
+	}
+	if conduit.Chats[1].TurnCount != 2 {
+		t.Errorf("turnCount: got %d want 2", conduit.Chats[1].TurnCount)
+	}
+	if conduit.Chats[1].CreatedAt != "2026-05-06T10:00:00Z" {
+		t.Errorf("createdAt: got %q want 2026-05-06T10:00:00Z", conduit.Chats[1].CreatedAt)
+	}
+
+	// Stable ID matches the helper.
+	if got, want := conduit.ID, projectIDFromPath("/repo/conduit"); got != want {
+		t.Errorf("project id: got %q want %q", got, want)
+	}
+	if len(conduit.ID) != 16 {
+		t.Errorf("project id length: got %d want 16", len(conduit.ID))
+	}
+
+	// Other project: 1 chat, lastActivity 13:00.
+	other := got.Projects[0]
+	if other.SessionCount != 1 || len(other.Chats) != 1 {
+		t.Errorf("other project chats: %+v", other)
+	}
+	if other.LastActivity != "2026-05-06T13:00:00Z" {
+		t.Errorf("other lastActivity: got %q", other.LastActivity)
+	}
+
+	// Orphans: 1 entry, the stray prompt.
+	if len(got.Orphans) != 1 {
+		t.Fatalf("orphans: got %d want 1 (%+v)", len(got.Orphans), got.Orphans)
+	}
+	if got.Orphans[0].ID != "code-4-ddd" {
+		t.Errorf("orphan id: got %q want code-4-ddd", got.Orphans[0].ID)
+	}
+	if got.Orphans[0].Title != "stray prompt" {
+		t.Errorf("orphan title: got %q want %q", got.Orphans[0].Title, "stray prompt")
+	}
+}
+
+func TestHandleProjectsMissingDir(t *testing.T) {
+	s := New(Config{SessionsDir: filepath.Join(t.TempDir(), "does-not-exist")})
+	rr := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/projects", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", rr.Code)
+	}
+	var got projectsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Projects) != 0 || len(got.Orphans) != 0 {
+		t.Errorf("missing-dir response: got %+v want empty projects+orphans", got)
+	}
+}
+
+func TestHomeRelative(t *testing.T) {
+	cases := []struct {
+		abs, home, want string
+	}{
+		{"/Users/me/code/conduit", "/Users/me", "~/code/conduit"},
+		{"/Users/me", "/Users/me", "~"},
+		{"/var/tmp/x", "/Users/me", "/var/tmp/x"},
+		{"/Users/me/code", "", "/Users/me/code"},
+	}
+	for _, c := range cases {
+		if got := homeRelative(c.abs, c.home); got != c.want {
+			t.Errorf("homeRelative(%q,%q): got %q want %q", c.abs, c.home, got, c.want)
+		}
+	}
+}
+
+// Sanity: ensure project ID is deterministic so the GUI can use it as a key.
+func TestProjectIDStable(t *testing.T) {
+	a := projectIDFromPath("/repo/conduit")
+	b := projectIDFromPath("/repo/conduit")
+	if a != b {
+		t.Errorf("non-deterministic id: %s vs %s", a, b)
+	}
+	if a == projectIDFromPath("/repo/other") {
+		t.Errorf("id collision: %s", a)
+	}
+	// Hash prefix surfaces as 16 hex chars.
+	if len(a) != 16 {
+		t.Errorf("id length: got %d want 16 (id=%q)", len(a), a)
+	}
+	_ = fmt.Sprintf // keep fmt import if future asserts need it
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -83,6 +83,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/agent", s.handleAgent)
 	mux.HandleFunc("/api/info", s.handleInfo)
 	mux.HandleFunc("/api/sessions", s.handleSessions)
+	mux.HandleFunc("/api/projects", s.handleProjects)
 	mux.HandleFunc("/api/memory", s.handleMemory)
 	return withCORS(mux)
 }

--- a/spike/gui/src/App.tsx
+++ b/spike/gui/src/App.tsx
@@ -1,39 +1,20 @@
 import { useEffect, useState } from "react";
-import {
-  Brain,
-  Gauge,
-  History,
-  MessagesSquare,
-  Sparkles,
-  Workflow,
-  type LucideIcon,
-} from "lucide-react";
 import { Spotlight } from "./Spotlight";
 import { ChatPanel } from "./components/ChatPanel";
-import { SessionList } from "./components/SessionList";
-import { MemoryView } from "./components/MemoryView";
-import logoUrl from "../../../assets/logo.svg";
+import { Sidebar } from "./components/Sidebar";
+import { WelcomeScreen } from "./components/WelcomeScreen";
 
-type SidebarTab = "chat" | "sessions" | "workflows" | "memory" | "skills" | "evals";
-
-type MainView = "chat" | "sessions" | "workflow" | "memory" | "evals";
-
-const TABS: { id: SidebarTab; label: string; view: MainView; icon: LucideIcon }[] = [
-  { id: "chat", label: "Chat", view: "chat", icon: MessagesSquare },
-  { id: "sessions", label: "Sessions", view: "sessions", icon: History },
-  { id: "workflows", label: "Workflows", view: "workflow", icon: Workflow },
-  { id: "memory", label: "Memory", view: "memory", icon: Brain },
-  { id: "skills", label: "Skills", view: "chat", icon: Sparkles },
-  { id: "evals", label: "Evals", view: "evals", icon: Gauge },
-];
-
+// Top-level shell: sidebar + main. activeChatId === null routes to the
+// welcome screen; "new" focuses the welcome composer; any other id renders
+// the live ChatPanel keyed on that id (so a fresh WS connect happens per
+// session — full history loading is SUP-30, out of scope here).
 export function App() {
-  const [activeTab, setActiveTab] = useState<SidebarTab>("chat");
-  const [mainView, setMainView] = useState<MainView>("chat");
+  const [activeChatId, setActiveChatId] = useState<string | null>(null);
+  const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [spotlightOpen, setSpotlightOpen] = useState(false);
 
-  // Global hotkey: ⌥Space (the production binding) AND ⌘K (dev convenience
-  // because most browsers swallow ⌥Space for IME composition).
+  // Global hotkey: ⌥Space (production) + ⌘K (dev convenience because most
+  // browsers swallow ⌥Space for IME composition).
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       const isSpotlight =
@@ -49,127 +30,46 @@ export function App() {
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
-  function selectTab(id: SidebarTab) {
-    setActiveTab(id);
-    const tab = TABS.find((t) => t.id === id);
-    if (tab) setMainView(tab.view);
+  function handleNewChat() {
+    setPendingPrompt(null);
+    setActiveChatId("new");
   }
 
+  function handleStartChat(prompt: string) {
+    setPendingPrompt(prompt);
+    setActiveChatId("active");
+  }
+
+  function handleSelectChat(id: string) {
+    setPendingPrompt(null);
+    setActiveChatId(id);
+  }
+
+  // Welcome shows whenever the user hasn't chosen a chat yet OR pressed
+  // "New chat" but hasn't typed anything. ChatPanel takes over once a
+  // prompt is in flight (activeChatId === "active") or a session is open.
+  const showWelcome = activeChatId === null || activeChatId === "new";
+
   return (
-    <div className="app">
-      <Sidebar activeTab={activeTab} onSelect={selectTab} />
-      <Main view={mainView} activeTab={activeTab} />
-      {spotlightOpen && (
-        <Spotlight onClose={() => setSpotlightOpen(false)} />
-      )}
+    <div className="app-shell">
+      <Sidebar
+        activeChatId={activeChatId}
+        onSelectChat={handleSelectChat}
+        onNewChat={handleNewChat}
+        version="0.4.2"
+      />
+      <main className="app-main">
+        {showWelcome ? (
+          <WelcomeScreen
+            branch="feat/projects-shell"
+            onStartChat={handleStartChat}
+            autoFocus={activeChatId === "new"}
+          />
+        ) : (
+          <ChatPanel key={activeChatId} initialPrompt={pendingPrompt} />
+        )}
+      </main>
+      {spotlightOpen && <Spotlight onClose={() => setSpotlightOpen(false)} />}
     </div>
   );
-}
-
-function Sidebar({
-  activeTab,
-  onSelect,
-}: {
-  activeTab: SidebarTab;
-  onSelect: (id: SidebarTab) => void;
-}) {
-  return (
-    <aside className="sidebar" aria-label="Navigation">
-      <div className="sidebar-header">
-        <img src={logoUrl} alt="" className="sidebar-logo" />
-        <span>Conduit</span>
-      </div>
-      <nav>
-        {TABS.map((t) => {
-          const Icon = t.icon;
-          return (
-            <button
-              key={t.id}
-              className={`sidebar-tab ${activeTab === t.id ? "active" : ""}`}
-              onClick={() => onSelect(t.id)}
-            >
-              <Icon size={16} className="sidebar-tab-icon" aria-hidden />
-              <span>{t.label}</span>
-            </button>
-          );
-        })}
-      </nav>
-      {activeTab === "sessions" && (
-        <div className="sidebar-section">
-          <SessionList />
-        </div>
-      )}
-      <div className="sidebar-footer">
-        <kbd>⌥Space</kbd> Spotlight · <kbd>⌘K</kbd> Palette
-      </div>
-    </aside>
-  );
-}
-
-function Main({ view, activeTab }: { view: MainView; activeTab: SidebarTab }) {
-  // Chat is the primary surface — render it edge-to-edge in main without a
-  // header, since ChatPanel has its own header with provider/model badge.
-  if (view === "chat") {
-    return (
-      <main className="main main-chat" aria-label="Chat">
-        <ChatPanel />
-      </main>
-    );
-  }
-  return (
-    <main className="main" aria-label="Main content">
-      <div className="main-header">
-        {view === "memory" && (
-          <Brain size={16} className="main-header-icon" aria-hidden />
-        )}
-        <span>{viewTitle(view)}</span>
-      </div>
-      <div className="main-body">{viewBody(view, activeTab)}</div>
-    </main>
-  );
-}
-
-function viewTitle(v: MainView): string {
-  switch (v) {
-    case "chat":
-      return "Chat";
-    case "sessions":
-      return "Sessions";
-    case "workflow":
-      return "Workflow DAG";
-    case "memory":
-      return "Memory — SOUL.md / USER.md";
-    case "evals":
-      return "Evals — scorecards";
-  }
-}
-
-function viewBody(v: MainView, _activeTab: SidebarTab) {
-  if (v === "memory") {
-    return <MemoryView />;
-  }
-  if (v === "evals") {
-    return (
-      <div className="placeholder">
-        <p>Per-model scorecards + trend lines.</p>
-        <p>View-model: <code>internal/gui/evals_view.go</code></p>
-      </div>
-    );
-  }
-  if (v === "workflow") {
-    return (
-      <div className="placeholder">
-        <p>Workflow DAG renderer — already implemented in <code>internal/gui/workflow_dag.go</code>.</p>
-      </div>
-    );
-  }
-  if (v === "sessions") {
-    return (
-      <div className="placeholder">
-        <p>Pick a session in the sidebar to view its turns.</p>
-        <p>View-model: <code>internal/gui/session_tree.go</code></p>
-      </div>
-    );
-  }
-  return null;
 }

--- a/spike/gui/src/api.ts
+++ b/spike/gui/src/api.ts
@@ -40,6 +40,32 @@ export type Memory = {
   user: string;
 };
 
+// Projects + chats — wire shape that the backend agent is building to.
+// Server source of truth: internal/gui/api/projects.go.
+
+export type ChatSummary = {
+  id: string;
+  title: string;
+  createdAt: string; // ISO
+  turnCount: number;
+};
+
+export type Project = {
+  id: string;
+  name: string;
+  path: string; // home-relative ~/...
+  absolutePath: string;
+  branch: string; // may be ""
+  sessionCount: number;
+  lastActivity: string; // ISO
+  chats: ChatSummary[];
+};
+
+export type ProjectsResponse = {
+  projects: Project[];
+  orphans: ChatSummary[];
+};
+
 // ── REST helpers ─────────────────────────────────────────────────────────
 
 async function getJSON<T>(path: string): Promise<T> {
@@ -52,6 +78,12 @@ export const getInfo = (): Promise<Info> => getJSON<Info>("/api/info");
 export const getSessions = (): Promise<SessionMeta[]> =>
   getJSON<SessionMeta[]>("/api/sessions");
 export const getMemory = (): Promise<Memory> => getJSON<Memory>("/api/memory");
+export const getProjects = (): Promise<ProjectsResponse> =>
+  getJSON<ProjectsResponse>("/api/projects");
+
+export function baseUrl(): string {
+  return BASE;
+}
 
 // ── WebSocket helper with reconnection ───────────────────────────────────
 

--- a/spike/gui/src/components/BrandRow.tsx
+++ b/spike/gui/src/components/BrandRow.tsx
@@ -1,0 +1,92 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+// Inlined Conduit "Channel Bracket" logo, traced from assets/logo.svg.
+// Inline so the sidebar can size it freely (22px) and the welcome screen can
+// reuse it at 44px without an extra <img>/<svg> roundtrip.
+export function ConduitMark({
+  size,
+  className,
+  idSuffix = "sm",
+}: {
+  size: number;
+  className?: string;
+  idSuffix?: string;
+}) {
+  const bgId = `conduit-bg-${idSuffix}`;
+  const gradId = `conduit-grad-${idSuffix}`;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 512 512"
+      className={className}
+      aria-hidden
+    >
+      <defs>
+        <linearGradient id={bgId} x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="#0b0d12" />
+          <stop offset="100%" stopColor="#0e1320" />
+        </linearGradient>
+        <linearGradient id={gradId} x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0%" stopColor="#fbbf24" />
+          <stop offset="100%" stopColor="#b45309" />
+        </linearGradient>
+      </defs>
+      <rect width="512" height="512" rx="112" fill={`url(#${bgId})`} />
+      <path
+        d="M 184 128 L 128 128 L 128 384 L 184 384"
+        fill="none"
+        stroke="#f5f5f4"
+        strokeWidth="36"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M 328 128 L 384 128 L 384 384 L 328 384"
+        fill="none"
+        stroke="#f5f5f4"
+        strokeWidth="36"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M 220 192 L 296 256 L 220 320"
+        fill="none"
+        stroke={`url(#${gradId})`}
+        strokeWidth="40"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx="178" cy="256" r="10" fill="#fbbf24" opacity="0.6" />
+      <circle cx="156" cy="256" r="6" fill="#fbbf24" opacity="0.3" />
+    </svg>
+  );
+}
+
+// BrandRow renders the macOS chrome row (traffic lights + back/fwd + Update
+// pill) and below it the brand row (logo + Conduit + version). It sits at
+// the top of the sidebar.
+export function BrandRow({ version }: { version: string }) {
+  return (
+    <>
+      <div className="chrome">
+        <div className="traffic" aria-hidden>
+          <span className="dot dot-r" />
+          <span className="dot dot-y" />
+          <span className="dot dot-g" />
+        </div>
+        <div className="nav-arrows" aria-hidden>
+          <ChevronLeft size={16} />
+          <ChevronRight size={16} />
+        </div>
+        <div className="chrome-spacer" />
+        <div className="update-pill">Update</div>
+      </div>
+      <div className="brand-row">
+        <ConduitMark size={22} className="brand-logo" idSuffix="brand" />
+        <span className="wordmark">Conduit</span>
+        <span className="brand-version">v{version}</span>
+      </div>
+    </>
+  );
+}

--- a/spike/gui/src/components/ChatPanel.tsx
+++ b/spike/gui/src/components/ChatPanel.tsx
@@ -63,7 +63,11 @@ function providerTone(provider: string | undefined): ProviderTone {
   }
 }
 
-export function ChatPanel() {
+export function ChatPanel({
+  initialPrompt = null,
+}: {
+  initialPrompt?: string | null;
+}) {
   const [info, setInfo] = useState<Info | null>(null);
   const [state, setState] = useState<ConnectionState>("connecting");
   const [turns, setTurns] = useState<Turn[]>([]);
@@ -71,6 +75,9 @@ export function ChatPanel() {
   const clientRef = useRef<ReturnType<typeof connectAgent> | null>(null);
   const streamRef = useRef<HTMLDivElement | null>(null);
   const turnIdRef = useRef(0);
+  // Track whether the welcome composer's prompt was already auto-sent so
+  // reconnects after a network blip don't replay it.
+  const initialSentRef = useRef(false);
 
   useEffect(() => {
     getInfo().then(setInfo).catch(() => {
@@ -87,6 +94,21 @@ export function ChatPanel() {
     clientRef.current = client;
     return () => client.close();
   }, []);
+
+  // Auto-send the welcome-screen prompt once the WS is connected. Renders
+  // the user turn locally so the chat surface mirrors a real send.
+  useEffect(() => {
+    if (state !== "connected" || initialSentRef.current) return;
+    const text = initialPrompt?.trim();
+    if (!text) return;
+    initialSentRef.current = true;
+    const id = ++turnIdRef.current;
+    setTurns((prev) => [
+      ...prev,
+      { id, blocks: [{ kind: "user", text }], done: false },
+    ]);
+    clientRef.current?.send({ type: "prompt", text });
+  }, [state, initialPrompt]);
 
   // Pin the stream to the bottom whenever it grows.
   useEffect(() => {

--- a/spike/gui/src/components/IntegrationCard.tsx
+++ b/spike/gui/src/components/IntegrationCard.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from "react";
+
+// IntegrationCard renders one of the 4 connect-X cards under the welcome
+// composer. Pure presentational — clicking the card is a no-op for now since
+// integration auth flows aren't wired in this PR.
+export function IntegrationCard({
+  icon,
+  title,
+  body,
+}: {
+  icon: ReactNode;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div className="integration-card">
+      <div className="integration-brand">{icon}</div>
+      <div className="integration-title">{title}</div>
+      <div className="integration-body">{body}</div>
+    </div>
+  );
+}
+
+// ── Brand SVGs — inlined so the cards don't depend on an icon library for
+//    third-party logos and so each mark gets its real brand colors. ──────
+
+export function GitHubMark() {
+  return (
+    <svg width="32" height="32" viewBox="0 0 24 24" fill="#E2E5EE" aria-hidden>
+      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.36-3.88-1.36-.52-1.33-1.28-1.69-1.28-1.69-1.05-.71.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.71 1.26 3.37.96.1-.75.4-1.26.74-1.55-2.55-.29-5.23-1.27-5.23-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 0 1 5.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5z" />
+    </svg>
+  );
+}
+
+export function LinearMark() {
+  return (
+    <svg width="32" height="32" viewBox="0 0 100 100" aria-hidden>
+      <defs>
+        <linearGradient id="conduit-linear-grad" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="#5E6AD2" />
+          <stop offset="100%" stopColor="#7A8CFF" />
+        </linearGradient>
+      </defs>
+      <path
+        fill="url(#conduit-linear-grad)"
+        d="M2 56c1.6 17.7 15.3 31.4 33 33L2 56zm0-9.6L45.6 90c4 .4 7.6.4 11.7 0L2 34.7v11.7zm0-19.7L65.3 88c2.8-.7 5.4-1.7 8-2.9L4.9 17.5c-1.2 2.6-2.2 5.2-2.9 8zM10.6 9C19.7 1.3 31-2 50 2c26.4 5.6 42.4 21.6 48 48 4 19-.7 30.3-8.4 39.4L10.6 9z"
+      />
+    </svg>
+  );
+}
+
+export function McpMark() {
+  return (
+    <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden>
+      <path
+        d="M16 2 L28 9 V23 L16 30 L4 23 V9 Z"
+        stroke="#F59E1F"
+        strokeWidth="1.8"
+        fill="rgba(245,158,31,0.06)"
+      />
+      <circle cx="16" cy="16" r="4" fill="#36B3CF" />
+      <path
+        d="M16 12 V6 M16 26 V20 M22 16 H28 M4 16 H10"
+        stroke="#36B3CF"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function SlackMark() {
+  return (
+    <svg width="32" height="32" viewBox="0 0 32 32" aria-hidden>
+      <rect x="4" y="13" width="9" height="3" rx="1.5" fill="#36C5F0" />
+      <rect x="13" y="4" width="3" height="9" rx="1.5" fill="#2EB67D" />
+      <rect
+        x="16"
+        y="13"
+        width="9"
+        height="3"
+        rx="1.5"
+        transform="rotate(180 20.5 14.5)"
+        fill="#ECB22E"
+      />
+      <rect
+        x="13"
+        y="16"
+        width="3"
+        height="9"
+        rx="1.5"
+        transform="rotate(180 14.5 20.5)"
+        fill="#E01E5A"
+      />
+      <rect x="19" y="13" width="9" height="3" rx="1.5" fill="#ECB22E" />
+      <rect x="16" y="19" width="3" height="9" rx="1.5" fill="#E01E5A" />
+      <rect x="4" y="16" width="9" height="3" rx="1.5" fill="#36C5F0" />
+      <rect x="13" y="19" width="3" height="9" rx="1.5" fill="#2EB67D" />
+    </svg>
+  );
+}

--- a/spike/gui/src/components/Sidebar.tsx
+++ b/spike/gui/src/components/Sidebar.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Clock,
+  Filter,
+  Folder,
+  MessageSquarePlus,
+  Plus,
+  Search,
+  Workflow,
+  Wrench,
+} from "lucide-react";
+import { BrandRow } from "./BrandRow";
+import { getProjects, type ChatSummary, type Project } from "../api";
+
+// Sidebar is the permanent left rail — chrome + brand + nav + projects + chats.
+// It owns the projects fetch (one shot on mount) and lifts chat selection up
+// to App via onSelectChat / onNewChat.
+export function Sidebar({
+  activeChatId,
+  onSelectChat,
+  onNewChat,
+  version,
+}: {
+  activeChatId: string | null;
+  onSelectChat: (id: string) => void;
+  onNewChat: () => void;
+  version: string;
+}) {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [orphans, setOrphans] = useState<ChatSummary[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getProjects()
+      .then((res) => {
+        setProjects(res.projects);
+        setOrphans(res.orphans);
+      })
+      .catch((e: unknown) =>
+        setError(e instanceof Error ? e.message : String(e)),
+      );
+  }, []);
+
+  return (
+    <aside className="conduit-sidebar" aria-label="Navigation">
+      <BrandRow version={version} />
+
+      <nav className="sb-nav">
+        <button
+          type="button"
+          className={`sb-nav-row ${activeChatId === null || activeChatId === "new" ? "active" : ""}`}
+          onClick={onNewChat}
+        >
+          <MessageSquarePlus size={16} aria-hidden />
+          <span className="sb-nav-label">New chat</span>
+        </button>
+        <button type="button" className="sb-nav-row">
+          <Search size={16} aria-hidden />
+          <span className="sb-nav-label">Search</span>
+        </button>
+        <button type="button" className="sb-nav-row">
+          <Wrench size={16} aria-hidden />
+          <span className="sb-nav-label">Plugins</span>
+        </button>
+        <button type="button" className="sb-nav-row">
+          <Workflow size={16} aria-hidden />
+          <span className="sb-nav-label">Automations</span>
+        </button>
+      </nav>
+
+      <div className="sb-scroll">
+        <ProjectsSection
+          projects={projects}
+          activeChatId={activeChatId}
+          onSelectChat={onSelectChat}
+          error={error}
+        />
+        <OrphanChatsSection
+          orphans={orphans}
+          activeChatId={activeChatId}
+          onSelectChat={onSelectChat}
+        />
+      </div>
+
+      <div className="sb-footer">
+        <kbd>⌥Space</kbd> Spotlight · <kbd>⌘K</kbd> Palette
+      </div>
+    </aside>
+  );
+}
+
+function ProjectsSection({
+  projects,
+  activeChatId,
+  onSelectChat,
+  error,
+}: {
+  projects: Project[];
+  activeChatId: string | null;
+  onSelectChat: (id: string) => void;
+  error: string | null;
+}) {
+  return (
+    <div className="sb-section">
+      <div className="sb-section-header">
+        <span className="sb-section-label">Projects</span>
+        <span className="sb-section-actions">
+          <span className="sb-icon-btn" aria-hidden>
+            <Plus size={13} />
+          </span>
+        </span>
+      </div>
+
+      {error && <div className="sb-section-empty">Failed: {error}</div>}
+      {!error && projects.length === 0 && (
+        <div className="sb-section-empty">No projects yet</div>
+      )}
+      {projects.map((p) => (
+        <ProjectRow
+          key={p.id}
+          project={p}
+          activeChatId={activeChatId}
+          onSelectChat={onSelectChat}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ProjectRow({
+  project,
+  activeChatId,
+  onSelectChat,
+}: {
+  project: Project;
+  activeChatId: string | null;
+  onSelectChat: (id: string) => void;
+}) {
+  // Project rows expand to show their chats by default — collapse is local-only.
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <button
+        type="button"
+        className="sb-project"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <Folder size={14} aria-hidden />
+        <span className="sb-project-name">{project.name}</span>
+      </button>
+      {open && project.chats.length > 0 && (
+        <div className="sb-chats">
+          {project.chats.map((c) => (
+            <ChatRow
+              key={c.id}
+              chat={c}
+              indent={36}
+              active={activeChatId === c.id}
+              onSelect={onSelectChat}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+function OrphanChatsSection({
+  orphans,
+  activeChatId,
+  onSelectChat,
+}: {
+  orphans: ChatSummary[];
+  activeChatId: string | null;
+  onSelectChat: (id: string) => void;
+}) {
+  return (
+    <div className="sb-section">
+      <div className="sb-section-header">
+        <span className="sb-section-label">Chats</span>
+        <span className="sb-section-actions">
+          <span className="sb-icon-btn" aria-hidden>
+            <Filter size={13} />
+          </span>
+          <span className="sb-icon-btn" aria-hidden>
+            <Plus size={13} />
+          </span>
+        </span>
+      </div>
+      {orphans.length === 0 && (
+        <div className="sb-section-empty">No orphan chats</div>
+      )}
+      <div className="sb-chats">
+        {orphans.map((c) => (
+          <ChatRow
+            key={c.id}
+            chat={c}
+            indent={14}
+            active={activeChatId === c.id}
+            onSelect={onSelectChat}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ChatRow({
+  chat,
+  indent,
+  active,
+  onSelect,
+}: {
+  chat: ChatSummary;
+  indent: number;
+  active: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const ts = useMemo(() => relativeTime(chat.createdAt), [chat.createdAt]);
+  return (
+    <button
+      type="button"
+      className={`sb-chat-row ${active ? "active" : ""}`}
+      style={{ paddingLeft: indent }}
+      onClick={() => onSelect(chat.id)}
+      title={chat.title}
+    >
+      <span className="sb-chat-name">{chat.title}</span>
+      <span className="sb-chat-ts">
+        <Clock size={10} aria-hidden /> {ts}
+      </span>
+    </button>
+  );
+}
+
+// relativeTime collapses an ISO timestamp into the compact h/d/w/mo form the
+// design uses — same vocabulary as iMessage / Slack.
+function relativeTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const diffMs = Date.now() - d.getTime();
+  const min = Math.floor(diffMs / 60000);
+  if (min < 1) return "now";
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d`;
+  const wk = Math.floor(day / 7);
+  if (wk < 5) return `${wk}w`;
+  const mo = Math.floor(day / 30);
+  if (mo < 12) return `${mo}mo`;
+  return `${Math.floor(day / 365)}y`;
+}

--- a/spike/gui/src/components/WelcomeScreen.tsx
+++ b/spike/gui/src/components/WelcomeScreen.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  ArrowUp,
+  ChevronDown,
+  Folder,
+  GitBranch,
+  Laptop,
+  Mic,
+  Plus,
+  Square,
+  SquareSplitHorizontal,
+} from "lucide-react";
+import { ConduitMark } from "./BrandRow";
+import {
+  GitHubMark,
+  IntegrationCard,
+  LinearMark,
+  McpMark,
+  SlackMark,
+} from "./IntegrationCard";
+
+// WelcomeScreen is the empty-state body of <main>. It's shown when no chat is
+// selected (activeChatId === null or "new"). The composer's submit fires the
+// onStartChat callback, which the parent uses to create a session and route
+// to ChatPanel for the rest of the conversation.
+export function WelcomeScreen({
+  branch,
+  onStartChat,
+  autoFocus,
+}: {
+  branch: string;
+  onStartChat: (prompt: string) => void;
+  autoFocus: boolean;
+}) {
+  const [draft, setDraft] = useState("");
+  const taRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (autoFocus) taRef.current?.focus();
+  }, [autoFocus]);
+
+  function submit() {
+    const text = draft.trim();
+    if (!text) return;
+    onStartChat(text);
+    setDraft("");
+  }
+
+  function onKey(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  }
+
+  return (
+    <div className="welcome">
+      <div className="welcome-top-actions" aria-hidden>
+        <button type="button" className="ghost-icon-btn" title="Split window">
+          <SquareSplitHorizontal size={16} />
+        </button>
+        <button type="button" className="ghost-icon-btn" title="New window">
+          <Square size={16} />
+        </button>
+      </div>
+
+      <div className="welcome-center">
+        <ConduitMark size={44} className="welcome-mark" idSuffix="hero" />
+        <h1 className="welcome-headline">What should we build in conduit?</h1>
+
+        <div className="composer-wrap">
+          <div className="composer">
+            <textarea
+              ref={taRef}
+              className="composer-input"
+              placeholder="Ask Conduit anything. @ to mention files or tools"
+              rows={3}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={onKey}
+            />
+            <div className="composer-bar">
+              <div className="composer-bar-left">
+                <button
+                  type="button"
+                  className="composer-icon"
+                  title="Attach"
+                  aria-label="Attach"
+                >
+                  <Plus size={16} />
+                </button>
+                <span className="pill pill-sandbox">
+                  <span className="pill-dot" />
+                  Sandboxed
+                  <ChevronDown size={10} className="pill-chev" />
+                </span>
+                <span className="pill pill-model">
+                  gpt-5.5 Medium
+                  <ChevronDown size={10} className="pill-chev" />
+                </span>
+              </div>
+              <div className="composer-bar-right">
+                <button
+                  type="button"
+                  className="composer-icon"
+                  title="Voice"
+                  aria-label="Voice"
+                >
+                  <Mic size={15} />
+                </button>
+                <button
+                  type="button"
+                  className="composer-send"
+                  onClick={submit}
+                  disabled={draft.trim().length === 0}
+                  aria-label="Send"
+                  title="Send"
+                >
+                  <ArrowUp size={14} strokeWidth={2.4} />
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="context-row">
+            <span className="ctx-pill">
+              <Folder size={13} />
+              conduit
+              <ChevronDown size={10} className="pill-chev" />
+            </span>
+            <span className="ctx-pill">
+              <Laptop size={13} />
+              Work locally
+              <ChevronDown size={10} className="pill-chev" />
+            </span>
+            <span className="ctx-pill">
+              <GitBranch size={13} />
+              {branch || "main"}
+              <ChevronDown size={10} className="pill-chev" />
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="integration-cards">
+        <IntegrationCard
+          icon={<GitHubMark />}
+          title="Connect GitHub"
+          body="Pull issues, branches, and PR context"
+        />
+        <IntegrationCard
+          icon={<LinearMark />}
+          title="Connect Linear"
+          body="Plan from your team's backlog"
+        />
+        <IntegrationCard
+          icon={<McpMark />}
+          title="Connect MCP"
+          body="Plug in external tools and data"
+        />
+        <IntegrationCard
+          icon={<SlackMark />}
+          title="Connect Slack"
+          body="Pull context from team threads"
+        />
+      </div>
+    </div>
+  );
+}

--- a/spike/gui/src/styles.css
+++ b/spike/gui/src/styles.css
@@ -16,7 +16,7 @@ body,
   background: var(--color-surface-canvas);
   color: var(--color-text-body);
   font-family: var(--ref-type-family-sans);
-  font-size: var(--ref-type-size-small);
+  font-size: var(--ref-type-size-body);
   line-height: var(--ref-type-line-height-normal);
   -webkit-font-smoothing: antialiased;
 }
@@ -27,161 +27,558 @@ body,
   border-radius: var(--ref-radius-sm);
 }
 
-/* ── two-column shell — sidebar + main (chat lives in main) ─────────── */
-.app {
-  display: grid;
-  grid-template-columns: 240px 1fr;
-  height: 100vh;
-  gap: 0;
-}
-
-/* Chat-as-main: ChatPanel paints the whole main column edge-to-edge,
-   no main-header (ChatPanel has its own header with provider badge). */
-.main-chat {
+button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  cursor: pointer;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  overflow: hidden;
 }
-.main-chat .agent-panel {
-  border-left: none;
+
+/* ── shell: sidebar + main ──────────────────────────────────────────── */
+.app-shell {
+  display: flex;
+  height: 100vh;
+  width: 100%;
+}
+
+.app-main {
   flex: 1;
-  min-height: 0;
-}
-
-.sidebar {
-  border-right: 1px solid var(--color-border-subtle);
-  background: var(--color-surface-primary);
+  min-width: 0;
+  background: var(--color-surface-canvas);
   display: flex;
   flex-direction: column;
-  padding: var(--ref-space-md) 0;
+  overflow: hidden;
+  position: relative;
 }
 
-.sidebar-header {
+/* ── sidebar ────────────────────────────────────────────────────────── */
+.conduit-sidebar {
+  width: 280px;
+  flex: 0 0 280px;
+  background: var(--color-surface-sunken);
   display: flex;
-  align-items: center;
-  padding: 0 var(--ref-space-md) var(--ref-space-md);
-  font-family: var(--ref-type-family-display);
-  font-weight: var(--ref-type-weight-semibold);
-  font-size: var(--ref-type-size-small);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  flex-direction: column;
+  overflow: hidden;
   color: var(--color-text-body);
 }
 
-.sidebar-logo {
+.chrome {
+  height: 40px;
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  gap: 12px;
+  flex: 0 0 40px;
+}
+
+.traffic {
+  display: flex;
+  gap: 8px;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.dot-r { background: #FF5F57; }
+.dot-y { background: #FEBC2E; }
+.dot-g { background: #28C840; }
+
+.nav-arrows {
+  display: flex;
+  gap: 2px;
+  margin-left: 6px;
+  color: var(--color-text-subtle);
+}
+
+.chrome-spacer {
+  flex: 1;
+}
+
+.update-pill {
+  background: var(--color-accent-cool);
+  color: var(--color-text-body);
+  font-size: var(--ref-type-size-caption);
+  font-weight: var(--ref-type-weight-semibold);
+  padding: 4px 10px;
+  border-radius: var(--ref-radius-md);
+  letter-spacing: 0.1px;
+}
+
+.brand-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px 18px;
+}
+
+.brand-logo {
   width: 22px;
   height: 22px;
-  margin-right: var(--ref-space-sm);
-  border-radius: var(--ref-radius-sm);
+  border-radius: 5px;
   display: block;
-  flex-shrink: 0;
+  flex: 0 0 22px;
 }
 
-.sidebar nav {
+.wordmark {
+  font-size: 15px;
+  font-weight: var(--ref-type-weight-semibold);
+  letter-spacing: 0.1px;
+  color: var(--color-text-body);
+}
+
+.brand-version {
+  font-size: var(--ref-type-size-caption);
+  color: var(--color-text-subtle);
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.sb-nav {
+  padding: 10px 8px 4px;
   display: flex;
   flex-direction: column;
-  gap: var(--ref-space-xs);
-  padding: 0 var(--ref-space-sm);
+  gap: 1px;
 }
 
-.sidebar-tab {
+.sb-nav-row {
   display: flex;
   align-items: center;
-  gap: var(--ref-space-sm);
-  background: transparent;
-  border: 1px solid transparent;
+  gap: 10px;
+  padding: 7px 10px;
+  border-radius: var(--ref-radius-md);
   color: var(--color-text-muted);
+  font-size: var(--ref-type-size-body);
   text-align: left;
-  padding: var(--ref-space-sm) var(--ref-space-sm);
-  border-radius: var(--ref-radius-sm);
-  font: inherit;
+  width: 100%;
+}
+
+.sb-nav-row:hover {
+  background: var(--color-surface-primary);
+  color: var(--color-text-body);
+}
+
+.sb-nav-row.active {
+  background: var(--color-surface-primary);
+  color: var(--color-text-body);
+}
+
+.sb-nav-row.active svg {
+  color: var(--color-text-body);
+}
+
+.sb-nav-label {
+  flex: 1;
+}
+
+.sb-scroll {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.sb-section {
+  margin-top: 14px;
+  padding: 0 8px;
+}
+
+.sb-section-header {
+  display: flex;
+  align-items: center;
+  padding: 4px 10px 6px;
+  color: var(--color-text-subtle);
+  font-size: var(--ref-type-size-caption);
   font-weight: var(--ref-type-weight-medium);
-  cursor: pointer;
-  transition: background-color 120ms ease, border-color 120ms ease,
-    color 120ms ease;
+  letter-spacing: 0.2px;
 }
 
-.sidebar-tab:hover {
-  background: var(--color-surface-elevated);
+.sb-section-label {
+  flex: 1;
+}
+
+.sb-section-actions {
+  display: flex;
+  gap: 4px;
+  color: var(--color-text-subtle);
+}
+
+.sb-icon-btn {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--ref-radius-sm);
+  color: var(--color-text-subtle);
+}
+
+.sb-section-empty {
+  padding: 4px 10px;
+  color: var(--color-text-subtle);
+  font-size: var(--ref-type-size-small);
+}
+
+.sb-project {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 6px 10px;
+  border-radius: var(--ref-radius-md);
+  color: var(--color-text-body);
+  font-size: var(--ref-type-size-body);
+  width: 100%;
+  text-align: left;
+}
+
+.sb-project:hover {
+  background: var(--color-surface-primary);
+}
+
+.sb-project svg {
+  color: var(--color-text-muted);
+  flex: 0 0 auto;
+}
+
+.sb-project-name {
+  flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.sb-chats {
+  display: flex;
+  flex-direction: column;
+  margin: 1px 0 6px;
+}
+
+.sb-chat-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  color: var(--color-text-muted);
+  font-size: 12.5px;
+  border-radius: var(--ref-radius-md);
+  line-height: 1.3;
+  width: 100%;
+  text-align: left;
+}
+
+.sb-chat-row:hover {
+  background: var(--color-surface-primary);
   color: var(--color-text-body);
 }
 
-.sidebar-tab.active {
-  background: var(--color-surface-elevated);
+.sb-chat-row.active {
+  background: var(--color-surface-primary);
   color: var(--color-text-body);
-  border-color: var(--color-border-default);
 }
 
-.sidebar-tab-icon {
-  flex-shrink: 0;
-  color: currentColor;
+.sb-chat-name {
+  flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
-.sidebar-tab.active .sidebar-tab-icon {
-  color: var(--color-brand-primary);
+.sb-chat-ts {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--color-text-subtle);
+  font-size: var(--ref-type-size-caption);
+  flex: 0 0 auto;
 }
 
-.sidebar-footer {
-  margin-top: auto;
+.sb-footer {
   padding: var(--ref-space-sm) var(--ref-space-md);
   border-top: 1px solid var(--color-border-subtle);
   color: var(--color-text-subtle);
   font-size: var(--ref-type-size-caption);
 }
 
-/* ── main ────────────────────────────────────────────────────────────── */
-.main {
+/* ── welcome screen ─────────────────────────────────────────────────── */
+.welcome {
+  flex: 1;
   display: flex;
   flex-direction: column;
-  background: var(--color-surface-canvas);
+  position: relative;
   overflow: hidden;
 }
 
-.main-header {
+.welcome-top-actions {
+  position: absolute;
+  top: 16px;
+  right: 20px;
+  display: flex;
+  gap: 4px;
+  z-index: 5;
+}
+
+.ghost-icon-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--ref-radius-md);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-subtle);
+}
+
+.ghost-icon-btn:hover {
+  background: var(--color-surface-elevated);
+  color: var(--color-text-muted);
+}
+
+.welcome-center {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0 32px;
+  gap: 28px;
+  min-height: 0;
+}
+
+.welcome-mark {
+  border-radius: 10px;
+  display: block;
+}
+
+.welcome-headline {
+  font-size: 30px;
+  font-weight: var(--ref-type-weight-medium);
+  color: var(--color-text-body);
+  letter-spacing: -0.3px;
+  text-align: center;
+  margin: 0;
+}
+
+.composer-wrap {
+  width: 100%;
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.composer {
+  width: 100%;
+  background: var(--color-surface-primary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--ref-radius-lg);
+  padding: 14px 16px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ref-space-sm);
+}
+
+.composer-input {
+  width: 100%;
+  min-height: 64px;
+  background: transparent;
+  border: none;
+  outline: none;
+  resize: none;
+  color: var(--color-text-body);
+  font: inherit;
+  font-size: var(--ref-type-size-body);
+  line-height: 1.5;
+  padding: 4px 2px;
+  font-family: var(--ref-type-family-sans);
+}
+
+.composer-input::placeholder {
+  color: var(--color-text-subtle);
+}
+
+.composer-bar {
   display: flex;
   align-items: center;
   gap: var(--ref-space-sm);
-  padding: var(--ref-space-sm) var(--ref-space-lg);
-  border-bottom: 1px solid var(--color-border-subtle);
-  font-weight: var(--ref-type-weight-medium);
-  font-size: var(--ref-type-size-small);
+  padding-top: var(--ref-space-sm);
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.composer-bar-left,
+.composer-bar-right {
+  display: flex;
+  align-items: center;
+  gap: var(--ref-space-sm);
+}
+
+.composer-bar-right {
+  margin-left: auto;
+}
+
+.composer-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--color-text-muted);
 }
 
-.main-header-icon {
-  color: var(--color-brand-primary);
-  flex-shrink: 0;
-}
-
-.main-body {
-  flex: 1;
-  padding: var(--ref-space-lg);
-  overflow: auto;
-}
-
-.placeholder {
-  border: 1px dashed var(--color-border-default);
-  border-radius: var(--ref-radius-md);
-  padding: var(--ref-space-lg);
-  color: var(--color-text-muted);
-}
-
-.placeholder code {
+.composer-icon:hover {
   background: var(--color-surface-elevated);
-  padding: 2px 6px;
-  border-radius: var(--ref-radius-sm);
-  font-family: var(--ref-type-family-mono);
-  font-size: var(--ref-type-size-small);
+  color: var(--color-text-body);
 }
 
-/* ── agent panel ─────────────────────────────────────────────────────── */
-.agent-panel {
-  border-left: 1px solid var(--color-border-subtle);
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--ref-radius-full);
+  font-size: var(--ref-type-size-small);
+  border: 1px solid transparent;
+  color: var(--color-text-muted);
+  background: transparent;
+  line-height: 1;
+}
+
+.pill-sandbox {
+  border-color: rgba(245, 158, 31, 0.55);
+  color: var(--color-brand-primary);
+  background: rgba(245, 158, 31, 0.04);
+}
+
+.pill-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-brand-primary);
+  box-shadow: 0 0 6px rgba(245, 158, 31, 0.6);
+}
+
+.pill-model {
+  background: var(--color-model-badge-openai-bg);
+  border-color: var(--color-model-badge-openai-border);
+  color: var(--color-model-badge-openai-fg);
+  font-family: var(--ref-type-family-mono);
+  font-size: 11.5px;
+  padding: 4px 8px 4px 10px;
+}
+
+.pill-chev {
+  opacity: 0.8;
+}
+
+.composer-send {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--color-text-subtle);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-inverted);
+  transition: background-color 120ms ease;
+}
+
+.composer-send:not(:disabled):hover {
+  background: var(--color-brand-primary);
+}
+
+.composer-send:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.context-row {
+  display: flex;
+  gap: 12px;
+  margin-top: var(--ref-space-md);
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.ctx-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 12px;
+  border-radius: var(--ref-radius-full);
+  border: 1px solid var(--color-border-subtle);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: var(--ref-type-size-small);
+  line-height: 1;
+}
+
+.ctx-pill svg {
+  color: var(--color-text-muted);
+}
+
+/* ── integration cards ──────────────────────────────────────────────── */
+.integration-cards {
+  width: 100%;
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 0 32px 36px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  box-sizing: border-box;
+}
+
+.integration-card {
   background: var(--color-surface-primary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--ref-radius-lg);
+  padding: 18px;
+  height: 130px;
   display: flex;
   flex-direction: column;
+  gap: 10px;
+  transition: border-color 120ms ease;
+}
+
+.integration-card:hover {
+  border-color: var(--color-border-default);
+}
+
+.integration-brand {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.integration-title {
+  font-size: var(--ref-type-size-body);
+  font-weight: var(--ref-type-weight-medium);
+  color: var(--color-text-body);
+}
+
+.integration-body {
+  font-size: var(--ref-type-size-small);
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+
+@media (max-width: 900px) {
+  .integration-cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* ── agent panel (ChatPanel) ────────────────────────────────────────── */
+.agent-panel {
+  flex: 1;
+  background: var(--color-surface-canvas);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .agent-header {
@@ -251,6 +648,13 @@ body,
   flex: 1;
   padding: var(--ref-space-md);
   overflow: auto;
+}
+
+.placeholder {
+  border: 1px dashed var(--color-border-default);
+  border-radius: var(--ref-radius-md);
+  padding: var(--ref-space-lg);
+  color: var(--color-text-muted);
 }
 
 .message {
@@ -358,119 +762,7 @@ body,
   box-shadow: 0 0 0 3px rgba(243, 130, 130, 0.18);
 }
 
-/* ── spotlight overlay ───────────────────────────────────────────────── */
-.spotlight-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.45);
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding-top: 12vh;
-  z-index: var(--ref-z-spotlight);
-}
-
-.spotlight {
-  width: min(620px, 90%);
-  background: var(--color-surface-elevated);
-  border: 1px solid var(--color-border-strong);
-  border-radius: var(--ref-radius-lg);
-  box-shadow: var(--ref-shadow-lg);
-  overflow: hidden;
-}
-
-.spotlight-input {
-  width: 100%;
-  padding: var(--ref-space-md) var(--ref-space-lg);
-  background: transparent;
-  color: var(--color-text-body);
-  border: none;
-  border-bottom: 1px solid var(--color-border-subtle);
-  font: inherit;
-  font-family: var(--ref-type-family-sans);
-  font-size: var(--ref-type-size-body-large);
-}
-
-.spotlight-input:focus {
-  outline: none;
-}
-
-.spotlight-results {
-  list-style: none;
-  margin: 0;
-  padding: var(--ref-space-sm);
-  max-height: 360px;
-  overflow: auto;
-}
-
-.spotlight-row {
-  display: grid;
-  grid-template-columns: 80px 1fr auto;
-  gap: var(--ref-space-sm);
-  padding: var(--ref-space-sm) var(--ref-space-sm);
-  border-radius: var(--ref-radius-sm);
-  align-items: center;
-}
-
-.spotlight-row.active {
-  background: var(--color-surface-primary);
-}
-
-.spotlight-row.empty {
-  display: block;
-  text-align: center;
-  color: var(--color-text-subtle);
-  padding: var(--ref-space-md);
-}
-
-.kind {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--color-text-subtle);
-  font-family: var(--ref-type-family-mono);
-}
-
-.kind-command {
-  color: var(--color-brand-primary);
-}
-
-.kind-workflow {
-  color: var(--color-text-link);
-}
-
-.kind-memory {
-  color: var(--color-text-muted);
-}
-
-.kind-recent {
-  color: var(--color-text-subtle);
-}
-
-.kind-session {
-  color: var(--color-text-muted);
-}
-
-.title {
-  color: var(--color-text-body);
-}
-
-.subtitle {
-  color: var(--color-text-subtle);
-  font-size: var(--ref-type-size-caption);
-  font-family: var(--ref-type-family-mono);
-}
-
-kbd {
-  background: var(--color-surface-elevated);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--ref-radius-sm);
-  padding: 1px 4px;
-  font-family: var(--ref-type-family-mono);
-  font-size: var(--ref-type-size-caption);
-}
-
-/* ── chat turns ──────────────────────────────────────────────────────── */
+/* ── chat turns ─────────────────────────────────────────────────────── */
 .turn {
   display: flex;
   flex-direction: column;
@@ -491,7 +783,7 @@ kbd {
   color: var(--color-text-body);
 }
 
-/* ── tool calls ──────────────────────────────────────────────────────── */
+/* ── tool calls ─────────────────────────────────────────────────────── */
 .tool-call {
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--ref-radius-sm);
@@ -595,99 +887,100 @@ kbd {
   overflow: auto;
 }
 
-/* ── session list (sidebar) ──────────────────────────────────────────── */
-.sidebar-section {
-  margin-top: var(--ref-space-sm);
-  padding: 0 var(--ref-space-sm);
-  overflow: auto;
+/* ── spotlight overlay (unchanged) ──────────────────────────────────── */
+.spotlight-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+  z-index: var(--ref-z-spotlight);
 }
 
-.session-list {
+.spotlight {
+  width: min(620px, 90%);
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--ref-radius-lg);
+  box-shadow: var(--ref-shadow-lg);
+  overflow: hidden;
+}
+
+.spotlight-input {
+  width: 100%;
+  padding: var(--ref-space-md) var(--ref-space-lg);
+  background: transparent;
+  color: var(--color-text-body);
+  border: none;
+  border-bottom: 1px solid var(--color-border-subtle);
+  font: inherit;
+  font-family: var(--ref-type-family-sans);
+  font-size: var(--ref-type-size-body-large);
+}
+
+.spotlight-input:focus {
+  outline: none;
+}
+
+.spotlight-results {
   list-style: none;
   margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--ref-space-xs);
+  padding: var(--ref-space-sm);
+  max-height: 360px;
+  overflow: auto;
 }
 
-.session-row {
+.spotlight-row {
+  display: grid;
+  grid-template-columns: 80px 1fr auto;
+  gap: var(--ref-space-sm);
   padding: var(--ref-space-sm) var(--ref-space-sm);
   border-radius: var(--ref-radius-sm);
-  background: var(--color-surface-elevated);
-  border: 1px solid transparent;
-  transition: border-color 120ms ease, background-color 120ms ease;
+  align-items: center;
 }
 
-.session-row:hover {
-  border-color: var(--color-border-default);
-}
-
-.session-id {
-  font-family: var(--ref-type-family-mono);
-  font-size: var(--ref-type-size-caption);
-  color: var(--color-text-link);
-}
-
-.session-summary {
-  color: var(--color-text-body);
-  font-size: var(--ref-type-size-small);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.session-time {
-  font-size: 10px;
-  color: var(--color-text-subtle);
-  font-family: var(--ref-type-family-mono);
-}
-
-.session-list-empty {
-  padding: var(--ref-space-sm);
-  color: var(--color-text-subtle);
-  font-size: var(--ref-type-size-small);
-}
-
-/* ── memory view ─────────────────────────────────────────────────────── */
-.memory-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--ref-space-md);
-  height: 100%;
-}
-
-@media (max-width: 1100px) {
-  .memory-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-.memory-card {
-  display: flex;
-  flex-direction: column;
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--ref-radius-md);
+.spotlight-row.active {
   background: var(--color-surface-primary);
-  overflow: hidden;
 }
 
-.memory-card-title {
-  padding: var(--ref-space-sm) var(--ref-space-md);
-  border-bottom: 1px solid var(--color-border-subtle);
-  color: var(--color-text-muted);
+.spotlight-row.empty {
+  display: block;
+  text-align: center;
+  color: var(--color-text-subtle);
+  padding: var(--ref-space-md);
+}
+
+.kind {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-text-subtle);
+  font-family: var(--ref-type-family-mono);
+}
+
+.kind-command { color: var(--color-brand-primary); }
+.kind-workflow { color: var(--color-text-link); }
+.kind-memory { color: var(--color-text-muted); }
+.kind-recent { color: var(--color-text-subtle); }
+.kind-session { color: var(--color-text-muted); }
+
+.title {
+  color: var(--color-text-body);
+}
+
+.subtitle {
+  color: var(--color-text-subtle);
+  font-size: var(--ref-type-size-caption);
+  font-family: var(--ref-type-family-mono);
+}
+
+kbd {
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--ref-radius-sm);
+  padding: 1px 4px;
   font-family: var(--ref-type-family-mono);
   font-size: var(--ref-type-size-caption);
-}
-
-.memory-card-body {
-  flex: 1;
-  margin: 0;
-  padding: var(--ref-space-md);
-  overflow: auto;
-  font-family: var(--ref-type-family-mono);
-  font-size: var(--ref-type-size-small);
-  white-space: pre-wrap;
-  word-break: break-word;
-  color: var(--color-text-body);
 }


### PR DESCRIPTION
## Summary

Replaces the previous chat-first layout with the **Codex-style projects shell** the user approved in [SUP-34](https://linear.app/super-ultra-big-dog/issue/SUP-34/gui-pick-a-visual-direction-4-design-explorations) → [SUP-35](https://linear.app/super-ultra-big-dog/issue/SUP-35/gui-pick-a-variation-of-refined-conduit-dark-4-takes-on-the-chosen). Hierarchical sidebar (brand row → top nav → projects with nested chats → orphan chats) on the left; Welcome screen with composer + brand mark + integration cards in the center when no chat is selected. ChatPanel still owns the chat surface — it just routes in only when a chat is active.

## Live screenshot — real data, not a mockup

![Projects shell — live](https://files.catbox.moe/djpijh.png)

The project name (\"clever-tereshkova-e97f86\") is the actual worktree this branch sits in. The chat titles inside it are the real prompts from this session's earlier testing (\`use the read_file tool...\`, \`reply with exactly: \"Conduit live test ok\"\`, etc.). The branch in the context pills row is the live \`feat/projects-shell\` branch.

## Backend — \`internal/server/projects.go\`

\`GET /api/projects\` groups coding-session journals (\`~/.conduit/coding-sessions/*.jsonl\`) by their \`RepositoryRoot\` field. Each session's title is derived from its first user turn (trimmed + truncated at 80 runes), branch from the most-recent session, project ID from \`sha256(absolutePath)[:16]\`. Sessions with no \`RepositoryRoot\` land in \`orphans\`. Empty/missing dir → \`{projects:[],orphans:[]}\` 200 OK. 4 new tests cover grouping, sort order, title truncation, and ID stability.

## Frontend — \`spike/gui/src/\`

| File | Lines | Role |
|---|---|---|
| \`components/BrandRow.tsx\` | 92 | Chrome row + brand row, inlines the real \`assets/logo.svg\` Channel Bracket mark |
| \`components/Sidebar.tsx\` | 255 | Fetches \`/api/projects\`, renders top nav, expandable project rows with chats indented ~36px, orphan chats section |
| \`components/WelcomeScreen.tsx\` | 169 | 44px brand mark + \"What should we build in conduit?\" headline + composer (Enter-to-send) + 3 context pills + 4 integration cards |
| \`components/IntegrationCard.tsx\` | 101 | Reusable card + inlined GitHub / Linear / MCP / Slack brand SVGs |
| \`App.tsx\` | 75 (rewrite) | \`activeChatId\` state. \`null\`/\`\"new\"\` → WelcomeScreen; otherwise ChatPanel with a \`key\` to force a fresh WS connect per chat. Spotlight ⌥Space untouched |
| \`ChatPanel.tsx\` | +18 | Optional \`initialPrompt\` prop that auto-sends once on first WS connect (used when Welcome composer starts a new chat) |
| \`api.ts\` | +44 | \`Project\` / \`ChatSummary\` / \`ProjectsResponse\` types + \`getProjects()\` |
| \`styles.css\` | full rewrite | New shell styles. ChatPanel + Spotlight + tool-call CSS untouched. All semantic tokens, zero hardcoded hex |

## Removed

- Old \`MainView\`/\`SidebarTab\` enums and the placeholder views (screenshot / workflow / evals) — superseded by the project tree
- \`MemoryView\` import (file kept on disk for a follow-up that wires it into the projects shell)

## Verified

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` all green (incl. 4 new \`projects_test.go\` tests)
- [x] \`make lint\` clean (gofmt + go vet)
- [x] \`cd spike/gui && npm run build\` clean — CSS 25.9 KB (4.8 KB gzip), JS 170.4 KB (53.7 KB gzip), zero \`any\`
- [x] Live smoke: \`conduit serve --provider codex\` → \`/api/projects\` returns the real worktree with real chats; \`vite dev\` renders the new layout against that data

## Out of scope (follow-ups)

- Search / Plugins / Automations are placeholders — no backend hooks yet
- Integration cards are visual only — no real OAuth
- Repo / Mode / Branch context pills aren't click-to-change yet
- Update pill is decorative
- Clicking a past chat in the sidebar routes to a fresh \`ChatPanel\` rather than loading the recorded journal — that's [SUP-30](https://linear.app/super-ultra-big-dog/issue/SUP-30/gui-persist-conversation-across-page-reloads-load-past-sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)