### PR TITLE
fix(gui): wire up context-row dropdown pills

### DIFF
--- a/spike/gui/src/components/WelcomeScreen.tsx
+++ b/spike/gui/src/components/WelcomeScreen.tsx
@@ -22,8 +22,13 @@ export function WelcomeScreen({
   const [draft, setDraft] = useState("");
   const [sandbox, setSandbox] = useState("Sandboxed");
   const [model, setModel] = useState("gpt-5.5 Medium");
-  const [menu, setMenu] = useState<null | "sandbox" | "model">(null);
+  const [machine, setMachine] = useState("Work locally");
+  const [menu, setMenu] = useState<
+    null | "sandbox" | "model" | "project" | "machine" | "branch"
+  >(null);
   const taRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const MACHINE_OPTS = ["Work locally", "Remote (SSH)", "Docker container"];
 
   const SANDBOX_OPTS = ["Sandboxed", "Unrestricted"];
   const MODEL_OPTS = [
@@ -172,20 +177,123 @@ export function WelcomeScreen({
           </div>
 
           <div className="context-row">
-            <span className="ctx-pill">
-              <Icon name="folder_open" size={14} />
-              conduit
-              <Icon name="expand_more" size={14} className="pill-chev" />
+            <span className="pill-wrap">
+              <button
+                type="button"
+                className="ctx-pill"
+                aria-haspopup="listbox"
+                aria-expanded={menu === "project"}
+                onClick={() =>
+                  setMenu((m) => (m === "project" ? null : "project"))
+                }
+              >
+                <Icon name="folder_open" size={14} />
+                conduit
+                <Icon name="expand_more" size={14} className="pill-chev" />
+              </button>
+              {menu === "project" && (
+                <ul className="composer-menu ctx-menu" role="listbox">
+                  <li role="option" aria-selected>
+                    <button
+                      type="button"
+                      className="composer-menu-item active"
+                      onClick={() => setMenu(null)}
+                    >
+                      conduit
+                    </button>
+                  </li>
+                  <li role="option" aria-selected={false}>
+                    <button
+                      type="button"
+                      className="composer-menu-item"
+                      onClick={() => setMenu(null)}
+                    >
+                      Browse projects…
+                    </button>
+                  </li>
+                </ul>
+              )}
             </span>
-            <span className="ctx-pill">
-              <Icon name="computer" size={14} />
-              Work locally
-              <Icon name="expand_more" size={14} className="pill-chev" />
+
+            <span className="pill-wrap">
+              <button
+                type="button"
+                className="ctx-pill"
+                aria-haspopup="listbox"
+                aria-expanded={menu === "machine"}
+                onClick={() =>
+                  setMenu((m) => (m === "machine" ? null : "machine"))
+                }
+              >
+                <Icon name="computer" size={14} />
+                {machine}
+                <Icon name="expand_more" size={14} className="pill-chev" />
+              </button>
+              {menu === "machine" && (
+                <ul className="composer-menu ctx-menu" role="listbox">
+                  {MACHINE_OPTS.map((opt) => (
+                    <li key={opt} role="option" aria-selected={opt === machine}>
+                      <button
+                        type="button"
+                        className={`composer-menu-item${opt === machine ? " active" : ""}`}
+                        onClick={() => {
+                          setMachine(opt);
+                          setMenu(null);
+                        }}
+                      >
+                        {opt}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </span>
-            <span className="ctx-pill">
-              <Icon name="account_tree" size={14} />
-              {branch || "main"}
-              <Icon name="expand_more" size={14} className="pill-chev" />
+
+            <span className="pill-wrap">
+              <button
+                type="button"
+                className="ctx-pill"
+                aria-haspopup="listbox"
+                aria-expanded={menu === "branch"}
+                onClick={() =>
+                  setMenu((m) => (m === "branch" ? null : "branch"))
+                }
+              >
+                <Icon name="account_tree" size={14} />
+                {branch || "main"}
+                <Icon name="expand_more" size={14} className="pill-chev" />
+              </button>
+              {menu === "branch" && (
+                <ul className="composer-menu ctx-menu" role="listbox">
+                  <li role="option" aria-selected>
+                    <button
+                      type="button"
+                      className="composer-menu-item active"
+                      onClick={() => setMenu(null)}
+                    >
+                      {branch || "main"}
+                    </button>
+                  </li>
+                  <li role="option" aria-selected={false}>
+                    <button
+                      type="button"
+                      className="composer-menu-item"
+                      onClick={() => setMenu(null)}
+                    >
+                      main
+                    </button>
+                  </li>
+                  <li role="option" aria-selected={false}>
+                    <button
+                      type="button"
+                      className="composer-menu-item"
+                      onClick={() => setMenu(null)}
+                    >
+                      Browse branches…
+                    </button>
+                  </li>
+                </ul>
+              )}
             </span>
           </div>
         </div>

--- a/spike/gui/src/styles.css
+++ b/spike/gui/src/styles.css
@@ -978,6 +978,11 @@ button {
   background: var(--color-surface-container);
 }
 
+.ctx-menu {
+  bottom: auto;
+  top: calc(100% + 6px);
+}
+
 /* ── integration bento cards ────────────────────────────────────────── */
 .integration-cards {
   width: 100%;


### PR DESCRIPTION
## Summary

- The three context pills (`conduit`, `Work locally`, `feat/projects-shell`) in `WelcomeScreen` were `<span>` elements — they looked like dropdowns visually but had no click handler, no state, and no menu
- Converted each to a `<button>` wrapped in a `pill-wrap` positioned container, matching the existing sandbox/model picker pattern
- All six menus share a single unified `menu` state so opening one auto-closes any other
- Added `.ctx-menu` CSS override so context-row menus open **downward** (they sit below the composer; upward would overlap it)
- Machine pill now tracks selection state; branch and project menus show current value as active + a "Browse…" option

## Test plan

- [ ] Click each of the three context pills — menu should appear below the pill
- [ ] Click a different pill while one is already open — first should close, second should open
- [ ] Select an option in the machine picker ("Remote (SSH)", etc.) — pill label updates
- [ ] Click the same pill again — menu should close
- [ ] Sandbox and model pickers still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)