### PR TITLE
test(e2e): add holistic end-to-end journey suite

### DIFF
--- a/tests/e2e/coding_journey_test.go
+++ b/tests/e2e/coding_journey_test.go
@@ -1,0 +1,353 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/coding"
+	"github.com/jabreeflor/conduit/internal/contracts"
+	"github.com/jabreeflor/conduit/internal/tools"
+	"github.com/jabreeflor/conduit/internal/tools/websearch"
+)
+
+// TestCodingAgentFullJourney walks a single `conduit code` session through
+// the major user-visible behaviors: tool registration, a happy-path read
+// turn, auto-continuation on truncation, a provider error, direct tool
+// invocation, and journal-on-disk persistence.
+func TestCodingAgentFullJourney(t *testing.T) {
+	// ── Stage 1: Bootstrap ────────────────────────────────────────────
+	home := newHome(t)
+
+	session, err := coding.NewSessionInDir(home.Root, home.WorkspaceDir)
+	if err != nil {
+		t.Fatalf("NewSessionInDir: %v", err)
+	}
+
+	mainGoPath := filepath.Join(home.WorkspaceDir, "main.go")
+	mainGoBody := "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hello from main\")\n}\n"
+	mustWrite(t, mainGoPath, mainGoBody)
+
+	// ── Stage 2: Tool wiring ──────────────────────────────────────────
+	tiered := coding.LiveCodingToolsForSession(websearch.Config{}, nil, session)
+	registered := coding.RegisterCodingTools(tiered, contracts.CodingPermissions{
+		AllowWrite: true,
+		AllowShell: true,
+	})
+
+	want := map[string]bool{
+		"read_file":   false,
+		"write_file":  false,
+		"edit_file":   false,
+		"bash":        false,
+		"list_dir":    false,
+		"grep_search": false,
+	}
+	for _, tl := range registered {
+		if _, ok := want[tl.Name]; ok {
+			want[tl.Name] = true
+		}
+	}
+	for name, present := range want {
+		if !present {
+			t.Fatalf("expected tool %q to be registered (write+shell perms), got names=%v",
+				name, toolNames(registered))
+		}
+	}
+
+	// ── Stage 3: First turn — read-only ────────────────────────────────
+	streamer := NewScripted(
+		// Stage 3 reply
+		Reply{
+			Deltas:       []string{"Reading the file", "..."},
+			FinishReason: "stop",
+		},
+	)
+
+	out := &bytes.Buffer{}
+	repl := &coding.REPL{
+		Session:         session,
+		Budget:          coding.NewBudget(20000),
+		Tools:           registered,
+		Streamer:        streamer,
+		In:              strings.NewReader("please summarize main.go\n"),
+		Out:             out,
+		MaxAutoContinue: 2,
+	}
+
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 5*time.Second)
+	if err := repl.Run(ctx1); err != nil {
+		cancel1()
+		t.Fatalf("REPL.Run stage 3: %v", err)
+	}
+	cancel1()
+
+	outStr := out.String()
+	if !strings.Contains(outStr, "Reading the file") {
+		t.Errorf("stage 3: expected delta %q in Out, got %q", "Reading the file", outStr)
+	}
+	if !strings.Contains(outStr, "...") {
+		t.Errorf("stage 3: expected delta %q in Out, got %q", "...", outStr)
+	}
+
+	entries := readJSONL(t, session.Path)
+	if len(entries) != 2 {
+		t.Fatalf("stage 3: expected 2 turns on disk, got %d (entries=%+v)", len(entries), entries)
+	}
+	if got := roleAt(entries, 0); got != "user" {
+		t.Errorf("stage 3: turn[0] role: want %q, got %q", "user", got)
+	}
+	if got := roleAt(entries, 1); got != "assistant" {
+		t.Errorf("stage 3: turn[1] role: want %q, got %q", "assistant", got)
+	}
+	if got := contentAt(entries, 0); got != "please summarize main.go" {
+		t.Errorf("stage 3: user content: want %q, got %q", "please summarize main.go", got)
+	}
+	if got := contentAt(entries, 1); !strings.Contains(got, "Reading the file") {
+		t.Errorf("stage 3: assistant content should contain delta, got %q", got)
+	}
+
+	// ── Stage 4: Truncated reply auto-continuation ────────────────────
+	streamer.mu.Lock()
+	streamer.Replies = append(streamer.Replies,
+		Reply{
+			Deltas:       []string{"partial-chunk-A"},
+			FinishReason: "length",
+		},
+		Reply{
+			Deltas:       []string{"final-chunk-B"},
+			FinishReason: "stop",
+		},
+	)
+	priorCallCount := len(streamer.calls)
+	streamer.mu.Unlock()
+
+	// New REPL for stage 4 with fresh stdin; reuses session/streamer.
+	out2 := &bytes.Buffer{}
+	repl2 := &coding.REPL{
+		Session:         session,
+		Budget:          coding.NewBudget(20000),
+		Tools:           registered,
+		Streamer:        streamer,
+		In:              strings.NewReader("write more about main.go\n"),
+		Out:             out2,
+		MaxAutoContinue: 2,
+	}
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+	if err := repl2.Run(ctx2); err != nil {
+		cancel2()
+		t.Fatalf("REPL.Run stage 4: %v", err)
+	}
+	cancel2()
+
+	out2Str := out2.String()
+	if !strings.Contains(out2Str, "partial-chunk-A") {
+		t.Errorf("stage 4: expected partial chunk in Out, got %q", out2Str)
+	}
+	if !strings.Contains(out2Str, "final-chunk-B") {
+		t.Errorf("stage 4: expected final chunk in Out, got %q", out2Str)
+	}
+
+	calls := streamer.Calls()
+	stage4Calls := calls[priorCallCount:]
+	if len(stage4Calls) != 2 {
+		t.Fatalf("stage 4: expected 2 streamer calls (initial + 1 auto-continue), got %d (prompts=%v)",
+			len(stage4Calls), promptsOf(stage4Calls))
+	}
+	if stage4Calls[0].Prompt != "write more about main.go" {
+		t.Errorf("stage 4: first prompt: want %q, got %q",
+			"write more about main.go", stage4Calls[0].Prompt)
+	}
+	if stage4Calls[1].Prompt != "continue" {
+		t.Errorf("stage 4: second prompt: want %q, got %q",
+			"continue", stage4Calls[1].Prompt)
+	}
+
+	entries = readJSONL(t, session.Path)
+	// Stage 3 wrote 2 (user+assistant); stage 4 writes 1 user + 2 assistant (length+continuation) = 3.
+	// Total expected: 5.
+	if len(entries) != 5 {
+		t.Fatalf("stage 4: expected 5 total turns on disk, got %d: roles=%v",
+			len(entries), rolesOf(entries))
+	}
+
+	// ── Stage 5: Provider error ───────────────────────────────────────
+	streamer.mu.Lock()
+	streamer.Replies = append(streamer.Replies, Reply{Err: errFakeProvider})
+	streamer.mu.Unlock()
+
+	out3 := &bytes.Buffer{}
+	repl3 := &coding.REPL{
+		Session:         session,
+		Budget:          coding.NewBudget(20000),
+		Tools:           registered,
+		Streamer:        streamer,
+		In:              strings.NewReader("trigger error\n"),
+		Out:             out3,
+		MaxAutoContinue: 2,
+	}
+	ctx3, cancel3 := context.WithTimeout(context.Background(), 5*time.Second)
+	err = repl3.Run(ctx3)
+	cancel3()
+	if err == nil {
+		t.Fatalf("stage 5: expected provider error to propagate, got nil")
+	}
+	if !errors.Is(err, errFakeProvider) {
+		t.Fatalf("stage 5: expected errFakeProvider, got %v", err)
+	}
+
+	// ── Stage 6: Direct tool exercise ─────────────────────────────────
+	writeTool := findTool(t, registered, "write_file")
+	readTool := findTool(t, registered, "read_file")
+
+	scratchPath := filepath.Join(home.WorkspaceDir, "scratch.txt")
+	scratchBody := "hello-from-direct-tool-invocation\n"
+	writeArgs, _ := json.Marshal(map[string]any{
+		"path":    scratchPath,
+		"content": scratchBody,
+	})
+	ctx6a, cancel6a := context.WithTimeout(context.Background(), 5*time.Second)
+	wRes, wErr := writeTool.Run(ctx6a, writeArgs)
+	cancel6a()
+	if wErr != nil {
+		t.Fatalf("stage 6: write_file run error: %v", wErr)
+	}
+	if wRes.IsError {
+		t.Fatalf("stage 6: write_file reported IsError: %s", wRes.Text)
+	}
+	// Sanity-check disk side effect.
+	gotOnDisk, err := os.ReadFile(scratchPath)
+	if err != nil {
+		t.Fatalf("stage 6: scratch.txt not created: %v", err)
+	}
+	if string(gotOnDisk) != scratchBody {
+		t.Errorf("stage 6: scratch.txt content: want %q, got %q", scratchBody, string(gotOnDisk))
+	}
+
+	readArgs, _ := json.Marshal(map[string]any{"path": scratchPath})
+	ctx6b, cancel6b := context.WithTimeout(context.Background(), 5*time.Second)
+	rRes, rErr := readTool.Run(ctx6b, readArgs)
+	cancel6b()
+	if rErr != nil {
+		t.Fatalf("stage 6: read_file run error: %v", rErr)
+	}
+	if rRes.IsError {
+		t.Fatalf("stage 6: read_file reported IsError: %s", rRes.Text)
+	}
+	if !strings.Contains(rRes.Text, "hello-from-direct-tool-invocation") {
+		t.Errorf("stage 6: read_file output should contain written content, got %q", rRes.Text)
+	}
+
+	// ── Stage 7: Session restart / persistence ────────────────────────
+	// After error, no new turn was appended for stage 5 (streamer returned
+	// before assistant Append). But a user turn for "trigger error" WAS
+	// appended before streamAssistant. So total = 5 (stage3+4) + 1 = 6.
+	entries = readJSONL(t, session.Path)
+	if len(entries) != len(session.Turns) {
+		t.Errorf("stage 7: JSONL count %d != in-memory Turns count %d",
+			len(entries), len(session.Turns))
+	}
+	for i, e := range entries {
+		jsonRole := roleAt([]map[string]any{e}, 0)
+		memRole := session.Turns[i].Role
+		if jsonRole != memRole {
+			t.Errorf("stage 7: turn[%d] role mismatch: jsonl=%q memory=%q",
+				i, jsonRole, memRole)
+		}
+	}
+
+	// Exactly one .jsonl file should exist in the coding-sessions dir.
+	dirEntries, err := os.ReadDir(home.CodingSessions)
+	if err != nil {
+		t.Fatalf("stage 7: read coding-sessions: %v", err)
+	}
+	jsonlCount := 0
+	var jsonlName string
+	for _, de := range dirEntries {
+		if strings.HasSuffix(de.Name(), ".jsonl") {
+			jsonlCount++
+			jsonlName = de.Name()
+		}
+	}
+	if jsonlCount != 1 {
+		t.Fatalf("stage 7: expected exactly 1 .jsonl file, got %d (entries=%v)",
+			jsonlCount, dirEntries)
+	}
+	if !strings.HasPrefix(jsonlName, strings.TrimSuffix(filepath.Base(session.Path), ".jsonl")) {
+		t.Errorf("stage 7: jsonl name %q should match session id %q",
+			jsonlName, filepath.Base(session.Path))
+	}
+}
+
+// ── local helpers ────────────────────────────────────────────────────────
+
+// findTool returns the tool by name from the slice, failing the test if absent.
+func findTool(t *testing.T, ts []tools.Tool, name string) tools.Tool {
+	t.Helper()
+	for _, tl := range ts {
+		if tl.Name == name {
+			return tl
+		}
+	}
+	t.Fatalf("tool %q not found in slice %v", name, toolNames(ts))
+	return tools.Tool{}
+}
+
+func toolNames(ts []tools.Tool) []string {
+	out := make([]string, 0, len(ts))
+	for _, tl := range ts {
+		out = append(out, tl.Name)
+	}
+	return out
+}
+
+// roleAt extracts the Role field from a JSONL-decoded turn entry.
+// CodingTurn has no json tags, so encoding/json marshals "Role" verbatim.
+func roleAt(entries []map[string]any, i int) string {
+	if i >= len(entries) {
+		return ""
+	}
+	if v, ok := entries[i]["Role"].(string); ok {
+		return v
+	}
+	if v, ok := entries[i]["role"].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// contentAt extracts the Content field similarly.
+func contentAt(entries []map[string]any, i int) string {
+	if i >= len(entries) {
+		return ""
+	}
+	if v, ok := entries[i]["Content"].(string); ok {
+		return v
+	}
+	if v, ok := entries[i]["content"].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func rolesOf(entries []map[string]any) []string {
+	out := make([]string, len(entries))
+	for i := range entries {
+		out[i] = roleAt(entries, i)
+	}
+	return out
+}
+
+func promptsOf(calls []ScriptedCall) []string {
+	out := make([]string, len(calls))
+	for i, c := range calls {
+		out[i] = c.Prompt
+	}
+	return out
+}

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -1,0 +1,246 @@
+// Package e2e holds Conduit's end-to-end test suite: full user journeys
+// that exercise multiple subsystems through their public entry points
+// (CLI, HTTP/WS, store APIs) with all side-effecting dependencies
+// (filesystem, LLM provider) faked or sandboxed under t.TempDir().
+//
+// Each journey lives in its own file:
+//
+//	coding_journey_test.go   - conduit code REPL + sessions + tools + hooks
+//	server_journey_test.go   - conduit serve + HTTP + WebSocket agent
+//	sandbox_journey_test.go  - sandbox create/snapshot/rollback/clone/destroy
+//	sessions_journey_test.go - sessions create/fork/replay/find lifecycle
+//
+// The shared fakes live here: ScriptedStreamer (a programmable
+// coding.Streamer that emits a fixed sequence of deltas), conduitHome
+// (a $HOME-shaped tempdir scaffold), and a few JSONL/fixture helpers.
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jabreeflor/conduit/internal/coding"
+)
+
+// ScriptedStreamer is a fully deterministic coding.Streamer for tests.
+//
+// Each Stream call pops the next Reply from Replies. Reply.Deltas are
+// emitted one by one via onDelta; Reply.Full is returned as the full
+// string (empty means concatenation of deltas). Reply.FinishReason is
+// the finish reason ("stop", "length", "max_tokens"). Reply.Err, if
+// non-nil, is returned instead of streaming — useful for testing error
+// paths.
+//
+// The streamer is goroutine-safe: tests can hand the same streamer to
+// multiple REPLs or WebSocket handlers and still get deterministic
+// per-call output.
+type ScriptedStreamer struct {
+	mu      sync.Mutex
+	Replies []Reply
+	calls   []ScriptedCall
+}
+
+// Reply is one scripted Stream call.
+type Reply struct {
+	Deltas       []string
+	Full         string
+	FinishReason string
+	Err          error
+}
+
+// ScriptedCall captures the inputs the REPL passed for one Stream call,
+// so tests can assert on prompts in order.
+type ScriptedCall struct {
+	Prompt string
+	At     time.Time
+}
+
+// NewScripted builds a streamer that emits the given replies in order.
+func NewScripted(replies ...Reply) *ScriptedStreamer {
+	return &ScriptedStreamer{Replies: append([]Reply(nil), replies...)}
+}
+
+// Calls returns a snapshot of every Stream invocation so far.
+func (s *ScriptedStreamer) Calls() []ScriptedCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ScriptedCall, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+// Stream implements coding.Streamer.
+func (s *ScriptedStreamer) Stream(ctx context.Context, prompt string, onDelta func(string)) (string, string, error) {
+	s.mu.Lock()
+	s.calls = append(s.calls, ScriptedCall{Prompt: prompt, At: time.Now()})
+	if len(s.Replies) == 0 {
+		s.mu.Unlock()
+		// Default trailing reply so misconfigured tests still terminate
+		// quickly with a recognisable diagnostic.
+		return "scripted: no more replies", "stop", nil
+	}
+	r := s.Replies[0]
+	s.Replies = s.Replies[1:]
+	s.mu.Unlock()
+
+	if r.Err != nil {
+		return "", "", r.Err
+	}
+	for _, d := range r.Deltas {
+		if err := ctx.Err(); err != nil {
+			return "", "", err
+		}
+		if onDelta != nil {
+			onDelta(d)
+		}
+	}
+	full := r.Full
+	if full == "" {
+		full = strings.Join(r.Deltas, "")
+	}
+	finish := r.FinishReason
+	if finish == "" {
+		finish = "stop"
+	}
+	return full, finish, nil
+}
+
+// _ enforces interface conformance at compile time.
+var _ coding.Streamer = (*ScriptedStreamer)(nil)
+
+// conduitHome is a tempdir scaffold mimicking the layout the rest of
+// Conduit expects: $HOME/.conduit/{coding-sessions,sessions} plus
+// SOUL.md / USER.md memory files. Tests use this to keep journeys
+// isolated from the host's real ~/.conduit.
+type conduitHome struct {
+	Root            string
+	ConduitDir      string
+	CodingSessions  string
+	Sessions        string
+	SkillsWorkspace string
+	SkillsPersonal  string
+	WorkspaceDir    string
+}
+
+// newHome materialises a fresh conduit-shaped home rooted at t.TempDir().
+// All directories exist; SOUL.md and USER.md are pre-seeded with stable
+// content so /api/memory has something to return.
+func newHome(t *testing.T) *conduitHome {
+	t.Helper()
+	root := t.TempDir()
+	h := &conduitHome{
+		Root:            root,
+		ConduitDir:      filepath.Join(root, ".conduit"),
+		CodingSessions:  filepath.Join(root, ".conduit", "coding-sessions"),
+		Sessions:        filepath.Join(root, ".conduit", "sessions"),
+		SkillsWorkspace: filepath.Join(root, "workspace", ".conduit", "skills"),
+		SkillsPersonal:  filepath.Join(root, ".conduit", "skills"),
+		WorkspaceDir:    filepath.Join(root, "workspace"),
+	}
+	for _, d := range []string{h.ConduitDir, h.CodingSessions, h.Sessions, h.SkillsWorkspace, h.SkillsPersonal, h.WorkspaceDir} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(h.ConduitDir, "SOUL.md"), []byte("# SOUL\n\nYou are Conduit.\n"), 0o600); err != nil {
+		t.Fatalf("seed SOUL.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(h.ConduitDir, "USER.md"), []byte("# USER\n\nThe user prefers concise replies.\n"), 0o600); err != nil {
+		t.Fatalf("seed USER.md: %v", err)
+	}
+	return h
+}
+
+// readJSONL reads a JSONL file and decodes each line into a fresh map.
+// It returns the decoded entries in file order. Empty lines are skipped.
+// Failures are reported via t.Fatalf so callers can write straight-line
+// assertions.
+func readJSONL(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var out []map[string]any
+	for i, line := range strings.Split(strings.TrimRight(string(raw), "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("decode %s line %d: %v\n%s", path, i+1, err, line)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// waitFor polls fn every 5 ms until it returns true or the timeout
+// expires. Returns true on success; tests should t.Fatal on false.
+// Use this instead of time.Sleep when waiting for an async event from
+// the streamer or WebSocket emitter.
+func waitFor(timeout time.Duration, fn func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return fn()
+}
+
+// errFakeProvider is the sentinel error ScriptedStreamer uses when a
+// test wants to assert that the REPL surfaces provider failures cleanly.
+var errFakeProvider = errors.New("fake-provider: synthetic failure")
+
+// firstUserContent returns the first user-role content from a JSONL
+// turn dump produced by readJSONL. Empty string when none is present.
+func firstUserContent(entries []map[string]any) string {
+	for _, e := range entries {
+		if role, _ := e["role"].(string); role == "user" {
+			if c, ok := e["content"].(string); ok {
+				return c
+			}
+		}
+	}
+	return ""
+}
+
+// mustWrite writes data to path, creating parents as needed, t.Fatal on
+// failure. Returns the absolute path for chaining.
+func mustWrite(t *testing.T, path string, data string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// debugDump prints a labelled, indented JSON snapshot of v. Use in tests
+// only when a failure is otherwise opaque; never leave behind in passing
+// runs.
+func debugDump(t *testing.T, label string, v any) {
+	t.Helper()
+	b, _ := json.MarshalIndent(v, "", "  ")
+	fmt.Printf("--- %s ---\n%s\n", label, b)
+}
+
+// noopT is a stub used by helpers that may run outside of tests. Kept
+// unexported so it never leaks.
+type noopT struct{}
+
+func (noopT) Helper()                           {}
+func (noopT) Fatalf(format string, args ...any) {}

--- a/tests/e2e/sandbox_journey_test.go
+++ b/tests/e2e/sandbox_journey_test.go
@@ -1,0 +1,373 @@
+package e2e
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/sandbox"
+)
+
+// TestSandboxFullLifecycleJourney drives the entire `conduit sandbox`
+// substrate end-to-end through Manager + Workspace APIs:
+//
+//   - create three sandboxes, verify on-disk layout
+//   - set/clear the active pointer
+//   - write workspace + home files
+//   - take v1 snapshot, mutate state, take v2 snapshot
+//   - clone the sandbox; verify post-mutation parity, clone has no snapshots
+//   - rollback the original to v1; assert clone is unaffected
+//   - exercise maxSnapshots auto-prune
+//   - destroy active sandbox; assert active-pointer is auto-cleared
+//   - verify final list contains only "staging" and "experiment"
+func TestSandboxFullLifecycleJourney(t *testing.T) {
+	home := newHome(t)
+	root := filepath.Join(home.Root, "sandboxes")
+	mgr := sandbox.NewManager(root)
+
+	// ── 1. Bootstrap & 2. Create three sandboxes ─────────────────────────
+	names := []string{"dev", "staging", "experiment"}
+	for _, name := range names {
+		ws, err := mgr.Create(name, sandbox.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Create(%q): unexpected error: %v", name, err)
+		}
+		if ws.Name() != name {
+			t.Fatalf("Create(%q): workspace name mismatch: got %q", name, ws.Name())
+		}
+		// on-disk layout: workspace/ and home/ both exist under <root>/sandboxes/<name>/
+		wsPath := ws.Path(sandbox.SubdirWorkspace)
+		hmPath := ws.Path(sandbox.SubdirHome)
+		mustBeDir(t, wsPath, "Create("+name+") workspace subdir")
+		mustBeDir(t, hmPath, "Create("+name+") home subdir")
+	}
+
+	list, err := mgr.List()
+	if err != nil {
+		t.Fatalf("List after creates: %v", err)
+	}
+	if got := sandboxNames(list); !equalSets(got, names) {
+		t.Fatalf("List() after create: expected %v, got %v", names, got)
+	}
+
+	// ── 3. Active sandbox: ErrNoActive → SetActive → Active ─────────────
+	if active, err := mgr.Active(); !errors.Is(err, sandbox.ErrNoActive) {
+		t.Fatalf("Active() before SetActive: expected ErrNoActive, got (%q, %v)", active, err)
+	}
+	if err := mgr.SetActive("dev"); err != nil {
+		t.Fatalf("SetActive(\"dev\"): %v", err)
+	}
+	active, err := mgr.Active()
+	if err != nil {
+		t.Fatalf("Active() after SetActive(\"dev\"): %v", err)
+	}
+	if active != "dev" {
+		t.Fatalf("Active(): expected \"dev\", got %q", active)
+	}
+	// pointer file must exist under <root>/sandboxes/.active
+	pointerPath := filepath.Join(root, "sandboxes", ".active")
+	if _, err := os.Stat(pointerPath); err != nil {
+		t.Fatalf("active pointer file %q: expected to exist, got %v", pointerPath, err)
+	}
+
+	// ── 4. Switch + write workspace content ─────────────────────────────
+	ws, err := mgr.Switch("dev")
+	if err != nil {
+		t.Fatalf("Switch(\"dev\"): %v", err)
+	}
+	if ws.Name() != "dev" {
+		t.Fatalf("Switch returned workspace named %q, expected \"dev\"", ws.Name())
+	}
+
+	originalMain := "package main\nfunc main(){}\n"
+	originalNotes := "initial notes\n"
+	originalValues := "v1\nv2\nv3\n"
+	originalGitconfig := "[user]\n  name = Tester\n"
+
+	write := func(rel, content string, sub sandbox.Subdir) string {
+		return mustWrite(t, filepath.Join(ws.Path(sub), rel), content)
+	}
+	mainPath := write("main.go", originalMain, sandbox.SubdirWorkspace)
+	notesPath := write("notes.md", originalNotes, sandbox.SubdirWorkspace)
+	valuesPath := write("data/values.txt", originalValues, sandbox.SubdirWorkspace)
+	gitconfigPath := write(".gitconfig", originalGitconfig, sandbox.SubdirHome)
+
+	for label, p := range map[string]string{
+		"main.go":    mainPath,
+		"notes.md":   notesPath,
+		"values.txt": valuesPath,
+		".gitconfig": gitconfigPath,
+	} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("pre-snapshot file %s at %s: expected to exist, got %v", label, p, err)
+		}
+	}
+
+	// ── 5. Snapshot v1 ─────────────────────────────────────────────────
+	snap1, err := ws.Snapshot("initial", 0)
+	if err != nil {
+		t.Fatalf("Snapshot v1 on dev: %v", err)
+	}
+	if snap1.ID == "" {
+		t.Fatalf("Snapshot v1: empty ID, info=%+v", snap1)
+	}
+	if snap1.FileCount < 4 {
+		t.Fatalf("Snapshot v1: FileCount expected >=4 (main.go, notes.md, data/values.txt, .gitconfig), got %d", snap1.FileCount)
+	}
+	if snap1.SizeBytes <= 0 {
+		t.Fatalf("Snapshot v1: SizeBytes expected >0, got %d", snap1.SizeBytes)
+	}
+	v1MetaPath := filepath.Join(ws.Path(sandbox.SubdirSnapshots), snap1.ID, "meta.yaml")
+	if _, err := os.Stat(v1MetaPath); err != nil {
+		t.Fatalf("Snapshot v1 meta.yaml at %s: expected to exist, got %v", v1MetaPath, err)
+	}
+
+	// ── 6. Mutate state ────────────────────────────────────────────────
+	mutatedMain := originalMain + "// extra line after edits\n"
+	if err := os.WriteFile(mainPath, []byte(mutatedMain), 0o600); err != nil {
+		t.Fatalf("append main.go: %v", err)
+	}
+	if err := os.Remove(notesPath); err != nil {
+		t.Fatalf("remove notes.md: %v", err)
+	}
+	secretsPath := write("secrets.env", "API_KEY=shh\n", sandbox.SubdirWorkspace)
+
+	// verify the mutations on disk
+	if got, err := os.ReadFile(mainPath); err != nil || string(got) != mutatedMain {
+		t.Fatalf("post-mutation main.go: expected %q, got %q (err=%v)", mutatedMain, got, err)
+	}
+	if _, err := os.Stat(notesPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("post-mutation notes.md at %s: expected not-exist, got err=%v", notesPath, err)
+	}
+	if _, err := os.Stat(secretsPath); err != nil {
+		t.Fatalf("post-mutation secrets.env at %s: expected to exist, got %v", secretsPath, err)
+	}
+
+	// ── 7. Snapshot v2 ─────────────────────────────────────────────────
+	snap2, err := ws.Snapshot("after-edits", 0)
+	if err != nil {
+		t.Fatalf("Snapshot v2 on dev: %v", err)
+	}
+	if snap2.ID == snap1.ID {
+		t.Fatalf("Snapshot v2: id collides with v1 (%q)", snap1.ID)
+	}
+	snaps, err := ws.ListSnapshots()
+	if err != nil {
+		t.Fatalf("ListSnapshots after v2: %v", err)
+	}
+	if len(snaps) != 2 {
+		t.Fatalf("ListSnapshots after v2: expected 2, got %d (%+v)", len(snaps), snaps)
+	}
+	// newest first → snap2 must be element 0
+	if snaps[0].ID != snap2.ID {
+		t.Fatalf("ListSnapshots[0]: expected v2 %q, got %q (full list: %+v)", snap2.ID, snaps[0].ID, snaps)
+	}
+	if snaps[1].ID != snap1.ID {
+		t.Fatalf("ListSnapshots[1]: expected v1 %q, got %q", snap1.ID, snaps[1].ID)
+	}
+
+	// ── 8. Clone dev → dev-fork ────────────────────────────────────────
+	cloneWS, err := mgr.Clone("dev", "dev-fork", sandbox.CloneOptions{})
+	if err != nil {
+		t.Fatalf("Clone(dev, dev-fork): %v", err)
+	}
+	if cloneWS.Name() != "dev-fork" {
+		t.Fatalf("Clone returned workspace named %q, expected \"dev-fork\"", cloneWS.Name())
+	}
+	mustBeDir(t, cloneWS.Path(sandbox.SubdirWorkspace), "clone workspace subdir")
+	mustBeDir(t, cloneWS.Path(sandbox.SubdirHome), "clone home subdir")
+
+	// post-mutation files should appear in the clone, notes.md should NOT
+	cloneMain := filepath.Join(cloneWS.Path(sandbox.SubdirWorkspace), "main.go")
+	if got, err := os.ReadFile(cloneMain); err != nil || string(got) != mutatedMain {
+		t.Fatalf("clone main.go at %s: expected mutated content %q, got %q (err=%v)", cloneMain, mutatedMain, got, err)
+	}
+	cloneSecrets := filepath.Join(cloneWS.Path(sandbox.SubdirWorkspace), "secrets.env")
+	if _, err := os.Stat(cloneSecrets); err != nil {
+		t.Fatalf("clone secrets.env at %s: expected to exist, got %v", cloneSecrets, err)
+	}
+	cloneNotes := filepath.Join(cloneWS.Path(sandbox.SubdirWorkspace), "notes.md")
+	if _, err := os.Stat(cloneNotes); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("clone notes.md at %s: expected not-exist (it was deleted before clone), got err=%v", cloneNotes, err)
+	}
+	cloneGitconfig := filepath.Join(cloneWS.Path(sandbox.SubdirHome), ".gitconfig")
+	if got, err := os.ReadFile(cloneGitconfig); err != nil || string(got) != originalGitconfig {
+		t.Fatalf("clone .gitconfig at %s: expected %q, got %q (err=%v)", cloneGitconfig, originalGitconfig, got, err)
+	}
+	// Clone does NOT carry over snapshots/ by design (see internal/sandbox/clone.go).
+	// Document the contract: clone starts with an empty snapshots/ subdir.
+	cloneSnaps, err := cloneWS.ListSnapshots()
+	if err != nil {
+		t.Fatalf("clone ListSnapshots: %v", err)
+	}
+	if len(cloneSnaps) != 0 {
+		t.Fatalf("clone ListSnapshots: expected 0 (snapshots/ intentionally not cloned), got %d (%+v)", len(cloneSnaps), cloneSnaps)
+	}
+
+	// ── 9. Rollback dev to v1 ─────────────────────────────────────────
+	if err := ws.Rollback(snap1.ID); err != nil {
+		t.Fatalf("Rollback(dev, v1=%s): %v", snap1.ID, err)
+	}
+	// notes.md is back
+	if got, err := os.ReadFile(notesPath); err != nil || string(got) != originalNotes {
+		t.Fatalf("post-rollback notes.md at %s: expected %q, got %q (err=%v)", notesPath, originalNotes, got, err)
+	}
+	// secrets.env is gone
+	if _, err := os.Stat(secretsPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("post-rollback secrets.env at %s: expected not-exist, got err=%v", secretsPath, err)
+	}
+	// main.go matches the pre-mutation version
+	if got, err := os.ReadFile(mainPath); err != nil || string(got) != originalMain {
+		t.Fatalf("post-rollback main.go at %s: expected %q, got %q (err=%v)", mainPath, originalMain, got, err)
+	}
+	// clone is unaffected
+	if got, err := os.ReadFile(cloneMain); err != nil || string(got) != mutatedMain {
+		t.Fatalf("post-rollback clone main.go at %s: expected mutated %q, got %q (err=%v)", cloneMain, mutatedMain, got, err)
+	}
+	if _, err := os.Stat(cloneSecrets); err != nil {
+		t.Fatalf("post-rollback clone secrets.env at %s: expected to still exist, got %v", cloneSecrets, err)
+	}
+	if _, err := os.Stat(cloneNotes); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("post-rollback clone notes.md at %s: expected still not-exist, got err=%v", cloneNotes, err)
+	}
+
+	// ── 10. Snapshot prune via maxSnapshots ────────────────────────────
+	// Currently dev has snap1 and snap2 from earlier. Take 3 more snapshots
+	// with maxSnapshots=2 each; the cap should hold list length <= 2.
+	for i := 0; i < 3; i++ {
+		// touch a file so each snapshot has new content / unique mtime
+		bump := []byte(originalMain + "// bump " + itoa(i) + "\n")
+		if err := os.WriteFile(mainPath, bump, 0o600); err != nil {
+			t.Fatalf("bump #%d write main.go: %v", i, err)
+		}
+		if _, err := ws.Snapshot("prune-"+itoa(i), 2); err != nil {
+			t.Fatalf("Snapshot(prune-%d, max=2): %v", i, err)
+		}
+	}
+	finalSnaps, err := ws.ListSnapshots()
+	if err != nil {
+		t.Fatalf("ListSnapshots after prune cycle: %v", err)
+	}
+	if len(finalSnaps) > 2 {
+		t.Fatalf("ListSnapshots after maxSnapshots=2 prune: expected <=2, got %d (%+v)", len(finalSnaps), finalSnaps)
+	}
+
+	// ── 11. Destroy dev-fork, then destroy active dev ───────────────────
+	if err := mgr.Destroy("dev-fork"); err != nil {
+		t.Fatalf("Destroy(dev-fork): %v", err)
+	}
+	if _, err := os.Stat(cloneWS.Root()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("post-Destroy dev-fork root %s: expected not-exist, got err=%v", cloneWS.Root(), err)
+	}
+	postForkList, err := mgr.List()
+	if err != nil {
+		t.Fatalf("List after destroy dev-fork: %v", err)
+	}
+	for _, w := range postForkList {
+		if w.Name == "dev-fork" {
+			t.Fatalf("List after destroy dev-fork: still present (%+v)", postForkList)
+		}
+	}
+
+	// Destroy "dev" while it's the active sandbox. Per workspace.go, Destroy
+	// auto-clears the active pointer when it matches the destroyed name.
+	if err := mgr.Destroy("dev"); err != nil {
+		t.Fatalf("Destroy(dev) while active: %v", err)
+	}
+	gotActive, gotErr := mgr.Active()
+	if !errors.Is(gotErr, sandbox.ErrNoActive) {
+		// Contract fallback (the prompt instructed to handle a possible
+		// dangling pointer): clear explicitly and re-assert.
+		t.Logf("contract note: Active() after Destroy of active returned (%q, %v); calling ClearActive() explicitly", gotActive, gotErr)
+		if clearErr := mgr.ClearActive(); clearErr != nil {
+			t.Fatalf("ClearActive after destroy: %v", clearErr)
+		}
+		if gotActive, gotErr = mgr.Active(); !errors.Is(gotErr, sandbox.ErrNoActive) {
+			t.Fatalf("Active() after ClearActive: expected ErrNoActive, got (%q, %v)", gotActive, gotErr)
+		}
+	}
+
+	// ── 12. Final state ────────────────────────────────────────────────
+	finalList, err := mgr.List()
+	if err != nil {
+		t.Fatalf("Final List: %v", err)
+	}
+	finalNames := sandboxNames(finalList)
+	want := []string{"staging", "experiment"}
+	if !equalSets(finalNames, want) {
+		t.Fatalf("Final list: expected %v, got %v", want, finalNames)
+	}
+
+	if _, err := mgr.Switch("staging"); err != nil {
+		t.Fatalf("Switch(staging) at end: %v", err)
+	}
+	final, err := mgr.Active()
+	if err != nil {
+		t.Fatalf("Active() after Switch(staging): %v", err)
+	}
+	if final != "staging" {
+		t.Fatalf("Active() after final switch: expected \"staging\", got %q", final)
+	}
+}
+
+// ── helpers (kept local to this file) ──────────────────────────────────
+
+// mustBeDir asserts path exists and is a directory; t.Fatalf with context.
+func mustBeDir(t *testing.T, path, label string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("%s: stat %s: %v", label, path, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("%s: %s exists but is not a directory", label, path)
+	}
+}
+
+// sandboxNames extracts the Name field from a slice of WorkspaceInfo, sorted.
+func sandboxNames(list []sandbox.WorkspaceInfo) []string {
+	out := make([]string, 0, len(list))
+	for _, w := range list {
+		out = append(out, w.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// equalSets compares two string slices irrespective of order.
+func equalSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := append([]string(nil), a...)
+	bc := append([]string(nil), b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	return strings.Join(ac, "\x00") == strings.Join(bc, "\x00")
+}
+
+// itoa is a tiny strconv.Itoa shim to avoid importing strconv solely for it.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}

--- a/tests/e2e/server_journey_test.go
+++ b/tests/e2e/server_journey_test.go
@@ -1,0 +1,625 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/jabreeflor/conduit/internal/coding"
+	"github.com/jabreeflor/conduit/internal/server"
+	"github.com/jabreeflor/conduit/internal/tools"
+)
+
+// TestServeAgentFullJourney is the end-to-end story of a browser-shaped
+// session against `conduit serve`: REST surface walkthrough, WebSocket
+// agent prompt/response loop, tool emission, error recovery, and
+// per-connection isolation. The journey is intentionally long because
+// the GUI's behaviour is the integration of all of these working in
+// concert; breaking any one of them breaks the product.
+func TestServeAgentFullJourney(t *testing.T) {
+	// ── 1. Bootstrap ────────────────────────────────────────────────
+	home := newHome(t)
+
+	older := filepath.Join(home.CodingSessions, "code-1-aaa.jsonl")
+	newer := filepath.Join(home.CodingSessions, "code-2-bbb.jsonl")
+	mustWrite(t, older, `{"role":"user","content":"older prompt body"}`+"\n")
+	mustWrite(t, newer, `{"role":"user","content":"newer prompt body"}`+"\n")
+	now := time.Now()
+	if err := os.Chtimes(older, now.Add(-2*time.Hour), now.Add(-2*time.Hour)); err != nil {
+		t.Fatalf("chtimes older: %v", err)
+	}
+	if err := os.Chtimes(newer, now, now); err != nil {
+		t.Fatalf("chtimes newer: %v", err)
+	}
+
+	// ── 2. Server construction ──────────────────────────────────────
+	// echoBack is the BASE tool we hand to the server. Each connection's
+	// factory will receive the *wrapped* slice (tool_use/tool_result
+	// instrumented) and we'll drive it from a custom streamer below.
+	echoBack := tools.Tool{
+		Name:        "echo_back",
+		Description: "echo back its raw input",
+		Schema:      map[string]any{"type": "object"},
+		Run: func(_ context.Context, raw json.RawMessage) (tools.Result, error) {
+			return tools.Result{Text: "echoed:" + string(raw)}, nil
+		},
+	}
+
+	// journeyStreamer is per-connection: it serves scripted text-delta
+	// replies, optionally invokes a named wrapped tool, and records each
+	// prompt so we can verify per-connection isolation.
+	type streamerState struct {
+		mu       sync.Mutex
+		wrapped  map[string]tools.Tool
+		prompts  []string
+		queue    []journeyReply
+		fallback journeyReply
+	}
+	makeStream := func(state *streamerState) coding.Streamer {
+		return journeyStreamerFunc(func(ctx context.Context, prompt string, onDelta func(string)) (string, string, error) {
+			state.mu.Lock()
+			state.prompts = append(state.prompts, prompt)
+			var r journeyReply
+			if len(state.queue) > 0 {
+				r = state.queue[0]
+				state.queue = state.queue[1:]
+			} else {
+				r = state.fallback
+			}
+			state.mu.Unlock()
+
+			var collected strings.Builder
+			for _, step := range r.steps {
+				if err := ctx.Err(); err != nil {
+					return "", "", err
+				}
+				if step.delta != "" {
+					if onDelta != nil {
+						onDelta(step.delta)
+					}
+					collected.WriteString(step.delta)
+					continue
+				}
+				if step.toolName != "" {
+					state.mu.Lock()
+					tool, ok := state.wrapped[step.toolName]
+					state.mu.Unlock()
+					if !ok {
+						return "", "", fmt.Errorf("scripted tool %q not in wrapped slice", step.toolName)
+					}
+					if _, err := tool.Run(ctx, json.RawMessage(step.toolIn)); err != nil {
+						return "", "", err
+					}
+				}
+			}
+			full := r.full
+			if full == "" {
+				full = collected.String()
+			}
+			finish := r.finish
+			if finish == "" {
+				finish = "stop"
+			}
+			return full, finish, nil
+		})
+	}
+
+	// One state object per WS connection so we can introspect what the
+	// streamer saw. The factory is called once per connection per
+	// agent.go's contract.
+	var connStates []*streamerState
+	var connMu sync.Mutex
+	var connCount int32
+
+	factory := func(wrapped []tools.Tool) (coding.Streamer, string, string) {
+		idx := atomic.AddInt32(&connCount, 1) - 1
+		state := &streamerState{
+			wrapped: make(map[string]tools.Tool, len(wrapped)),
+			fallback: journeyReply{
+				steps:  []journeyStep{{delta: "fallback "}, {delta: "reply"}},
+				finish: "stop",
+			},
+		}
+		for _, w := range wrapped {
+			state.wrapped[w.Name] = w
+		}
+		// Conn 0 is the main journey; conn 1 is the parallel-isolation
+		// peer. We seed scripted queues per-connection from the outer
+		// test; missing entries fall back to the default reply.
+		connMu.Lock()
+		// Grow connStates as needed.
+		for int(idx) >= len(connStates) {
+			connStates = append(connStates, nil)
+		}
+		if connStates[idx] == nil {
+			connStates[idx] = state
+		} else {
+			// A test pre-populated this slot — adopt its queue/fallback
+			// but always rebind wrapped to the *current* connection's
+			// wrapped slice (so tool_use events flow through the right
+			// emitter).
+			pre := connStates[idx]
+			pre.wrapped = state.wrapped
+			state = pre
+		}
+		connMu.Unlock()
+		return makeStream(state), "test-provider", "test-model"
+	}
+
+	// Pre-stage connection 0's reply queue: three turns plus a malformed
+	// turn (server emits error frame and stays open), then a recovery
+	// turn after the error. We pre-create the state so we can write its
+	// queue before the connection dials.
+	conn0State := &streamerState{
+		queue: []journeyReply{
+			// Turn 1: simple deltas.
+			{steps: []journeyStep{{delta: "Hello"}, {delta: ", "}, {delta: "world!"}}, finish: "stop"},
+			// Turn 2: a different deltas pattern.
+			{steps: []journeyStep{{delta: "Second "}, {delta: "turn"}}, finish: "stop"},
+			// Turn 3: tool use surrounded by deltas.
+			{steps: []journeyStep{
+				{delta: "calling "},
+				{toolName: "echo_back", toolIn: `{"hello":"there"}`},
+				{delta: " done"},
+			}, finish: "stop"},
+			// Turn 4 (recovery after error frame): a simple delta.
+			{steps: []journeyStep{{delta: "recovered"}}, finish: "stop"},
+		},
+		fallback: journeyReply{
+			steps: []journeyStep{{delta: "fallback"}}, finish: "stop",
+		},
+	}
+	connMu.Lock()
+	connStates = append(connStates, conn0State)
+	connMu.Unlock()
+
+	srv := server.New(server.Config{
+		Factory:     factory,
+		BaseTools:   []tools.Tool{echoBack},
+		Provider:    "test-provider",
+		Model:       "test-model",
+		Version:     "e2e-test",
+		HomeDir:     home.Root,
+		SessionsDir: home.CodingSessions,
+	})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+
+	// ── 3. REST surface walkthrough ─────────────────────────────────
+	// /api/info
+	{
+		resp := mustGET(t, httpClient, ts.URL+"/api/info")
+		var got map[string]any
+		decodeBody(t, resp, &got)
+		if got["provider"] != "test-provider" {
+			t.Errorf("/api/info provider: got %v want test-provider", got["provider"])
+		}
+		if got["model"] != "test-model" {
+			t.Errorf("/api/info model: got %v want test-model", got["model"])
+		}
+		if got["version"] != "e2e-test" {
+			t.Errorf("/api/info version: got %v want e2e-test", got["version"])
+		}
+	}
+
+	// /api/memory
+	{
+		resp := mustGET(t, httpClient, ts.URL+"/api/memory")
+		var got map[string]any
+		decodeBody(t, resp, &got)
+		soul, _ := got["soul"].(string)
+		user, _ := got["user"].(string)
+		if !strings.Contains(soul, "You are Conduit.") {
+			t.Errorf("/api/memory soul: missing seeded SOUL.md content, got %q", soul)
+		}
+		if !strings.Contains(user, "concise replies") {
+			t.Errorf("/api/memory user: missing seeded USER.md content, got %q", user)
+		}
+	}
+
+	// /api/sessions
+	{
+		resp := mustGET(t, httpClient, ts.URL+"/api/sessions")
+		var got []map[string]any
+		decodeBody(t, resp, &got)
+		if len(got) != 2 {
+			t.Fatalf("/api/sessions count: got %d want 2 (%+v)", len(got), got)
+		}
+		if id, _ := got[0]["id"].(string); id != "code-2-bbb" {
+			t.Errorf("/api/sessions newest: got %q want code-2-bbb", id)
+		}
+		if id, _ := got[1]["id"].(string); id != "code-1-aaa" {
+			t.Errorf("/api/sessions oldest: got %q want code-1-aaa", id)
+		}
+	}
+
+	// /api/projects — assert 200 and JSON only.
+	{
+		resp := mustGET(t, httpClient, ts.URL+"/api/projects")
+		if resp.StatusCode/100 == 5 {
+			t.Fatalf("/api/projects: server error %d", resp.StatusCode)
+		}
+		var anyShape any
+		decodeBody(t, resp, &anyShape)
+		if anyShape == nil {
+			t.Errorf("/api/projects: nil body")
+		}
+	}
+
+	// OPTIONS /api/info — CORS preflight.
+	{
+		req, err := http.NewRequest(http.MethodOptions, ts.URL+"/api/info", nil)
+		if err != nil {
+			t.Fatalf("options req: %v", err)
+		}
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			t.Fatalf("options do: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			t.Errorf("options status: got %d want 204", resp.StatusCode)
+		}
+		if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "*" {
+			t.Errorf("options CORS: got %q want *", got)
+		}
+	}
+
+	// ── 4. WebSocket round-trip ─────────────────────────────────────
+	wsCtx, wsCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer wsCancel()
+
+	wsURL := strings.Replace(ts.URL, "http", "ws", 1) + "/api/agent"
+	c, _, err := websocket.Dial(wsCtx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "done")
+
+	// Session frame (unsolicited).
+	first := readEvent(t, wsCtx, c)
+	if first.Type != "session" {
+		t.Fatalf("first frame type: got %q want session (%+v)", first.Type, first)
+	}
+	if first.Provider != "test-provider" {
+		t.Errorf("session provider: got %q want test-provider", first.Provider)
+	}
+	if first.ID == "" {
+		t.Errorf("session id: empty")
+	}
+	sessionID1 := first.ID
+
+	// Turn 1: send prompt, expect three deltas + end_turn.
+	writeJSON(t, wsCtx, c, promptFrame("first message"))
+	gotText1 := drainTurn(t, wsCtx, c)
+	if gotText1 != "Hello, world!" {
+		t.Errorf("turn 1 concatenated deltas: got %q want %q", gotText1, "Hello, world!")
+	}
+
+	// Turn 2: another prompt over the SAME connection. Per agent.go,
+	// one streamer per connection — both prompts hit the same streamer
+	// so its call log should now contain both prompts in order.
+	writeJSON(t, wsCtx, c, promptFrame("second message"))
+	gotText2 := drainTurn(t, wsCtx, c)
+	if gotText2 != "Second turn" {
+		t.Errorf("turn 2 concatenated deltas: got %q want %q", gotText2, "Second turn")
+	}
+
+	conn0State.mu.Lock()
+	gotPrompts := append([]string(nil), conn0State.prompts...)
+	conn0State.mu.Unlock()
+	if len(gotPrompts) < 2 {
+		t.Fatalf("conn0 streamer prompts: got %d want >=2 (%v)", len(gotPrompts), gotPrompts)
+	}
+	if gotPrompts[0] != "first message" || gotPrompts[1] != "second message" {
+		t.Errorf("conn0 streamer prompt order: got %v want [first message, second message]", gotPrompts)
+	}
+
+	// ── 5. Tool emission on the wire ────────────────────────────────
+	writeJSON(t, wsCtx, c, promptFrame("third message"))
+
+	var sawText, sawToolUse, sawToolResult, sawEnd bool
+	var toolUseEv, toolResultEv agentEv
+	for !sawEnd {
+		ev := readEvent(t, wsCtx, c)
+		switch ev.Type {
+		case "text_delta":
+			sawText = true
+		case "tool_use":
+			sawToolUse = true
+			toolUseEv = ev
+		case "tool_result":
+			sawToolResult = true
+			toolResultEv = ev
+		case "end_turn":
+			sawEnd = true
+		case "error":
+			t.Fatalf("turn 3 unexpected error frame: %+v", ev)
+		}
+	}
+	if !sawText {
+		t.Errorf("turn 3: never saw text_delta")
+	}
+	if !sawToolUse {
+		t.Fatalf("turn 3: never saw tool_use")
+	}
+	if toolUseEv.Name != "echo_back" {
+		t.Errorf("tool_use name: got %q want echo_back", toolUseEv.Name)
+	}
+	if !sawToolResult {
+		t.Fatalf("turn 3: never saw tool_result")
+	}
+	if toolResultEv.Name != "echo_back" {
+		t.Errorf("tool_result name: got %q want echo_back", toolResultEv.Name)
+	}
+	if !strings.Contains(toolResultEv.Output, "echoed:") {
+		t.Errorf("tool_result output: got %q want substring %q", toolResultEv.Output, "echoed:")
+	}
+
+	// ── 6. Error path ───────────────────────────────────────────────
+	// Send a malformed prompt frame (wrong type). Expect error frame
+	// back, connection stays open.
+	bad, _ := json.Marshal(map[string]string{"type": "not-prompt", "text": "x"})
+	if err := c.Write(wsCtx, websocket.MessageText, bad); err != nil {
+		t.Fatalf("write malformed: %v", err)
+	}
+	errEv := readEvent(t, wsCtx, c)
+	if errEv.Type != "error" {
+		t.Fatalf("expected error frame, got %+v", errEv)
+	}
+	if !strings.Contains(errEv.Message, "expected") {
+		t.Errorf("error message: got %q want substring %q", errEv.Message, "expected")
+	}
+
+	// Recovery: send a valid prompt; expect normal lifecycle.
+	writeJSON(t, wsCtx, c, promptFrame("recovery"))
+	recoveryText := drainTurn(t, wsCtx, c)
+	if recoveryText != "recovered" {
+		t.Errorf("recovery text: got %q want %q", recoveryText, "recovered")
+	}
+
+	// ── 7. Concurrent connections are isolated ──────────────────────
+	// Pre-stage conn1 and conn2 states. conn0 already holds slot 0.
+	conn1State := &streamerState{
+		queue: []journeyReply{
+			{steps: []journeyStep{{delta: "alpha"}}, finish: "stop"},
+		},
+		fallback: journeyReply{steps: []journeyStep{{delta: "alpha-fb"}}, finish: "stop"},
+	}
+	conn2State := &streamerState{
+		queue: []journeyReply{
+			{steps: []journeyStep{{delta: "beta"}}, finish: "stop"},
+		},
+		fallback: journeyReply{steps: []journeyStep{{delta: "beta-fb"}}, finish: "stop"},
+	}
+	connMu.Lock()
+	connStates = append(connStates, conn1State, conn2State)
+	connMu.Unlock()
+
+	parCtx, parCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer parCancel()
+
+	type connResult struct {
+		sessionID string
+		text      string
+		err       error
+	}
+	results := make(chan connResult, 2)
+
+	runPeer := func(label, text string) {
+		go func() {
+			pc, _, dialErr := websocket.Dial(parCtx, wsURL, nil)
+			if dialErr != nil {
+				results <- connResult{err: fmt.Errorf("%s dial: %w", label, dialErr)}
+				return
+			}
+			defer pc.Close(websocket.StatusNormalClosure, "done")
+
+			sess := readEvent(noopFatal{}, parCtx, pc)
+			if sess.Type != "session" {
+				results <- connResult{err: fmt.Errorf("%s expected session frame, got %+v", label, sess)}
+				return
+			}
+			payload, _ := json.Marshal(promptMsg{Type: "prompt", Text: text})
+			if err := pc.Write(parCtx, websocket.MessageText, payload); err != nil {
+				results <- connResult{err: fmt.Errorf("%s write: %w", label, err)}
+				return
+			}
+			var accum strings.Builder
+			for {
+				ev := readEvent(noopFatal{}, parCtx, pc)
+				switch ev.Type {
+				case "text_delta":
+					accum.WriteString(ev.Text)
+				case "end_turn":
+					results <- connResult{sessionID: sess.ID, text: accum.String()}
+					return
+				case "error":
+					results <- connResult{err: fmt.Errorf("%s error frame: %s", label, ev.Message)}
+					return
+				}
+			}
+		}()
+	}
+
+	runPeer("peer-A", "from-A")
+	runPeer("peer-B", "from-B")
+
+	var peerResults []connResult
+	for i := 0; i < 2; i++ {
+		select {
+		case r := <-results:
+			if r.err != nil {
+				t.Fatalf("peer: %v", r.err)
+			}
+			peerResults = append(peerResults, r)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("peer timeout waiting for result %d", i)
+		}
+	}
+	if len(peerResults) != 2 {
+		t.Fatalf("peer results: got %d want 2", len(peerResults))
+	}
+	if peerResults[0].sessionID == "" || peerResults[1].sessionID == "" {
+		t.Errorf("peer session IDs empty: %+v", peerResults)
+	}
+	// The session IDs are stamped from time.Now().Unix() in agent.go, so
+	// they MAY collide when two dials land in the same second. Don't
+	// require distinctness — that's an implementation detail. Do require
+	// they got their OWN session frames and own end_turn frames (the
+	// fact that we collected two results proves this).
+	gotTexts := map[string]bool{peerResults[0].text: true, peerResults[1].text: true}
+	if !gotTexts["alpha"] || !gotTexts["beta"] {
+		t.Errorf("peer texts: got %v want both alpha and beta", gotTexts)
+	}
+	// And the main connection's session ID is from a different second
+	// (we did several turns since dialing) — sanity check it's still
+	// non-empty.
+	if sessionID1 == "" {
+		t.Errorf("main session id was empty")
+	}
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+// journeyStep is one action inside a scripted reply: either emit a text
+// delta or run a named tool from the wrapped slice.
+type journeyStep struct {
+	delta    string
+	toolName string
+	toolIn   string
+}
+
+// journeyReply is one full Stream() reply: the steps to play, the
+// optional aggregated full string, and the finish reason.
+type journeyReply struct {
+	steps  []journeyStep
+	full   string
+	finish string
+}
+
+// journeyStreamerFunc adapts a Stream-shaped function into a
+// coding.Streamer so each connection can have its own behaviour without
+// defining a struct per test.
+type journeyStreamerFunc func(ctx context.Context, prompt string, onDelta func(string)) (string, string, error)
+
+func (f journeyStreamerFunc) Stream(ctx context.Context, prompt string, onDelta func(string)) (string, string, error) {
+	return f(ctx, prompt, onDelta)
+}
+
+var _ coding.Streamer = journeyStreamerFunc(nil)
+
+// agentEv mirrors the server's agentEvent wire shape (unexported in the
+// server package, so we redeclare here).
+type agentEv struct {
+	Type     string `json:"type"`
+	ID       string `json:"id,omitempty"`
+	Provider string `json:"provider,omitempty"`
+	Model    string `json:"model,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Text     string `json:"text,omitempty"`
+	Input    string `json:"input,omitempty"`
+	Output   string `json:"output,omitempty"`
+	IsError  bool   `json:"isError,omitempty"`
+	Message  string `json:"message,omitempty"`
+}
+
+type promptMsg struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func promptFrame(text string) promptMsg { return promptMsg{Type: "prompt", Text: text} }
+
+// fatalLogger is the minimum surface we need from *testing.T inside
+// helpers — extracted so we can pass a noop variant from goroutines that
+// must not call t.Fatalf concurrently.
+type fatalLogger interface {
+	Fatalf(format string, args ...any)
+	Helper()
+}
+
+type noopFatal struct{}
+
+func (noopFatal) Fatalf(string, ...any) {}
+func (noopFatal) Helper()               {}
+
+func readEvent(t fatalLogger, ctx context.Context, c *websocket.Conn) agentEv {
+	t.Helper()
+	_, data, err := c.Read(ctx)
+	if err != nil {
+		t.Fatalf("ws read: %v", err)
+		return agentEv{}
+	}
+	var ev agentEv
+	if err := json.Unmarshal(data, &ev); err != nil {
+		t.Fatalf("ws decode: %v (raw=%s)", err, string(data))
+		return agentEv{}
+	}
+	return ev
+}
+
+func writeJSON(t *testing.T, ctx context.Context, c *websocket.Conn, v any) {
+	t.Helper()
+	payload, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := c.Write(ctx, websocket.MessageText, payload); err != nil {
+		t.Fatalf("ws write: %v", err)
+	}
+}
+
+// drainTurn reads frames until end_turn, concatenating all text_delta
+// payloads. Fails the test on error or premature error frame.
+func drainTurn(t *testing.T, ctx context.Context, c *websocket.Conn) string {
+	t.Helper()
+	var b strings.Builder
+	for {
+		ev := readEvent(t, ctx, c)
+		switch ev.Type {
+		case "text_delta":
+			b.WriteString(ev.Text)
+		case "end_turn":
+			return b.String()
+		case "error":
+			t.Fatalf("drainTurn unexpected error frame: %s", ev.Message)
+			return b.String()
+		case "tool_use", "tool_result", "session":
+			// Ignore — these don't contribute to the concatenated text.
+		}
+	}
+}
+
+func mustGET(t *testing.T, client *http.Client, url string) *http.Response {
+	t.Helper()
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: status %d", url, resp.StatusCode)
+	}
+	return resp
+}
+
+func decodeBody(t *testing.T, resp *http.Response, v any) {
+	t.Helper()
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+}

--- a/tests/e2e/sessions_skills_journey_test.go
+++ b/tests/e2e/sessions_skills_journey_test.go
@@ -1,0 +1,502 @@
+package e2e
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jabreeflor/conduit/internal/contracts"
+	"github.com/jabreeflor/conduit/internal/sessions"
+	"github.com/jabreeflor/conduit/internal/skills"
+)
+
+// TestSessionsLifecycleJourney walks a complete session-store lifecycle:
+// create two parallel sessions, list/load them, find a turn by id, fork
+// from a midpoint, diverge the fork, replay through a scripted responder,
+// and assert the missing-turn error path.
+func TestSessionsLifecycleJourney(t *testing.T) {
+	home := newHome(t)
+
+	// 1. Bootstrap.
+	store, err := sessions.NewStore(home.Sessions)
+	if err != nil {
+		t.Fatalf("NewStore(%q): %v", home.Sessions, err)
+	}
+
+	// 2. Two parallel conversations.
+	sessA, err := store.Create()
+	if err != nil {
+		t.Fatalf("Create sessA: %v", err)
+	}
+	sessB, err := store.Create()
+	if err != nil {
+		t.Fatalf("Create sessB: %v", err)
+	}
+	if sessA.ID == sessB.ID {
+		t.Fatalf("Create returned duplicate session ids: %q", sessA.ID)
+	}
+
+	// Six turns into A, alternating user / assistant.
+	contentsA := []struct {
+		Role    string
+		Content string
+	}{
+		{"user", "Can you help me design a session store?"},
+		{"assistant", "Sure — what storage layout did you have in mind?"},
+		{"user", "JSONL per session with parent links between turns."},
+		{"assistant", "That gives you append-only writes and easy forks."},
+		{"user", "How would I implement fork-from-turn cleanly?"},
+		{"assistant", "Walk the parent chain to the fork point, rewrite ids."},
+	}
+
+	var idsA []string
+	var lastIDA string
+	for i, c := range contentsA {
+		written, err := store.Append(sessA, sessions.Turn{
+			Role:     c.Role,
+			Content:  c.Content,
+			ParentID: lastIDA,
+		})
+		if err != nil {
+			t.Fatalf("Append sessA turn %d (%s): %v", i, c.Role, err)
+		}
+		if written.ID == "" {
+			t.Fatalf("Append sessA turn %d returned empty id", i)
+		}
+		if written.SessionID != sessA.ID {
+			t.Fatalf("Append sessA turn %d session id mismatch: got %q want %q", i, written.SessionID, sessA.ID)
+		}
+		idsA = append(idsA, written.ID)
+		lastIDA = written.ID
+
+		if i == 0 {
+			// Verify the disk-backed journal exists after the first append.
+			if info, err := os.Stat(sessA.Path); err != nil || info.Size() == 0 {
+				t.Fatalf("expected non-empty journal at %s after first append; err=%v info=%+v", sessA.Path, err, info)
+			}
+		}
+	}
+
+	contentsB := []struct {
+		Role    string
+		Content string
+	}{
+		{"user", "Different conversation about logging."},
+		{"assistant", "Sure, what level granularity are you considering?"},
+		{"user", "Structured JSON, one event per line."},
+		{"assistant", "That pairs well with jq-style debugging."},
+	}
+	var lastIDB string
+	for i, c := range contentsB {
+		written, err := store.Append(sessB, sessions.Turn{
+			Role:     c.Role,
+			Content:  c.Content,
+			ParentID: lastIDB,
+		})
+		if err != nil {
+			t.Fatalf("Append sessB turn %d (%s): %v", i, c.Role, err)
+		}
+		lastIDB = written.ID
+	}
+
+	if got := len(sessA.Turns); got != 6 {
+		t.Fatalf("sessA in-memory turns: got %d want 6", got)
+	}
+	if got := len(sessB.Turns); got != 4 {
+		t.Fatalf("sessB in-memory turns: got %d want 4", got)
+	}
+
+	// 3. List both, newest first, with correct titles.
+	infos, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("List returned %d sessions, want 2: %+v", len(infos), infos)
+	}
+	// Newest first — sessB was written last, so it should come first.
+	if !infos[0].UpdatedAt.After(infos[1].UpdatedAt) && !infos[0].UpdatedAt.Equal(infos[1].UpdatedAt) {
+		t.Fatalf("List not sorted newest-first: %v then %v", infos[0].UpdatedAt, infos[1].UpdatedAt)
+	}
+	// TurnCount per id.
+	turnCounts := map[string]int{}
+	titles := map[string]string{}
+	for _, info := range infos {
+		turnCounts[info.ID] = info.TurnCount
+		titles[info.ID] = info.Title
+	}
+	if turnCounts[sessA.ID] != 6 {
+		t.Fatalf("sessA TurnCount: got %d want 6", turnCounts[sessA.ID])
+	}
+	if turnCounts[sessB.ID] != 4 {
+		t.Fatalf("sessB TurnCount: got %d want 4", turnCounts[sessB.ID])
+	}
+	wantTitleA := truncateExpected(contentsA[0].Content, 60)
+	if titles[sessA.ID] != wantTitleA {
+		t.Fatalf("sessA Title: got %q want %q", titles[sessA.ID], wantTitleA)
+	}
+
+	// 4. Load round-trip: ids, roles, contents preserved.
+	loadedA, err := store.Load(sessA.ID)
+	if err != nil {
+		t.Fatalf("Load %s: %v", sessA.ID, err)
+	}
+	if got := len(loadedA.Turns); got != len(contentsA) {
+		t.Fatalf("loadedA turn count: got %d want %d", got, len(contentsA))
+	}
+	for i, want := range contentsA {
+		got := loadedA.Turns[i]
+		if got.ID != idsA[i] {
+			t.Fatalf("loadedA turn %d id: got %q want %q", i, got.ID, idsA[i])
+		}
+		if got.Role != want.Role {
+			t.Fatalf("loadedA turn %d role: got %q want %q", i, got.Role, want.Role)
+		}
+		if got.Content != want.Content {
+			t.Fatalf("loadedA turn %d content: got %q want %q", i, got.Content, want.Content)
+		}
+		if got.SessionID != sessA.ID {
+			t.Fatalf("loadedA turn %d session id: got %q want %q", i, got.SessionID, sessA.ID)
+		}
+		// Timestamp should round-trip with monotonic-clock tolerance: the
+		// reloaded timestamp must not be earlier than the writer's.
+		orig := sessA.Turns[i].At
+		if got.At.Before(orig.Add(-1)) || got.At.After(orig.Add(1)) {
+			// JSON marshalling via RFC3339Nano is lossless modulo monotonic
+			// fields; assert the wall-clock instants match within a tiny window.
+			t.Fatalf("loadedA turn %d timestamp drift: got %v want ~%v", i, got.At, orig)
+		}
+	}
+
+	// 5. FindTurn finds a middle turn.
+	midIdx := 2 // third turn in A (zero-indexed)
+	midTurnID := idsA[midIdx]
+	foundSess, foundTurn, err := store.FindTurn(midTurnID)
+	if err != nil {
+		t.Fatalf("FindTurn(%q): %v", midTurnID, err)
+	}
+	if foundSess.ID != sessA.ID {
+		t.Fatalf("FindTurn returned session %q want %q", foundSess.ID, sessA.ID)
+	}
+	if foundTurn.ID != midTurnID {
+		t.Fatalf("FindTurn returned turn id %q want %q", foundTurn.ID, midTurnID)
+	}
+	if foundTurn.Content != contentsA[midIdx].Content {
+		t.Fatalf("FindTurn content: got %q want %q", foundTurn.Content, contentsA[midIdx].Content)
+	}
+
+	// 6. Fork at the midpoint.
+	forked, err := store.Fork(sessA.ID, midTurnID)
+	if err != nil {
+		t.Fatalf("Fork(%s, %s): %v", sessA.ID, midTurnID, err)
+	}
+	if forked.ID == sessA.ID {
+		t.Fatalf("Fork returned same id as source: %q", forked.ID)
+	}
+	if forked.ForkParentID != midTurnID {
+		t.Fatalf("Fork ForkParentID: got %q want %q", forked.ForkParentID, midTurnID)
+	}
+	if len(forked.Turns) != midIdx+1 {
+		t.Fatalf("Fork prefix length: got %d want %d (turns=%+v)", len(forked.Turns), midIdx+1, forked.Turns)
+	}
+	// Each turn in the fork has a fresh id and parent chain points internally,
+	// except the root which carries the source turn id.
+	if forked.Turns[0].ParentID != midTurnID {
+		t.Fatalf("forked root ParentID: got %q want %q (cross-session link)", forked.Turns[0].ParentID, midTurnID)
+	}
+	for i, ft := range forked.Turns {
+		// New id, not equal to any original id from sessA.
+		for j, origID := range idsA {
+			if ft.ID == origID {
+				t.Fatalf("forked turn %d reused source id %q (source idx %d); fork must rewrite ids", i, origID, j)
+			}
+		}
+		if i == 0 {
+			continue
+		}
+		if ft.ParentID != forked.Turns[i-1].ID {
+			t.Fatalf("forked turn %d ParentID: got %q want %q (internal chain)", i, ft.ParentID, forked.Turns[i-1].ID)
+		}
+	}
+
+	// 7. Diverge the fork: append two new turns; ensure sessA stays untouched.
+	forkExtra := []struct {
+		Role    string
+		Content string
+	}{
+		{"user", "What if I add embeddings later?"},
+		{"assistant", "Plug a strategy into the search method — registry-friendly."},
+	}
+	lastForkID := forked.Turns[len(forked.Turns)-1].ID
+	for i, c := range forkExtra {
+		written, err := store.Append(forked, sessions.Turn{
+			Role:     c.Role,
+			Content:  c.Content,
+			ParentID: lastForkID,
+		})
+		if err != nil {
+			t.Fatalf("Append forked turn %d: %v", i, err)
+		}
+		lastForkID = written.ID
+	}
+
+	reloadedA, err := store.Load(sessA.ID)
+	if err != nil {
+		t.Fatalf("reload sessA: %v", err)
+	}
+	if got := len(reloadedA.Turns); got != 6 {
+		t.Fatalf("sessA must remain 6 turns after fork divergence, got %d", got)
+	}
+	reloadedFork, err := store.Load(forked.ID)
+	if err != nil {
+		t.Fatalf("reload forked: %v", err)
+	}
+	if got := len(reloadedFork.Turns); got != 5 {
+		t.Fatalf("forked must have 5 turns (3 prefix + 2 new), got %d", got)
+	}
+	for _, path := range []string{sessA.Path, forked.Path} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected session file at %s: %v", path, err)
+		}
+	}
+
+	// 8. Replay from the midpoint via a deterministic responder.
+	responder := scriptedResponder{prefix: "replay-reply for "}
+	replaySess, replayTurn, err := store.Replay(sessA.ID, midTurnID, sessions.ReplayOptions{
+		Model:     "fake-model",
+		Params:    map[string]string{"temperature": "0.0"},
+		Responder: responder,
+	})
+	if err != nil {
+		t.Fatalf("Replay(%s, %s): %v", sessA.ID, midTurnID, err)
+	}
+	if replaySess.ID == sessA.ID || replaySess.ID == forked.ID || replaySess.ID == sessB.ID {
+		t.Fatalf("Replay reused an existing session id: %q", replaySess.ID)
+	}
+	wantTurns := midIdx + 1 + 1
+	if got := len(replaySess.Turns); got != wantTurns {
+		t.Fatalf("Replay session turn count: got %d want %d", got, wantTurns)
+	}
+	if replayTurn.Role != "assistant" {
+		t.Fatalf("Replay turn role: got %q want assistant", replayTurn.Role)
+	}
+	if replayTurn.Model != "fake-model" {
+		t.Fatalf("Replay turn model: got %q want fake-model", replayTurn.Model)
+	}
+	if got := replayTurn.Metadata["source"]; got != "replay" {
+		t.Fatalf("Replay turn metadata[source]: got %q want %q", got, "replay")
+	}
+	if !strings.HasPrefix(replayTurn.Content, "replay-reply for") {
+		t.Fatalf("Replay turn content: got %q want prefix %q", replayTurn.Content, "replay-reply for")
+	}
+	if got := replayTurn.Params["temperature"]; got != "0.0" {
+		t.Fatalf("Replay turn params[temperature]: got %q want 0.0", got)
+	}
+
+	// 9. Final List shows all four sessions: sessA, sessB, forked, replay.
+	infos, err = store.List()
+	if err != nil {
+		t.Fatalf("final List: %v", err)
+	}
+	if len(infos) != 4 {
+		ids := make([]string, len(infos))
+		for i, info := range infos {
+			ids[i] = info.ID
+		}
+		t.Fatalf("final List count: got %d want 4 (ids=%v)", len(infos), ids)
+	}
+	// All four expected ids appear.
+	seen := map[string]bool{}
+	for _, info := range infos {
+		seen[info.ID] = true
+	}
+	for _, want := range []string{sessA.ID, sessB.ID, forked.ID, replaySess.ID} {
+		if !seen[want] {
+			t.Fatalf("final List missing session id %q: ids=%+v", want, infos)
+		}
+	}
+
+	// 10. FindTurn on a non-existent id returns wrapped os.ErrNotExist.
+	_, _, err = store.FindTurn("turn-does-not-exist")
+	if err == nil {
+		t.Fatalf("FindTurn(missing): want error, got nil")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("FindTurn(missing) error: got %v, want errors.Is(_, os.ErrNotExist)", err)
+	}
+}
+
+// TestSkillsRegistryJourney loads the registry with a tier conflict and
+// asserts precedence resolution, lookup, listing, and search.
+func TestSkillsRegistryJourney(t *testing.T) {
+	home := newHome(t)
+
+	// Derive the canonical roots so we write to paths the registry will
+	// actually scan. DefaultRoots places personal at
+	// $HOME/.conduit/skills/personal, not the bare $HOME/.conduit/skills
+	// directory newHome creates — so go through the API.
+	roots := skills.DefaultRoots(home.Root, home.WorkspaceDir)
+	workspaceRoot, ok := roots[contracts.SkillTierWorkspace]
+	if !ok {
+		t.Fatalf("DefaultRoots missing workspace root; got %+v", roots)
+	}
+	personalRoot, ok := roots[contracts.SkillTierPersonal]
+	if !ok {
+		t.Fatalf("DefaultRoots missing personal root; got %+v", roots)
+	}
+
+	// Sanity: workspace root should equal the helpers' scaffolded path.
+	if workspaceRoot != home.SkillsWorkspace {
+		t.Fatalf("workspace root mismatch: helpers %q vs DefaultRoots %q", home.SkillsWorkspace, workspaceRoot)
+	}
+
+	// Seed skills.
+	workspacePath := writeSkillFile(t, workspaceRoot, "format-go.md", "---\nname: format-go\ndescription: Format Go code\ntags: [go, formatting]\n---\nUse gofmt -s.\n")
+	personalConflictPath := writeSkillFile(t, personalRoot, "format-go.md", "---\nname: format-go\ndescription: Personal go-fmt rules\n---\nLocal overrides.\n")
+	personalGitPath := writeSkillFile(t, personalRoot, "git-summary.md", "---\nname: git-summary\ndescription: Summarize git diff\ntags: [git]\n---\nRun git diff and summarize.\n")
+
+	// Construct + load.
+	reg := skills.NewRegistry(roots)
+	if err := reg.Load([]skills.Adapter{skills.NewMarkdownAdapter()}); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Workspace wins for the conflicting name.
+	got, ok := reg.Lookup("format-go")
+	if !ok {
+		t.Fatalf("Lookup format-go: not found")
+	}
+	if got.Tier != contracts.SkillTierWorkspace {
+		t.Fatalf("format-go tier: got %q want %q", got.Tier, contracts.SkillTierWorkspace)
+	}
+	if got.Path != workspacePath {
+		t.Fatalf("format-go winning path: got %q want %q", got.Path, workspacePath)
+	}
+	if got.Description != "Format Go code" {
+		t.Fatalf("format-go description: got %q want %q (workspace should win)", got.Description, "Format Go code")
+	}
+
+	// Conflict is recorded with the personal copy as a loser.
+	conflicts := reg.Conflicts()
+	if len(conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d: %+v", len(conflicts), conflicts)
+	}
+	if conflicts[0].Name != "format-go" {
+		t.Fatalf("conflict name: got %q want format-go", conflicts[0].Name)
+	}
+	if conflicts[0].Winner != workspacePath {
+		t.Fatalf("conflict winner: got %q want %q", conflicts[0].Winner, workspacePath)
+	}
+	foundLoser := false
+	for _, loser := range conflicts[0].Losers {
+		if loser == personalConflictPath {
+			foundLoser = true
+			break
+		}
+	}
+	if !foundLoser {
+		t.Fatalf("conflict losers missing %q: got %v", personalConflictPath, conflicts[0].Losers)
+	}
+
+	// git-summary resolves from personal (no conflict).
+	gitSkill, ok := reg.Lookup("git-summary")
+	if !ok {
+		t.Fatalf("Lookup git-summary: not found")
+	}
+	if gitSkill.Tier != contracts.SkillTierPersonal {
+		t.Fatalf("git-summary tier: got %q want %q", gitSkill.Tier, contracts.SkillTierPersonal)
+	}
+	if gitSkill.Path != personalGitPath {
+		t.Fatalf("git-summary path: got %q want %q", gitSkill.Path, personalGitPath)
+	}
+
+	// Missing skill.
+	if missing, ok := reg.Lookup("nonexistent"); ok {
+		t.Fatalf("Lookup nonexistent: expected miss, got %+v", missing)
+	}
+
+	// List shows both names, alphabetical.
+	listed := reg.List()
+	if len(listed) != 2 {
+		names := make([]string, len(listed))
+		for i, s := range listed {
+			names[i] = s.Name
+		}
+		t.Fatalf("List size: got %d want 2 (names=%v)", len(listed), names)
+	}
+	if listed[0].Name != "format-go" || listed[1].Name != "git-summary" {
+		t.Fatalf("List ordering: got [%s, %s] want [format-go, git-summary]", listed[0].Name, listed[1].Name)
+	}
+
+	// Search by tag (case-insensitive) reaches the workspace winner.
+	results := reg.Search("GO")
+	if len(results) == 0 {
+		t.Fatalf("Search GO returned no results")
+	}
+	sawFormat := false
+	for _, r := range results {
+		if r.Name == "format-go" {
+			sawFormat = true
+			if r.Tier != contracts.SkillTierWorkspace {
+				t.Fatalf("Search returned non-workspace format-go: tier=%q", r.Tier)
+			}
+		}
+	}
+	if !sawFormat {
+		names := make([]string, len(results))
+		for i, r := range results {
+			names[i] = r.Name
+		}
+		t.Fatalf("Search GO did not contain format-go (got %v)", names)
+	}
+
+	// Search by description token finds git-summary only.
+	gitResults := reg.Search("summarize")
+	if len(gitResults) != 1 || gitResults[0].Name != "git-summary" {
+		names := make([]string, len(gitResults))
+		for i, r := range gitResults {
+			names[i] = r.Name
+		}
+		t.Fatalf("Search 'summarize': got %v want [git-summary]", names)
+	}
+}
+
+// ---- helpers ----
+
+// scriptedResponder is a deterministic sessions.ReplayResponder that
+// echoes the last turn's content with a fixed prefix.
+type scriptedResponder struct {
+	prefix string
+}
+
+func (r scriptedResponder) Respond(history []sessions.Turn, model string, params map[string]string) (string, error) {
+	if len(history) == 0 {
+		return r.prefix + "<empty>", nil
+	}
+	last := history[len(history)-1]
+	return fmt.Sprintf("%s%s", r.prefix, last.Content), nil
+}
+
+// writeSkillFile materialises a markdown skill file at dir/name.
+func writeSkillFile(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	return mustWrite(t, path, body)
+}
+
+// truncateExpected mirrors the private truncate helper in the sessions
+// package so tests can assert the Title field deterministically. Keep it
+// in lock-step with sessions/store.go truncate(...).
+func truncateExpected(s string, max int) string {
+	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+	if len(s) <= max {
+		return s
+	}
+	if max <= 1 {
+		return s[:max]
+	}
+	return s[:max-1] + "…"
+}


### PR DESCRIPTION
## Summary

Adds `tests/e2e/`, a top-level suite that drives **full user journeys** through Conduit's public entry points end-to-end. Each file is one complete story (~300–600 lines), not a collection of micro-cases.

Developed by a fan-out of four parallel implementation agents on top of a shared fakes/scaffolding helper. All five journey tests pass under `go test -race`, with no real LLM provider, `$HOME`, or network access touched.

## Journeys

| File | What it walks through |
|------|----------------------|
| `coding_journey_test.go` | `conduit code` REPL — tool wiring with tiered permissions, three-turn dialog including truncation auto-continuation and provider error propagation, direct read/write tool invocation against a temp workspace, JSONL session persistence. |
| `server_journey_test.go` | `conduit serve` — REST surface (`/api/info`, `/api/memory`, `/api/sessions`, `/api/projects`, CORS preflight) plus a real WebSocket round-trip covering `session`/`text_delta`/`end_turn` frames, `tool_use`/`tool_result` emission via a wrapped tool, malformed-prompt recovery, and isolation between two concurrent connections. |
| `sandbox_journey_test.go` | Full lifecycle — create/list/active, two snapshots around mutations, clone-vs-rollback non-interference, `maxSnapshots` auto-prune, destroy of the active sandbox. |
| `sessions_skills_journey_test.go` | `sessions` store: create/append/load/list/FindTurn/Fork/Replay; plus a skills-registry precedence walkthrough across workspace and personal tiers with a deliberate conflict. |
| `helpers_test.go` | Shared `ScriptedStreamer` (deterministic `coding.Streamer` fake), `conduitHome` tempdir scaffold, JSONL/fixture helpers. |

## Test plan

- [x] `go test ./tests/e2e/... -count=1 -v` — 5/5 pass
- [x] `go test -race ./tests/e2e/... -count=1` — pass (catches goroutine leaks in the WS journey)
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [x] `go build ./...` clean
- [ ] Optional follow-up: extend to MCP subprocess handshake and workflow YAML runner end-to-end.

https://claude.ai/code/session_01Q17sVV2mpehTBq2dUb5Xfe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q17sVV2mpehTBq2dUb5Xfe)_