### PR TITLE
chore(gui): remove split-view and dock icons from TopBar

### DIFF
--- a/spike/gui/src/components/TopBar.tsx
+++ b/spike/gui/src/components/TopBar.tsx
@@ -1,8 +1,7 @@
 import { Icon } from "./Icon";
 
 // TopBar is the 48px chrome above the content column: history nav, a global
-// search field, an optional context label, and window split/dock controls.
-// Search + controls are presentational for now (wiring tracked separately).
+// search field, and an optional context label.
 export function TopBar({
   label,
   searchPlaceholder = "Search conversations…",
@@ -59,15 +58,6 @@ export function TopBar({
       </div>
       <div className="topbar-spacer" />
       {label && <span className="topbar-label">{label}</span>}
-      <div className="topbar-spacer" />
-      <div className="topbar-actions">
-        <span className="topbar-icon" aria-hidden title="Split view">
-          <Icon name="splitscreen" size={20} />
-        </span>
-        <span className="topbar-icon" aria-hidden title="Dock">
-          <Icon name="dock" size={20} />
-        </span>
-      </div>
     </header>
   );
 }


### PR DESCRIPTION
## Summary

- Removes the `splitscreen` and `dock` icons from the top-right corner of the TopBar
- Deletes the `topbar-actions` div and its preceding spacer
- Updates the component comment to reflect the simplified layout

## Test plan

- [ ] Launch the GUI and verify no icons appear in the top-right of the TopBar
- [ ] Confirm nav (back/forward) and search still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)