### PR TITLE
feat(setup): agnostic API key input accepts Claude Code tokens

### DIFF
--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -390,13 +390,13 @@ func selectCodingStreamer(provider, model string, codingTools []tools.Tool, stde
 	case "echo":
 		return echoStreamer{}, "echo", "(none)"
 	case "auto", "":
-		if os.Getenv("ANTHROPIC_API_KEY") != "" {
+		if anthropicAPIKeyFromEnv() != "" {
 			return newAnthropicStreamer(model, codingTools, stderr, false)
 		}
 		if _, err := codex.LoadAuth(); err == nil {
 			return newCodexStreamer(model, codingTools, stderr, false)
 		}
-		fmt.Fprintln(stderr, "conduit code: no credentials found (set ANTHROPIC_API_KEY or run `codex login`); using echo streamer")
+		fmt.Fprintln(stderr, "conduit code: no credentials found (set ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or run `codex login`); using echo streamer")
 		return echoStreamer{}, "echo", "(none)"
 	default:
 		fmt.Fprintf(stderr, "conduit code: unknown provider %q; using echo streamer\n", provider)
@@ -408,15 +408,27 @@ func newAnthropicStreamer(model string, codingTools []tools.Tool, stderr *os.Fil
 	if model == "" {
 		model = "claude-opus-4-5"
 	}
-	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	apiKey := anthropicAPIKeyFromEnv()
 	if apiKey == "" {
 		if explicit {
-			fmt.Fprintln(stderr, "conduit code: --provider=anthropic but ANTHROPIC_API_KEY is not set; falling back to echo")
+			fmt.Fprintln(stderr, "conduit code: --provider=anthropic but no Anthropic key found (set ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN); falling back to echo")
 		}
 		return echoStreamer{}, "echo", "(none)"
 	}
 	client := anthropic.New(apiKey, model)
 	return coding.NewAgentStreamer(client, codingTools, codingSystemPrompt), "anthropic", model
+}
+
+// anthropicAPIKeyFromEnv resolves an Anthropic-compatible credential from the
+// environment, accepting a Claude Code subscription token in place of a bare
+// API key. The first non-empty value wins.
+func anthropicAPIKeyFromEnv() string {
+	for _, name := range []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CODE_API_KEY"} {
+		if v := os.Getenv(name); v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func newCodexStreamer(model string, codingTools []tools.Tool, stderr *os.File, explicit bool) (coding.Streamer, string, string) {
@@ -466,7 +478,7 @@ func providerResponderFromEnv(model string) (evalpkg.Responder, bool) {
 			Model:   model,
 		})}, true
 	case strings.HasPrefix(model, "claude-"):
-		key := os.Getenv("ANTHROPIC_API_KEY")
+		key := anthropicAPIKeyFromEnv()
 		if key == "" {
 			return nil, false
 		}

--- a/internal/core/setup.go
+++ b/internal/core/setup.go
@@ -91,11 +91,13 @@ func (s *firstRunSetup) SetupLocalAI() (contracts.FirstRunSetupSnapshot, error) 
 }
 
 // DefaultExternalAPIOptions keeps the non-local path visible next to local
-// setup, as required by PRD 7.4.
+// setup, as required by PRD 7.4. The list is provider-agnostic so a Claude
+// Code subscription token can stand in for a bare Anthropic API key.
 func DefaultExternalAPIOptions() []contracts.ExternalAPIOption {
 	return []contracts.ExternalAPIOption{
 		{Provider: "openai", Label: "Connect OpenAI", EnvVar: "OPENAI_API_KEY"},
 		{Provider: "anthropic", Label: "Connect Anthropic", EnvVar: "ANTHROPIC_API_KEY"},
+		{Provider: "claude-code", Label: "Connect Claude Code", EnvVar: "CLAUDE_CODE_OAUTH_TOKEN"},
 	}
 }
 

--- a/internal/core/setup_test.go
+++ b/internal/core/setup_test.go
@@ -79,8 +79,18 @@ func TestFirstRunSetupWelcomeIncludesProfileLocalSetupAndExternalAPI(t *testing.
 	if snapshot.Recommendation.Name == "" || !localSetupRecommended(snapshot) {
 		t.Fatalf("missing local recommendation: %+v", snapshot.Recommendation)
 	}
-	if len(snapshot.ExternalAPI) < 2 {
-		t.Fatalf("ExternalAPI = %+v, want OpenAI and Anthropic options", snapshot.ExternalAPI)
+	if len(snapshot.ExternalAPI) < 3 {
+		t.Fatalf("ExternalAPI = %+v, want OpenAI, Anthropic, and Claude Code options", snapshot.ExternalAPI)
+	}
+	var sawClaudeCode bool
+	for _, opt := range snapshot.ExternalAPI {
+		if opt.Provider == "claude-code" {
+			sawClaudeCode = true
+			break
+		}
+	}
+	if !sawClaudeCode {
+		t.Fatalf("ExternalAPI = %+v, missing Claude Code option", snapshot.ExternalAPI)
 	}
 	if snapshot.Steps[0].Status != contracts.FirstRunSetupStepDone {
 		t.Fatalf("first step = %+v, want profiled machine done", snapshot.Steps[0])

--- a/internal/credential/source.go
+++ b/internal/credential/source.go
@@ -12,7 +12,10 @@ import (
 //
 // It first scans CONDUIT_{PROVIDER}_API_KEY_1, _2, … until one is absent,
 // then falls back to the bare CONDUIT_{PROVIDER}_API_KEY for a single key.
-// provider is case-insensitive ("anthropic", "ANTHROPIC", etc.).
+// As a final fallback for known provider aliases — anthropic accepts a
+// Claude Code subscription token — the canonical provider env vars
+// (ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, OPENAI_API_KEY) are also
+// consulted. provider is case-insensitive ("anthropic", "ANTHROPIC", etc.).
 func LoadFromEnv(provider string, backoff time.Duration) *Pool {
 	upper := strings.ToUpper(provider)
 
@@ -31,7 +34,30 @@ func LoadFromEnv(provider string, backoff time.Duration) *Pool {
 		}
 	}
 
+	if len(keys) == 0 {
+		for _, name := range providerEnvAliases(upper) {
+			if k := os.Getenv(name); k != "" {
+				keys = append(keys, k)
+				break
+			}
+		}
+	}
+
 	return New(keys, backoff)
+}
+
+// providerEnvAliases returns the canonical, non-CONDUIT-prefixed env vars
+// recognised for a provider. Anthropic is treated agnostically: a Claude
+// Code subscription token is a valid Anthropic credential.
+func providerEnvAliases(upperProvider string) []string {
+	switch upperProvider {
+	case "ANTHROPIC", "CLAUDE", "CLAUDE_CODE", "CLAUDE-CODE":
+		return []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CODE_API_KEY"}
+	case "OPENAI":
+		return []string{"OPENAI_API_KEY"}
+	default:
+		return nil
+	}
 }
 
 // LoadFromKeychain loads API keys for provider from the macOS Keychain.

--- a/internal/credential/source_test.go
+++ b/internal/credential/source_test.go
@@ -37,6 +37,35 @@ func TestLoadFromEnv_NoKeys(t *testing.T) {
 	}
 }
 
+func TestLoadFromEnv_AnthropicAcceptsClaudeCodeToken(t *testing.T) {
+	// Unset ANTHROPIC_API_KEY so the Claude Code alias is the only credential.
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "subscription-token")
+
+	p := credential.LoadFromEnv("anthropic", 0)
+	if p.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1 from CLAUDE_CODE_OAUTH_TOKEN", p.Len())
+	}
+	k, ok := p.Next()
+	if !ok || k != "subscription-token" {
+		t.Errorf("Next() = (%q, %v), want (\"subscription-token\", true)", k, ok)
+	}
+}
+
+func TestLoadFromEnv_AnthropicPrefersExplicitConduitKey(t *testing.T) {
+	t.Setenv("CONDUIT_ANTHROPIC_API_KEY", "explicit")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "fallback")
+
+	p := credential.LoadFromEnv("anthropic", 0)
+	if p.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", p.Len())
+	}
+	k, _ := p.Next()
+	if k != "explicit" {
+		t.Errorf("Next() = %q, want explicit CONDUIT_ key to win over Claude Code fallback", k)
+	}
+}
+
 func TestLoadFromEnv_CaseInsensitive(t *testing.T) {
 	t.Setenv("CONDUIT_MYPROVIDER_API_KEY", "lower")
 


### PR DESCRIPTION
## Summary
- Add **Connect Claude Code** as a third option in the welcome external-API list, so a Claude Code subscription token is a first-class credential alongside OpenAI and Anthropic.
- Make Anthropic credential resolution agnostic: when `ANTHROPIC_API_KEY` is unset, fall back to `CLAUDE_CODE_OAUTH_TOKEN` then `CLAUDE_CODE_API_KEY`. This applies to both the `credential.LoadFromEnv` pool and the `conduit code` / responder code paths.
- Banner text and "no credentials found" message updated to mention Claude Code as a valid source.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/core/... ./internal/credential/... ./internal/tui/...` — all pass
- [x] New tests: `TestLoadFromEnv_AnthropicAcceptsClaudeCodeToken`, `TestLoadFromEnv_AnthropicPrefersExplicitConduitKey`, plus assertion that `DefaultExternalAPIOptions` includes the `claude-code` provider.
- [ ] Manual smoke: launch TUI welcome and confirm three options render.

https://claude.ai/code/session_01FiSfYRx8qu8iHDjySukEZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiSfYRx8qu8iHDjySukEZF)_