### PR TITLE
feat(gui): required validation for Project Name in New Project form

### DIFF
--- a/spike/gui/src/components/NewProject.css
+++ b/spike/gui/src/components/NewProject.css
@@ -82,9 +82,34 @@
 }
 
 .np-field-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-size: 14px;
   font-weight: 600;
   color: var(--color-text-body);
+}
+
+.np-required {
+  color: var(--color-error, #d32f2f);
+  font-size: 14px;
+  line-height: 1;
+}
+
+.np-optional {
+  font-size: 12px;
+  font-weight: 400;
+  font-family: var(--ref-type-family-mono);
+  color: var(--color-text-subtle);
+  letter-spacing: 0.02em;
+}
+
+.np-field-error {
+  font-size: 12px;
+  color: var(--color-error, #d32f2f);
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .np-input,
@@ -116,6 +141,14 @@
 .np-textarea:focus {
   outline: none;
   border-color: var(--color-secondary-base);
+}
+
+.np-input-error {
+  border-color: var(--color-error, #d32f2f);
+}
+
+.np-input-error:focus {
+  border-color: var(--color-error, #d32f2f);
 }
 
 /* ── Chips ─────────────────────────────────────────────────── */

--- a/spike/gui/src/components/NewProject.tsx
+++ b/spike/gui/src/components/NewProject.tsx
@@ -119,6 +119,7 @@ export function NewProject({
   onCreate: (draft: NewProjectDraft) => void;
 }): JSX.Element {
   const [name, setName] = useState("");
+  const [nameTouched, setNameTouched] = useState(false);
   const [description, setDescription] = useState("");
   const [infra, setInfra] = useState<InfraChoice>("local");
   const [assetTab, setAssetTab] = useState<AssetTab>("designs");
@@ -127,6 +128,8 @@ export function NewProject({
     new Set(["code-auditor"]),
   );
   const [stagedAssets, setStagedAssets] = useState<StagedAsset[]>([]);
+
+  const nameError = nameTouched && name.trim() === "";
 
   const removeAsset = (id: string): void =>
     setStagedAssets((prev) => prev.filter((a) => a.id !== id));
@@ -161,19 +164,31 @@ export function NewProject({
             <div className="np-field">
               <label className="np-field-label" htmlFor="np-name">
                 Project Name
+                <span className="np-required" aria-hidden="true">*</span>
               </label>
               <input
                 id="np-name"
-                className="np-input"
+                className={`np-input${nameError ? " np-input-error" : ""}`}
                 type="text"
                 placeholder="e.g. Project 'Aether' - Q4 Infrastructure"
                 value={name}
+                required
+                aria-required="true"
+                aria-invalid={nameError}
+                aria-describedby={nameError ? "np-name-error" : undefined}
                 onChange={(e) => setName(e.target.value)}
+                onBlur={() => setNameTouched(true)}
               />
+              {nameError && (
+                <span id="np-name-error" className="np-field-error" role="alert">
+                  Project name is required.
+                </span>
+              )}
             </div>
             <div className="np-field">
               <label className="np-field-label" htmlFor="np-description">
                 Description
+                <span className="np-optional">Optional</span>
               </label>
               <textarea
                 id="np-description"
@@ -379,15 +394,18 @@ export function NewProject({
             <button
               type="button"
               className="np-btn-primary"
-              disabled={name.trim() === ""}
-              onClick={() =>
+              onClick={() => {
+                if (name.trim() === "") {
+                  setNameTouched(true);
+                  return;
+                }
                 onCreate({
                   name: name.trim(),
                   description: description.trim(),
                   infra,
                   visibility,
-                })
-              }
+                });
+              }}
             >
               Create Project
             </button>


### PR DESCRIPTION
## Summary

- `name` field in the Project Core section is now required — error surfaces on blur or submit-attempt via a `nameTouched` touch-state pattern
- `description` field is labeled **Optional** to make the contrast with the required field explicit  
- Create button no longer silently disabled; clicking with an empty name triggers the error inline instead
- CSS additions: `.np-input-error` (red border), `.np-field-error` (error text), `.np-required` (asterisk), `.np-optional` (mono badge)
- Full ARIA wiring: `aria-required`, `aria-invalid`, `aria-describedby`, `role="alert"` on the error span

## Test plan

- [ ] Open New Project form, click **Create Project** without entering a name → red border + "Project name is required." error appears
- [ ] Tab into the name field and tab away without typing → same error on blur
- [ ] Type a name → error clears, Create Project proceeds normally
- [ ] Description field has no validation — leaving it empty does not block submit
- [ ] All other sections (Infrastructure, Assets, Agents, Visibility) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)