### PR TITLE
feat(agents): built-in agent templates and custom agent flow

### DIFF
--- a/internal/agent/templates/templates.go
+++ b/internal/agent/templates/templates.go
@@ -1,0 +1,187 @@
+// Package templates defines the built-in agent templates shipped with Conduit.
+//
+// Each template is a provider-agnostic system prompt that shapes the agent's
+// persona and response style. They are distinct from user-defined AgentProfiles
+// (file-based, YAML frontmatter) — built-ins live in memory and are always
+// available without any file on disk.
+//
+// Templates are intentionally model-provider-agnostic: no provider-specific
+// syntax, XML tags, or API conventions. A template can be sent verbatim to
+// Anthropic, OpenAI, Codex, or any local model.
+package templates
+
+// Template is a built-in agent definition.
+type Template struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Description  string `json:"description"`
+	Icon         string `json:"icon"` // Material Symbols icon name
+	SystemPrompt string `json:"-"`    // not exposed over the wire
+}
+
+// Builtin returns all shipped templates in display order.
+func Builtin() []Template {
+	return []Template{
+		{
+			ID:           "code-auditor",
+			Name:         "Code Auditor",
+			Description:  "Reviews PRs for security and style vulnerabilities.",
+			Icon:         "code",
+			SystemPrompt: codeAuditor,
+		},
+		{
+			ID:           "content-strategist",
+			Name:         "Content Strategist",
+			Description:  "Drafts and refines technical copy and documentation.",
+			Icon:         "description",
+			SystemPrompt: contentStrategist,
+		},
+		{
+			ID:           "system-architect",
+			Name:         "System Architect",
+			Description:  "Designs scalable infrastructure and API schemas.",
+			Icon:         "architecture",
+			SystemPrompt: systemArchitect,
+		},
+		{
+			ID:           "product-manager",
+			Name:         "Product Manager",
+			Description:  "Synthesizes market data and user feedback into actionable PRDs and roadmaps.",
+			Icon:         "assignment",
+			SystemPrompt: productManager,
+		},
+		{
+			ID:           "security-researcher",
+			Name:         "Security Researcher",
+			Description:  "Performs deep audits of code and architecture for vulnerabilities and compliance.",
+			Icon:         "security",
+			SystemPrompt: securityResearcher,
+		},
+		{
+			ID:           "ui-ux-critic",
+			Name:         "UI/UX Critic",
+			Description:  "Provides expert feedback on design flows, accessibility, and visual hierarchy.",
+			Icon:         "brush",
+			SystemPrompt: uiuxCritic,
+		},
+	}
+}
+
+// Lookup returns the built-in template with the given ID, or false.
+func Lookup(id string) (Template, bool) {
+	for _, t := range Builtin() {
+		if t.ID == id {
+			return t, true
+		}
+	}
+	return Template{}, false
+}
+
+// ── System prompts ────────────────────────────────────────────────────────────
+
+const codeAuditor = `You are a Code Auditor — a meticulous engineer who reviews pull requests, diffs, and source files for security vulnerabilities, style regressions, and correctness issues.
+
+Your approach:
+- Lead with the highest-severity finding. Group findings by severity: Critical > High > Medium > Info.
+- For each finding, cite the exact file path and line number, explain the risk, and suggest a concrete fix.
+- Flag OWASP Top 10 patterns: injection flaws, broken authentication, insecure deserialization, XSS, misconfiguration.
+- Call out style violations only when they obscure intent or create future bugs, not for cosmetic preference.
+- End every review with a brief overall verdict: approve, approve with nits, or request changes.
+
+Be direct. No filler praise. "Looks good" means it genuinely looks good — no hedging.
+
+When reviewing code, always consider:
+- What happens if the inputs are malicious, malformed, or at scale limits?
+- Does error handling leak internal state to callers?
+- Are authentication and authorization checks present at every trust boundary?
+- Are secrets, keys, or tokens ever logged, returned, or stored in plain text?`
+
+const contentStrategist = `You are a Content Strategist — a technical writer and editor who drafts, refines, and structures documentation, blog posts, READMEs, changelogs, and internal copy.
+
+Your approach:
+- Match register to audience: terse for engineers, narrative for product announcements, structured for reference docs.
+- Prefer active voice, concrete nouns, and short sentences. Cut filler words.
+- For documentation: lead with what the reader needs to do, not what the system does. Follow with explanations.
+- For changelogs: group by user impact, not by subsystem. Lead with breaking changes.
+- Flag gaps: missing prerequisites, undefined acronyms, undocumented edge cases, and assumptions the author forgot to state.
+
+When asked to draft, produce complete copy ready to publish — not an outline. When asked to edit, return the edited text with a brief rationale for structural changes only; don't explain grammar fixes.
+
+Style rules:
+- Sentences under 25 words where possible.
+- One idea per paragraph.
+- Code samples over prose for anything a developer will copy-paste.
+- Avoid: "leverage", "utilize", "seamlessly", "robust", "cutting-edge".`
+
+const systemArchitect = `You are a System Architect — a senior engineer who designs scalable infrastructure, data models, API contracts, and service boundaries.
+
+Your approach:
+- Start with constraints: throughput, latency budget, consistency requirements, failure modes, and team size.
+- Prefer explicit trade-offs over vague "it depends." When you recommend an approach, name what you're giving up.
+- Design for the stated scale, not hypothetical future scale. Three correct lines beat an over-engineered abstraction.
+- For API schemas: name resources as nouns, use standard HTTP status codes, version from day one, design for backward compatibility.
+- For data models: show the entity-relationship structure, highlight the write path, and call out every denormalization decision and why.
+- Flag missing requirements before designing around them. "What's the read:write ratio?" beats a wrong answer.
+
+Format:
+- Diagrams in Mermaid or ASCII block art — not prose descriptions of diagrams.
+- Pseudocode over prose for algorithms and data flows.
+- Tables for comparing options with their trade-offs.
+
+Never recommend a distributed system for a problem a monolith solves. Never recommend synchronous calls for fire-and-forget work.`
+
+const productManager = `You are a Product Manager — a strategist who synthesizes user research, market signals, and technical constraints into prioritized roadmaps and clear PRDs.
+
+Your approach:
+- Frame everything in user value: what problem does this solve, for whom, and how will we measure success?
+- For PRDs: lead with the problem statement and success metrics, then requirements, then non-goals. Executives read the first paragraph.
+- For roadmap decisions: use impact × confidence ÷ effort as a mental model. Show your reasoning when you prioritize or de-prioritize.
+- Flag assumption gaps: unvalidated hypotheses, missing user research, undefined success criteria, or scope that depends on another team.
+- Compress long briefs into the key decision being made. If I need to ask what you want from me, the brief isn't clear enough.
+
+When asked to write a PRD, produce a complete document with:
+1. Problem statement (one paragraph)
+2. Target users and their jobs-to-be-done
+3. Goals and non-goals
+4. Success metrics (specific, measurable)
+5. Requirements (must-have vs. nice-to-have)
+6. Open questions
+
+When reviewing a spec, call out: missing success criteria, under-specified edge cases, scope creep, and dependencies that aren't owned.`
+
+const securityResearcher = `You are a Security Researcher — an expert in threat modeling, vulnerability analysis, compliance auditing, and secure architecture review.
+
+Your approach:
+- Apply structured threat modeling before jumping to findings: enumerate assets, trust boundaries, data flows, and attacker capabilities first.
+- For code review: prioritize injection flaws, authentication bypass, privilege escalation, secrets in source, and insecure dependencies.
+- For architecture review: check for missing encryption at rest and in transit, overly broad IAM roles, unauthenticated internal APIs, excessive blast radius on compromise, and missing audit logging.
+- Cite CVEs, CWEs, or compliance controls (SOC 2, NIST 800-53, OWASP ASVS, ISO 27001) where relevant — don't just name-drop them, explain which control applies and why.
+- Every finding needs: severity (Critical/High/Medium/Low/Info), affected component, realistic attack scenario, and concrete remediation.
+
+Severity calibration:
+- Critical: exploitable remotely without authentication, data exfiltration or RCE possible.
+- High: requires some access but leads to significant data exposure or account compromise.
+- Medium: requires specific conditions, limited blast radius, or needs chaining with another issue.
+- Low / Info: defense-in-depth, best practice deviation, or informational context.
+
+You do not assist in building offensive tools, exploits, or bypasses for production systems. You help defenders understand and close gaps.`
+
+const uiuxCritic = `You are a UI/UX Critic — a designer and accessibility expert who evaluates interfaces for usability, visual hierarchy, accessibility compliance, and interaction quality.
+
+Your approach:
+- Lead with the primary user flow: does the golden path work end-to-end without confusion? Only then address edge cases.
+- Evaluate against WCAG 2.1 AA as the baseline: color contrast ratios (4.5:1 for normal text, 3:1 for large), keyboard navigability, screen reader semantics, and focus management.
+- Visual hierarchy: is the most important action visually dominant? Does the eye flow naturally from context → action → result?
+- Interaction feedback: are loading states, errors, and confirmations clear, timely, and recoverable?
+- When suggesting changes, be specific: "increase contrast on the disabled button label to 4.5:1 using #6B6B6B on white" beats "improve contrast."
+
+When reviewing a design file or screenshot, annotate specific elements by name or position. When reviewing code, mentally render the output and critique that — not the implementation.
+
+Do not suggest changes that add friction without measurable benefit. Consistency with established patterns (platform HIG, established design system) is a feature, not a constraint.
+
+Common patterns to flag:
+- Unlabeled icon-only buttons without tooltips or aria-labels.
+- Form errors shown only in red without a text label (color-blind failure mode).
+- Modal dialogs that trap keyboard focus outside the modal.
+- Touch targets under 44×44 dp on mobile.
+- Placeholder text used as the only label for a form field.`

--- a/internal/surface/server/agent.go
+++ b/internal/surface/server/agent.go
@@ -40,10 +40,25 @@ type promptMsg struct {
 // package README. One streamer + one wrapped tool slice are bound per
 // connection so concurrent sessions don't share conversation history
 // or tool-event channels.
+//
+// An optional ?template=<id> query parameter selects a built-in agent
+// template. When set, the template's system prompt is prepended to the
+// first user message of the session so the model receives the persona
+// context before any user content.
 func (s *Server) handleAgent(w http.ResponseWriter, r *http.Request) {
 	if s.factory == nil {
 		http.Error(w, "agent: no streamer factory configured", http.StatusServiceUnavailable)
 		return
+	}
+
+	// Resolve the optional template system prompt before upgrading so we
+	// can emit a "template" field on the session frame.
+	templateID := r.URL.Query().Get("template")
+	var systemPrompt string
+	var templateName string
+	if t, ok := s.lookupTemplate(templateID); ok {
+		systemPrompt = t.SystemPrompt
+		templateName = t.Name
 	}
 
 	c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
@@ -68,15 +83,20 @@ func (s *Server) handleAgent(w http.ResponseWriter, r *http.Request) {
 	streamer, providerName, modelName := s.factory(wrappedTools)
 	sessionID := fmt.Sprintf("code-%d", time.Now().UTC().Unix())
 
-	if err := emitter.send(agentEvent{
+	sessionEv := agentEvent{
 		Type:     "session",
 		ID:       sessionID,
 		Provider: providerName,
 		Model:    modelName,
-	}); err != nil {
+	}
+	if templateName != "" {
+		sessionEv.Name = templateName
+	}
+	if err := emitter.send(sessionEv); err != nil {
 		return
 	}
 
+	firstTurn := true
 	for {
 		_, data, err := c.Read(ctx)
 		if err != nil {
@@ -87,7 +107,17 @@ func (s *Server) handleAgent(w http.ResponseWriter, r *http.Request) {
 			_ = emitter.send(agentEvent{Type: "error", Message: "expected {type:\"prompt\", text:string}"})
 			continue
 		}
-		runTurn(ctx, streamer, msg.Text, emitter)
+		prompt := msg.Text
+		// Prepend the template system prompt to the first user turn so the
+		// model receives it as a grounding context block. Subsequent turns
+		// are sent verbatim — the streamer's own history carries context forward.
+		if firstTurn && systemPrompt != "" {
+			prompt = systemPrompt + "\n\n" + prompt
+			firstTurn = false
+		} else {
+			firstTurn = false
+		}
+		runTurn(ctx, streamer, prompt, emitter)
 	}
 }
 

--- a/internal/surface/server/server.go
+++ b/internal/surface/server/server.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/jabreeflor/conduit/internal/agent/templates"
 	"github.com/jabreeflor/conduit/internal/surface/coding"
 	"github.com/jabreeflor/conduit/internal/tools"
 )
@@ -39,6 +40,8 @@ type Server struct {
 	version     string
 	homeDir     string
 	sessionsDir string
+	// builtinTemplates is pre-loaded once at construction so lookups are O(1).
+	builtinTemplates map[string]templates.Template
 }
 
 // Config bundles the values the server needs to render /api/info and
@@ -65,15 +68,30 @@ func New(cfg Config) *Server {
 	if sessions == "" && home != "" {
 		sessions = filepath.Join(home, ".conduit", "coding-sessions")
 	}
-	return &Server{
-		factory:     cfg.Factory,
-		baseTools:   cfg.BaseTools,
-		provider:    cfg.Provider,
-		model:       cfg.Model,
-		version:     cfg.Version,
-		homeDir:     home,
-		sessionsDir: sessions,
+	builtins := make(map[string]templates.Template, len(templates.Builtin()))
+	for _, t := range templates.Builtin() {
+		builtins[t.ID] = t
 	}
+	return &Server{
+		factory:          cfg.Factory,
+		baseTools:        cfg.BaseTools,
+		provider:         cfg.Provider,
+		model:            cfg.Model,
+		version:          cfg.Version,
+		homeDir:          home,
+		sessionsDir:      sessions,
+		builtinTemplates: builtins,
+	}
+}
+
+// lookupTemplate resolves a template ID from built-ins. Returns the zero value
+// and false when the ID is not found.
+func (s *Server) lookupTemplate(id string) (templates.Template, bool) {
+	if id == "" {
+		return templates.Template{}, false
+	}
+	t, ok := s.builtinTemplates[id]
+	return t, ok
 }
 
 // Handler returns the HTTP mux with all routes wired up. Exposed
@@ -81,6 +99,7 @@ func New(cfg Config) *Server {
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/agent", s.handleAgent)
+	mux.HandleFunc("/api/agents", s.handleAgents)
 	mux.HandleFunc("/api/info", s.handleInfo)
 	mux.HandleFunc("/api/sessions", s.handleSessions)
 	mux.HandleFunc("/api/projects", s.handleProjects)

--- a/internal/surface/server/views.go
+++ b/internal/surface/server/views.go
@@ -8,6 +8,9 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/jabreeflor/conduit/internal/agent/templates"
+	"github.com/jabreeflor/conduit/internal/surface/coding"
 )
 
 // ── /api/info ────────────────────────────────────────────────────────
@@ -210,4 +213,103 @@ func readFileOrEmpty(path string) string {
 		return ""
 	}
 	return string(b)
+}
+
+// ── /api/agents ──────────────────────────────────────────────────────
+
+// agentTemplateResponse is the wire shape for one agent template. The system
+// prompt is intentionally omitted — clients reference templates by ID when
+// connecting to /api/agent?template=<id>; the server resolves the prompt.
+type agentTemplateResponse struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Icon        string `json:"icon"`
+	IsBuiltIn   bool   `json:"isBuiltIn"`
+}
+
+// handleAgents serves GET /api/agents (list) and POST /api/agents (create custom).
+//
+// GET returns built-in templates merged with user-defined profiles from
+// ~/.conduit/agents/. Built-ins appear first; user profiles are appended in
+// alphabetical order and carry isBuiltIn=false.
+//
+// POST creates a new user-defined agent profile from a JSON body:
+//
+//	{ "name": "...", "description": "...", "systemPrompt": "..." }
+//
+// The profile is written to ~/.conduit/agents/ and the saved record is echoed.
+func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listAgents(w, r)
+	case http.MethodPost:
+		s.createAgent(w, r)
+	default:
+		w.Header().Set("Allow", "GET, POST")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+	}
+}
+
+func (s *Server) listAgents(w http.ResponseWriter, _ *http.Request) {
+	out := make([]agentTemplateResponse, 0)
+	for _, t := range templates.Builtin() {
+		out = append(out, agentTemplateResponse{
+			ID:          t.ID,
+			Name:        t.Name,
+			Description: t.Description,
+			Icon:        t.Icon,
+			IsBuiltIn:   true,
+		})
+	}
+	if s.homeDir != "" {
+		userDir, _ := coding.DefaultAgentProfileDirs(s.homeDir, "")
+		profiles, _ := coding.LoadProfiles(userDir, "")
+		for _, p := range profiles {
+			out = append(out, agentTemplateResponse{
+				ID:          p.Name,
+				Name:        p.Name,
+				Description: p.Description,
+				Icon:        "person",
+				IsBuiltIn:   false,
+			})
+		}
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// createAgentBody is the expected POST body for custom agent creation.
+type createAgentBody struct {
+	Name         string `json:"name"`
+	Description  string `json:"description"`
+	SystemPrompt string `json:"systemPrompt"`
+}
+
+func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
+	if s.homeDir == "" {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "no home directory configured"})
+		return
+	}
+	var body createAgentBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || strings.TrimSpace(body.Name) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+		return
+	}
+	userDir, _ := coding.DefaultAgentProfileDirs(s.homeDir, "")
+	profile := coding.AgentProfile{
+		Name:          strings.TrimSpace(body.Name),
+		Description:   strings.TrimSpace(body.Description),
+		InitialPrompt: strings.TrimSpace(body.SystemPrompt),
+	}
+	if err := coding.WriteProfile(userDir, profile); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusCreated, agentTemplateResponse{
+		ID:          profile.Name,
+		Name:        profile.Name,
+		Description: profile.Description,
+		Icon:        "person",
+		IsBuiltIn:   false,
+	})
 }

--- a/spike/gui/src/App.tsx
+++ b/spike/gui/src/App.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { Spotlight } from "./Spotlight";
+import { AgentSessionsPage } from "./components/AgentSessionsPage";
+import "./components/AgentSessionsPage.css";
 import { ChatPanel } from "./components/ChatPanel";
 import { NewProject, type NewProjectDraft } from "./components/NewProject";
 import { ProjectDashboard } from "./components/ProjectDashboard";
@@ -43,6 +45,8 @@ function initialView(): View {
       return "plugins";
     case "automations":
       return "automations";
+    case "agents":
+      return "agents";
     default:
       return "welcome";
   }
@@ -54,6 +58,7 @@ const TOPBAR_LABEL: Record<View, string> = {
   projects: "Projects",
   newProject: "New Project",
   workspace: "Workspace",
+  agents: "Agent Sessions",
   soul: "Soul",
   settings: "Settings",
   plugins: "Plugins",
@@ -70,6 +75,7 @@ export function App() {
     demoParam === "chat" || demoParam === "spotlight" ? "demo" : null,
   );
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
+  const [pendingTemplateId, setPendingTemplateId] = useState<string | null>(null);
   const [spotlightOpen, setSpotlightOpen] = useState(demoParam === "spotlight");
   const [spotlightQuery, setSpotlightQuery] = useState("");
   const [activeProject, setActiveProject] = useState<{
@@ -112,6 +118,15 @@ export function App() {
 
   function handleStartChat(prompt: string) {
     setPendingPrompt(prompt);
+    setActiveChatId("active");
+    navigate("chat");
+  }
+
+  // Called from AgentSessionsPage when the user picks a template and clicks
+  // "Start Session". templateId null means a bare chat with no persona.
+  function handleStartAgentSession(templateId: string | null) {
+    setPendingTemplateId(templateId);
+    setPendingPrompt(null);
     setActiveChatId("active");
     navigate("chat");
   }
@@ -201,6 +216,7 @@ export function App() {
             <ChatPanel
               key={activeChatId}
               initialPrompt={pendingPrompt}
+              templateId={pendingTemplateId}
               demo={activeChatId === "demo"}
             />
           )}
@@ -225,6 +241,12 @@ export function App() {
               projectName={activeProject?.title}
               onStartSession={() => go("welcome")}
               onBack={() => navigate("projects")}
+            />
+          )}
+          {view === "agents" && (
+            <AgentSessionsPage
+              onStartSession={handleStartAgentSession}
+              onOpenAutomations={() => navigate("automations")}
             />
           )}
           {view === "soul" && <SoulPage />}

--- a/spike/gui/src/api.ts
+++ b/spike/gui/src/api.ts
@@ -66,6 +66,23 @@ export type ProjectsResponse = {
   orphans: ChatSummary[];
 };
 
+// Agent templates — wire shape from GET /api/agents.
+// The server never exposes the raw system prompt; clients reference templates
+// by ID when connecting to /api/agent?template=<id>.
+export type AgentTemplate = {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  isBuiltIn: boolean;
+};
+
+export type CreateAgentBody = {
+  name: string;
+  description: string;
+  systemPrompt: string;
+};
+
 // ── REST helpers ─────────────────────────────────────────────────────────
 
 async function getJSON<T>(path: string): Promise<T> {
@@ -94,6 +111,19 @@ export async function saveMemory(mem: Memory): Promise<Memory> {
 export const getProjects = (): Promise<ProjectsResponse> =>
   getJSON<ProjectsResponse>("/api/projects");
 
+export const getAgents = (): Promise<AgentTemplate[]> =>
+  getJSON<AgentTemplate[]>("/api/agents");
+
+export async function createAgent(body: CreateAgentBody): Promise<AgentTemplate> {
+  const r = await fetch(`${BASE}/api/agents`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!r.ok) throw new Error(`/api/agents: HTTP ${r.status}`);
+  return (await r.json()) as AgentTemplate;
+}
+
 export function baseUrl(): string {
   return BASE;
 }
@@ -112,7 +142,15 @@ export type AgentClientHandlers = {
   onState: (state: ConnectionState) => void;
 };
 
-export function connectAgent(handlers: AgentClientHandlers): AgentClient {
+export type AgentClientOptions = {
+  /** When set, the server will prime the session with the named template's system prompt. */
+  templateId?: string;
+};
+
+export function connectAgent(
+  handlers: AgentClientHandlers,
+  options: AgentClientOptions = {},
+): AgentClient {
   let ws: WebSocket | null = null;
   let closed = false;
   let retry = 0;
@@ -120,7 +158,10 @@ export function connectAgent(handlers: AgentClientHandlers): AgentClient {
 
   function open() {
     handlers.onState("connecting");
-    ws = new WebSocket(`${wsBase()}/api/agent`);
+    const url = options.templateId
+      ? `${wsBase()}/api/agent?template=${encodeURIComponent(options.templateId)}`
+      : `${wsBase()}/api/agent`;
+    ws = new WebSocket(url);
 
     ws.addEventListener("open", () => {
       retry = 0;

--- a/spike/gui/src/components/AgentSessionsPage.css
+++ b/spike/gui/src/components/AgentSessionsPage.css
@@ -1,0 +1,281 @@
+/* ── Agent Sessions page ──────────────────────────────────────────────── */
+
+.agent-sessions-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 28px 32px;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.agent-sessions-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.agent-sessions-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.agent-sessions-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: var(--color-text-primary, #1a1a1a);
+}
+
+.agent-sessions-actions {
+  display: flex;
+  gap: 8px;
+}
+
+/* ── Buttons ──────────────────────────────────────────────────────────── */
+
+.agents-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 120ms, box-shadow 120ms;
+  border: 1px solid transparent;
+}
+
+.agents-btn-primary {
+  background: var(--color-surface-2, #f0ece4);
+  color: var(--color-text-primary, #1a1a1a);
+  border-color: var(--color-border, #d8d3cc);
+}
+.agents-btn-primary:hover {
+  background: var(--color-surface-3, #e8e3da);
+}
+
+.agents-btn-secondary {
+  background: transparent;
+  color: var(--color-text-secondary, #6b6560);
+  border-color: var(--color-border, #d8d3cc);
+}
+.agents-btn-secondary:hover {
+  background: var(--color-surface-2, #f0ece4);
+}
+
+.agents-btn-start {
+  background: var(--color-accent, #1a1a1a);
+  color: #fff;
+  border-color: transparent;
+  padding: 9px 18px;
+  font-size: 0.85rem;
+}
+.agents-btn-start:hover {
+  opacity: 0.88;
+}
+
+/* ── Template grid ────────────────────────────────────────────────────── */
+
+.agent-sessions-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+
+.agent-sessions-loading {
+  color: var(--color-text-secondary, #6b6560);
+  font-size: 0.875rem;
+  padding: 24px 0;
+}
+
+/* ── Template card ────────────────────────────────────────────────────── */
+
+.agent-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 18px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border, #d8d3cc);
+  background: var(--color-surface-1, #faf8f5);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 120ms, box-shadow 120ms;
+}
+
+.agent-card:hover {
+  border-color: var(--color-border-strong, #b5afa6);
+}
+
+.agent-card--selected {
+  border-color: var(--color-accent, #1a1a1a);
+  box-shadow: 0 0 0 1px var(--color-accent, #1a1a1a);
+}
+
+.agent-card-top {
+  display: flex;
+  width: 100%;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.agent-card-radio {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1.5px solid var(--color-border, #d8d3cc);
+  background: transparent;
+  flex-shrink: 0;
+  transition: border-color 120ms, background 120ms;
+}
+
+.agent-card-radio--checked {
+  border-color: var(--color-accent, #1a1a1a);
+  background: var(--color-accent, #1a1a1a);
+  box-shadow: inset 0 0 0 3px var(--color-surface-1, #faf8f5);
+}
+
+.agent-card-name {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-primary, #1a1a1a);
+}
+
+.agent-card-desc {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--color-text-secondary, #6b6560);
+}
+
+/* ── Start row ────────────────────────────────────────────────────────── */
+
+.agent-sessions-start-row {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 4px;
+}
+
+/* ── Modal ────────────────────────────────────────────────────────────── */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.modal-panel {
+  background: var(--color-surface-1, #faf8f5);
+  border-radius: 14px;
+  border: 1px solid var(--color-border, #d8d3cc);
+  width: 480px;
+  max-width: calc(100vw - 40px);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.18);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--color-border, #d8d3cc);
+}
+
+.modal-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-text-primary, #1a1a1a);
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-secondary, #6b6560);
+  padding: 4px;
+  border-radius: 6px;
+  display: flex;
+}
+.modal-close:hover {
+  background: var(--color-surface-2, #f0ece4);
+}
+
+.modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 18px 20px;
+}
+
+.modal-label {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--color-text-primary, #1a1a1a);
+}
+
+.modal-label-hint {
+  font-weight: 400;
+  color: var(--color-text-secondary, #6b6560);
+}
+
+.modal-input {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border, #d8d3cc);
+  background: var(--color-surface-2, #f0ece4);
+  font-size: 0.85rem;
+  color: var(--color-text-primary, #1a1a1a);
+  box-sizing: border-box;
+}
+.modal-input:focus {
+  outline: none;
+  border-color: var(--color-accent, #1a1a1a);
+}
+
+.modal-textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border, #d8d3cc);
+  background: var(--color-surface-2, #f0ece4);
+  font-size: 0.82rem;
+  font-family: var(--font-mono, monospace);
+  line-height: 1.5;
+  color: var(--color-text-primary, #1a1a1a);
+  resize: vertical;
+  box-sizing: border-box;
+}
+.modal-textarea:focus {
+  outline: none;
+  border-color: var(--color-accent, #1a1a1a);
+}
+
+.modal-error {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-error, #c0392b);
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 14px 20px 18px;
+  border-top: 1px solid var(--color-border, #d8d3cc);
+}

--- a/spike/gui/src/components/AgentSessionsPage.tsx
+++ b/spike/gui/src/components/AgentSessionsPage.tsx
@@ -1,0 +1,265 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  getAgents,
+  createAgent,
+  type AgentTemplate,
+} from "../api";
+import { Icon } from "./Icon";
+
+// AgentSessionsPage shows the built-in template picker and routes the
+// selected template into a new chat session via onStartSession.
+export function AgentSessionsPage({
+  onStartSession,
+  onOpenAutomations,
+}: {
+  onStartSession: (templateId: string | null) => void;
+  onOpenAutomations: () => void;
+}) {
+  const [templates, setTemplates] = useState<AgentTemplate[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [showCustomModal, setShowCustomModal] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    getAgents()
+      .then(setTemplates)
+      .catch(() => setTemplates(builtinFallback))
+      .finally(() => setLoading(false));
+  }, []);
+
+  function handleStart() {
+    onStartSession(selected);
+  }
+
+  function handleCustomSaved(t: AgentTemplate) {
+    setTemplates((prev) => [...prev, t]);
+    setSelected(t.id);
+    setShowCustomModal(false);
+  }
+
+  return (
+    <div className="agent-sessions-page">
+      <div className="agent-sessions-header">
+        <div className="agent-sessions-title-row">
+          <Icon name="smart_toy" size={22} fill />
+          <h1 className="agent-sessions-title">Agent Sessions</h1>
+        </div>
+        <div className="agent-sessions-actions">
+          <button
+            type="button"
+            className="agents-btn agents-btn-primary"
+            onClick={() => setShowCustomModal(true)}
+          >
+            <Icon name="person_add" size={16} />
+            Custom Agent
+          </button>
+          <button
+            type="button"
+            className="agents-btn agents-btn-secondary"
+            onClick={onOpenAutomations}
+          >
+            Automation
+          </button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="agent-sessions-loading">Loading templates…</div>
+      ) : (
+        <div className="agent-sessions-grid">
+          {templates.map((t) => (
+            <TemplateCard
+              key={t.id}
+              template={t}
+              selected={selected === t.id}
+              onSelect={() => setSelected((s) => (s === t.id ? null : t.id))}
+            />
+          ))}
+        </div>
+      )}
+
+      {selected && (
+        <div className="agent-sessions-start-row">
+          <button
+            type="button"
+            className="agents-btn agents-btn-start"
+            onClick={handleStart}
+          >
+            Start Session
+            <Icon name="arrow_forward" size={16} />
+          </button>
+        </div>
+      )}
+
+      {showCustomModal && (
+        <CustomAgentModal
+          onSave={handleCustomSaved}
+          onClose={() => setShowCustomModal(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Template card ──────────────────────────────────────────────────────────
+
+function TemplateCard({
+  template,
+  selected,
+  onSelect,
+}: {
+  template: AgentTemplate;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`agent-card${selected ? " agent-card--selected" : ""}`}
+      onClick={onSelect}
+      aria-pressed={selected}
+    >
+      <div className="agent-card-top">
+        <TemplateIcon name={template.icon} />
+        <span className={`agent-card-radio${selected ? " agent-card-radio--checked" : ""}`} aria-hidden />
+      </div>
+      <p className="agent-card-name">{template.name}</p>
+      <p className="agent-card-desc">{template.description}</p>
+    </button>
+  );
+}
+
+function TemplateIcon({ name }: { name: string }) {
+  const iconMap: Record<string, string> = {
+    code: "code",
+    description: "description",
+    architecture: "architecture",
+    assignment: "assignment",
+    security: "security",
+    brush: "edit",
+    person: "person",
+  };
+  return <Icon name={iconMap[name] ?? name} size={22} />;
+}
+
+// ── Custom agent modal ─────────────────────────────────────────────────────
+
+function CustomAgentModal({
+  onSave,
+  onClose,
+}: {
+  onSave: (t: AgentTemplate) => void;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [systemPrompt, setSystemPrompt] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    nameRef.current?.focus();
+  }, []);
+
+  async function handleSave() {
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+    if (!systemPrompt.trim()) {
+      setError("System prompt is required.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const saved = await createAgent({ name: name.trim(), description: description.trim(), systemPrompt: systemPrompt.trim() });
+      onSave(saved);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function onKey(e: React.KeyboardEvent) {
+    if (e.key === "Escape") onClose();
+  }
+
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal aria-label="Create custom agent" onKeyDown={onKey}>
+      <div className="modal-panel">
+        <div className="modal-header">
+          <h2 className="modal-title">Custom Agent</h2>
+          <button type="button" className="modal-close" onClick={onClose} aria-label="Close">
+            <Icon name="close" size={18} />
+          </button>
+        </div>
+
+        <div className="modal-body">
+          <label className="modal-label" htmlFor="agent-name">Name</label>
+          <input
+            ref={nameRef}
+            id="agent-name"
+            className="modal-input"
+            type="text"
+            placeholder="e.g. Data Analyst"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+
+          <label className="modal-label" htmlFor="agent-desc">Description</label>
+          <input
+            id="agent-desc"
+            className="modal-input"
+            type="text"
+            placeholder="One sentence about what this agent does"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+
+          <label className="modal-label" htmlFor="agent-prompt">
+            System Prompt
+            <span className="modal-label-hint"> — defines the agent's persona and behavior</span>
+          </label>
+          <textarea
+            id="agent-prompt"
+            className="modal-textarea"
+            rows={8}
+            placeholder={"You are a Data Analyst. Your job is to…\n\nBe concise. Lead with findings, not methodology."}
+            value={systemPrompt}
+            onChange={(e) => setSystemPrompt(e.target.value)}
+          />
+
+          {error && <p className="modal-error">{error}</p>}
+        </div>
+
+        <div className="modal-footer">
+          <button type="button" className="agents-btn agents-btn-secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="agents-btn agents-btn-primary"
+            onClick={handleSave}
+            disabled={saving}
+          >
+            {saving ? "Saving…" : "Save Agent"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Fallback shown when the backend is unreachable — mirrors the 6 built-ins.
+const builtinFallback: AgentTemplate[] = [
+  { id: "code-auditor", name: "Code Auditor", description: "Reviews PRs for security and style vulnerabilities.", icon: "code", isBuiltIn: true },
+  { id: "content-strategist", name: "Content Strategist", description: "Drafts and refines technical copy and documentation.", icon: "description", isBuiltIn: true },
+  { id: "system-architect", name: "System Architect", description: "Designs scalable infrastructure and API schemas.", icon: "architecture", isBuiltIn: true },
+  { id: "product-manager", name: "Product Manager", description: "Synthesizes market data and user feedback into actionable PRDs and roadmaps.", icon: "assignment", isBuiltIn: true },
+  { id: "security-researcher", name: "Security Researcher", description: "Performs deep audits of code and architecture for vulnerabilities and compliance.", icon: "security", isBuiltIn: true },
+  { id: "ui-ux-critic", name: "UI/UX Critic", description: "Provides expert feedback on design flows, accessibility, and visual hierarchy.", icon: "brush", isBuiltIn: true },
+];

--- a/spike/gui/src/components/ChatPanel.tsx
+++ b/spike/gui/src/components/ChatPanel.tsx
@@ -67,9 +67,11 @@ const DEMO_TURNS: Turn[] = [
 
 export function ChatPanel({
   initialPrompt = null,
+  templateId = null,
   demo = false,
 }: {
   initialPrompt?: string | null;
+  templateId?: string | null;
   demo?: boolean;
 }) {
   const [info, setInfo] = useState<Info | null>(null);
@@ -93,13 +95,13 @@ export function ChatPanel({
 
   useEffect(() => {
     if (demo) return;
-    const client = connectAgent({
-      onState: setState,
-      onMessage: (msg) => applyMessage(msg, setTurns, setInfo),
-    });
+    const client = connectAgent(
+      { onState: setState, onMessage: (msg) => applyMessage(msg, setTurns, setInfo) },
+      { templateId: templateId ?? undefined },
+    );
     clientRef.current = client;
     return () => client.close();
-  }, [demo]);
+  }, [demo, templateId]);
 
   // Auto-send the welcome-screen prompt once the WS is connected.
   useEffect(() => {

--- a/spike/gui/src/components/Sidebar.tsx
+++ b/spike/gui/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ export type NavView =
   | "projects"
   | "newProject"
   | "workspace"
+  | "agents"
   | "soul"
   | "settings"
   | "plugins"
@@ -19,6 +20,7 @@ export type NavView =
 const NAV_ITEMS: { view: NavView; icon: string; label: string }[] = [
   { view: "welcome", icon: "add_box", label: "New chat" },
   { view: "projects", icon: "folder_open", label: "Projects" },
+  { view: "agents", icon: "smart_toy", label: "Agents" },
   { view: "plugins", icon: "extension", label: "Plugins" },
   { view: "automations", icon: "auto_mode", label: "Automations" },
   { view: "soul", icon: "psychology", label: "Soul" },


### PR DESCRIPTION
## Summary

- Defines 6 provider-agnostic built-in agent templates (Code Auditor, Content Strategist, System Architect, Product Manager, Security Researcher, UI/UX Critic) as standalone system prompts in `internal/agent/templates/`
- Exposes `GET /api/agents` (list) and `POST /api/agents` (create custom) REST endpoints
- Extends `/api/agent?template=<id>` WebSocket to inject the template system prompt into the first user turn — no factory signature changes, existing sessions unaffected
- Adds `AgentSessionsPage` (2-column card grid with radio selection, "Start Session" routing), `Custom Agent` modal (name + description + system prompt → persisted to `~/.conduit/agents/`), and wires the new `"agents"` nav view into `App.tsx` / `Sidebar.tsx`
- `ChatPanel` accepts optional `templateId` prop forwarded to the WebSocket URL

## Test plan

- [ ] `go build ./...` passes (verified)
- [ ] `go test ./internal/surface/server/...` passes (verified)
- [ ] `conduit serve` → `GET localhost:9876/api/agents` returns 6 built-in templates
- [ ] `POST /api/agents` with `{name, description, systemPrompt}` creates a file in `~/.conduit/agents/` and appears on next list
- [ ] Selecting a template card in the GUI and clicking "Start Session" opens a chat where the first assistant reply reflects the chosen persona
- [ ] Custom Agent modal saves and the new card appears in the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)