### PR TITLE
chore(gui): gray out Public visibility option and rename section label

### DIFF
--- a/spike/gui/src/components/NewProject.css
+++ b/spike/gui/src/components/NewProject.css
@@ -185,6 +185,12 @@
   padding: 19px;
 }
 
+.np-toggle-card-disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 .np-toggle-icon {
   display: inline-flex;
   color: var(--color-text-subtle);

--- a/spike/gui/src/components/NewProject.tsx
+++ b/spike/gui/src/components/NewProject.tsx
@@ -341,19 +341,21 @@ export function NewProject({
           </div>
         </section>
 
-        {/* 6. Visibility & Governance */}
+        {/* 6. Visibility */}
         <section className="np-section">
-          <div className="np-section-label">Visibility & Governance</div>
+          <div className="np-section-label">Visibility</div>
           <div className="np-visibility-grid">
             {VISIBILITY_OPTIONS.map((option) => {
               const active = visibility === option.id;
+              const disabled = option.id === "public";
               return (
                 <button
                   key={option.id}
                   type="button"
-                  className={`np-toggle-card${active ? " np-toggle-card-active" : ""}`}
+                  className={`np-toggle-card${active ? " np-toggle-card-active" : ""}${disabled ? " np-toggle-card-disabled" : ""}`}
                   aria-pressed={active}
-                  onClick={() => setVisibility(option.id)}
+                  aria-disabled={disabled}
+                  onClick={() => !disabled && setVisibility(option.id)}
                 >
                   <span className="np-toggle-icon">
                     <Icon name={option.icon} size={24} />


### PR DESCRIPTION
## Summary

- Disables the unimplemented **Public** visibility card in the New Project form — grayed out with `opacity: 0.4`, `cursor: not-allowed`, and `pointer-events: none`
- Renames the section heading from **Visibility & Governance** to **Visibility**
- Guards the click handler so selecting a disabled card is a no-op (`!disabled && setVisibility(...)`)

## Test plan

- [ ] Open New Project form — confirm the Public card appears visually muted
- [ ] Click the Public card — confirm no state change occurs
- [ ] Private and Team cards still select normally
- [ ] Section heading reads "Visibility" (not "Visibility & Governance")

🤖 Generated with [Claude Code](https://claude.com/claude-code)